### PR TITLE
Device channels

### DIFF
--- a/gadgets/interventional_mri/grappa_device.xml
+++ b/gadgets/interventional_mri/grappa_device.xml
@@ -41,15 +41,13 @@
         <classname>MRIImageAttribWriterUSHORT</classname>
     </writer>
 
-    <!-- We need to modify the coil adjust to that we only scale channels according to noise variance -->
-    <!--
     <gadget>
       <name>NoiseAdjust</name>
       <dll>gadgetron_mricore</dll>
       <classname>NoiseAdjustGadget</classname>
-      <property><name>scale_only</name><value>present_uncombined_channels@PCA</value></property>
+      <property><name>scale_only_channels_by_name</name><value>uncombined_channels_by_name@PCA</value></property>
     </gadget>    
-    -->
+
 
     <gadget>
       <name>PCA</name>

--- a/gadgets/mri_core/NoiseAdjustGadget.h
+++ b/gadgets/mri_core/NoiseAdjustGadget.h
@@ -29,6 +29,7 @@ namespace Gadgetron {
       hoNDArray< std::complex<float> > noise_covariance_matrixf_;
       hoNDArray< std::complex<float> > noise_prewhitener_matrixf_;
       hoNDArray< std::complex<float> > noise_covariance_matrixf_once_;
+      std::vector<unsigned int> scale_only_channels_;
 
       unsigned long long number_of_noise_samples_;
       unsigned long long number_of_noise_samples_per_acquisition_;

--- a/gadgets/mri_core/PCACoilGadget.cpp
+++ b/gadgets/mri_core/PCACoilGadget.cpp
@@ -42,14 +42,6 @@ namespace Gadgetron {
       ISMRMRD::IsmrmrdHeader h;
       ISMRMRD::deserialize(mb->rd_ptr(),h);
 
-      if (h.acquisitionSystemInformation) {
-	for (size_t i = 0; i < h.acquisitionSystemInformation->coilLabel.size(); i++) {
-	  int coil_num = h.acquisitionSystemInformation->coilLabel[i].coilNumber;
-	  channel_map_[h.acquisitionSystemInformation->coilLabel[i].coilName] = coil_num;
-	}
-      }
-      
-      
       boost::shared_ptr<std::string> uncomb_str = this->get_string_value("uncombined_channels_by_name");
       std::vector<std::string> uncomb;
       if (uncomb_str->size()) {
@@ -57,11 +49,13 @@ namespace Gadgetron {
 	boost::split(uncomb, *uncomb_str, boost::is_any_of(","));
 	for (unsigned int i = 0; i < uncomb.size(); i++) {
 	  std::string ch = boost::algorithm::trim_copy(uncomb[i]);
-	  coil_map_type_::iterator it = channel_map_.find(ch);
-	  if (it != channel_map_.end()) {
-	    unsigned int channel_id = static_cast<unsigned int>(it->second);
-	    GADGET_DEBUG2("Device channel: %s (%d)\n",  uncomb[i].c_str(), channel_id);
-	    uncombined_channels_.push_back(channel_id);
+	  if (h.acquisitionSystemInformation) {
+	    for (size_t i = 0; i < h.acquisitionSystemInformation->coilLabel.size(); i++) {
+	      if (ch == h.acquisitionSystemInformation->coilLabel[i].coilName) {
+		uncombined_channels_.push_back(i);//This assumes that the channels are sorted in the header
+		break;
+	      }
+	    }
 	  }
 	}
       }

--- a/gadgets/mri_core/PCACoilGadget.h
+++ b/gadgets/mri_core/PCACoilGadget.h
@@ -27,10 +27,7 @@ namespace Gadgetron {
 			GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2);
 
   private:
-    typedef std::map< std::string, int > coil_map_type_;
-    coil_map_type_ channel_map_;
     std::vector<unsigned int> uncombined_channels_;
-
     
     //Map containing buffers, one for each location
     std::map< int, std::vector< ACE_Message_Block* > > buffer_;


### PR DESCRIPTION
The PCA gadget now used the new coil labels in the ismrmrd header and the NoiseAdjustGadget takes an optional list of channels that will only be scaled (not fully decorrelated).
