### PR TITLE
optimize the threading for registration

### DIFF
--- a/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorker2DTSPIRIT.h
+++ b/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorker2DTSPIRIT.h
@@ -202,10 +202,6 @@ template <typename T>
 bool gtPlusReconWorker2DTSPIRIT<T>::
 performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspace, hoNDArray<T>& adj_forward_G_I, hoNDArray<T>& res, size_t s)
 {
-    #ifdef USE_OMP
-        int nested = omp_get_nested();
-    #endif // USE_OMP
-
     try
     {
         size_t refN = adj_forward_G_I.get_size(4);
@@ -231,21 +227,6 @@ performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspac
 
             int maxOpenMPThreads = omp_get_max_threads();
             GADGET_MSG("gtPlusReconWorker2DTSPIRIT, maxOpenMPThreads : " << maxOpenMPThreads);
-
-            int allowOpenMPNested = 0;
-
-            if ( N < numOpenMPProcs-2 )
-            {
-                omp_set_nested(1);
-                allowOpenMPNested = 1;
-            }
-            else
-            {
-                omp_set_nested(0);
-                allowOpenMPNested = 0;
-            }
-
-            GADGET_MSG("gtPlusReconWorker2DTSPIRIT, allowOpenMPNested : " << allowOpenMPNested);
             GADGET_MSG("gtPlusReconWorker2DTSPIRIT, numThreads : " << numThreads);
         #endif
 
@@ -367,10 +348,6 @@ performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspac
             }
         }
 
-        #ifdef USE_OMP
-            omp_set_nested(nested);
-        #endif
-
         GADGET_EXPORT_ARRAY_COMPLEX(debugFolder_, gt_exporter_, res, "res_Shifted");
 
         Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->fftshift2D(res, kspace_Shifted);
@@ -380,11 +357,6 @@ performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspac
     catch(...)
     {
         GADGET_ERROR_MSG("Errors in gtPlusReconWorker2DTSPIRIT<T>::performUnwarppingImpl(...) ... ");
-
-        #ifdef USE_OMP
-            omp_set_nested(nested);
-        #endif
-
         return false;
     }
 

--- a/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorker2DTSPIRIT.h
+++ b/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorker2DTSPIRIT.h
@@ -202,6 +202,10 @@ template <typename T>
 bool gtPlusReconWorker2DTSPIRIT<T>::
 performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspace, hoNDArray<T>& adj_forward_G_I, hoNDArray<T>& res, size_t s)
 {
+    #ifdef USE_OMP
+        int nested = omp_get_nested();
+    #endif // USE_OMP
+
     try
     {
         size_t refN = adj_forward_G_I.get_size(4);
@@ -228,7 +232,7 @@ performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspac
             int maxOpenMPThreads = omp_get_max_threads();
             GADGET_MSG("gtPlusReconWorker2DTSPIRIT, maxOpenMPThreads : " << maxOpenMPThreads);
 
-            int allowOpenMPNested = omp_get_nested();
+            int allowOpenMPNested = 0;
 
             if ( N < numOpenMPProcs-2 )
             {
@@ -364,7 +368,7 @@ performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspac
         }
 
         #ifdef USE_OMP
-            omp_set_nested(0);
+            omp_set_nested(nested);
         #endif
 
         GADGET_EXPORT_ARRAY_COMPLEX(debugFolder_, gt_exporter_, res, "res_Shifted");
@@ -376,6 +380,11 @@ performUnwarppingImpl(gtPlusReconWorkOrder<T>* workOrder2DT, hoNDArray<T>& kspac
     catch(...)
     {
         GADGET_ERROR_MSG("Errors in gtPlusReconWorker2DTSPIRIT<T>::performUnwarppingImpl(...) ... ");
+
+        #ifdef USE_OMP
+            omp_set_nested(nested);
+        #endif
+
         return false;
     }
 

--- a/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorker3DTSPIRIT.h
+++ b/toolboxes/gtplus/workflow/gtPlusISMRMRDReconWorker3DTSPIRIT.h
@@ -702,6 +702,10 @@ template <typename T>
 bool gtPlusReconWorker3DTSPIRIT<T>::
 performUnwarppingImplROPermuted(gtPlusReconWorkOrder<T>* workOrder3DT, hoNDArray<T>& kspace, hoNDArray<T>& ker, hoNDArray<T>& /*coilMap*/, hoNDArray<T>& res)
 {
+    #ifdef USE_OMP
+        int nested = omp_get_nested();
+    #endif // USE_OMP
+
     try
     {
         size_t E1 = kspace.get_size(0);
@@ -752,7 +756,7 @@ performUnwarppingImplROPermuted(gtPlusReconWorkOrder<T>* workOrder3DT, hoNDArray
             int maxOpenMPThreads = omp_get_max_threads();
             GADGET_MSG("gtPlusReconWorker3DTSPIRIT, maxOpenMPThreads : " << maxOpenMPThreads);
 
-            int allowOpenMPNested = omp_get_nested();
+            int allowOpenMPNested = 0;
 
             if ( NUM < numOpenMPProcs-2 )
             {
@@ -848,7 +852,7 @@ performUnwarppingImplROPermuted(gtPlusReconWorkOrder<T>* workOrder3DT, hoNDArray
         }
 
         #ifdef USE_OMP
-            omp_set_nested(0);
+            omp_set_nested(nested);
         #endif
 
         GADGET_EXPORT_ARRAY_COMPLEX(debugFolder_, gt_exporter_, res, "res_Shifted");
@@ -861,6 +865,11 @@ performUnwarppingImplROPermuted(gtPlusReconWorkOrder<T>* workOrder3DT, hoNDArray
     catch(...)
     {
         GADGET_ERROR_MSG("Errors in gtPlusReconWorker3DTSPIRIT<T>::performUnwarppingImplROPermuted(...) ... ");
+
+        #ifdef USE_OMP
+            omp_set_nested(nested);
+        #endif
+
         return false;
     }
 

--- a/toolboxes/registration/optical_flow/cpu/application/hoImageRegContainer2DRegistration.h
+++ b/toolboxes/registration/optical_flow/cpu/application/hoImageRegContainer2DRegistration.h
@@ -798,10 +798,6 @@ namespace Gadgetron
     bool hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::
     registerOverContainer2DPairWise(TargetContinerType& targetContainer, SourceContinerType& sourceContainer, bool warped)
     {
-        #ifdef USE_OMP
-            int nested = omp_get_nested();
-        #endif // USE_OMP
-
         try
         {
             GADGET_CHECK_RETURN_FALSE(this->initialize(targetContainer, warped));
@@ -823,20 +819,6 @@ namespace Gadgetron
             }
 
             GADGET_MSG("registerOverContainer2DPairWise - threading ... ");
-
-            #ifdef USE_OMP
-                int numOfProcs = omp_get_num_procs();
-                if ( numOfImages < numOfProcs-1 )
-                {
-                    omp_set_nested(1);
-                    GADGET_MSG("registerOverContainer2DPairWise - nested openMP on ... ");
-                }
-                else
-                {
-                    omp_set_nested(0);
-                    GADGET_MSG("registerOverContainer2DPairWise - nested openMP off ... ");
-                }
-            #endif // USE_OMP
 
             unsigned int ii;
             long long n;
@@ -935,19 +917,10 @@ namespace Gadgetron
             {
                 GADGET_MSG("To be implemented ...");
             }
-
-            #ifdef USE_OMP
-                omp_set_nested(nested);
-            #endif // USE_OMP
         }
         catch(...)
         {
             GADGET_ERROR_MSG("Error happened in hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::registerOverContainer2DPairWise(...) ... ");
-
-            #ifdef USE_OMP
-                omp_set_nested(nested);
-            #endif // USE_OMP
-
             return false;
         }
 
@@ -958,10 +931,6 @@ namespace Gadgetron
     bool hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::
     registerOverContainer2DFixedReference(TargetContinerType& imageContainer, const std::vector<unsigned int>& referenceFrame, bool warped)
     {
-        #ifdef USE_OMP
-            int nested = omp_get_nested();
-        #endif // USE_OMP
-
         try
         {
             GADGET_CHECK_RETURN_FALSE(this->initialize(imageContainer, warped));
@@ -1003,20 +972,6 @@ namespace Gadgetron
             }
 
             GADGET_CHECK_RETURN_FALSE(numOfImages==targetImages.size());
-
-            #ifdef USE_OMP
-                int numOfProcs = omp_get_num_procs();
-                if ( numOfImages < numOfProcs-1 )
-                {
-                    omp_set_nested(1);
-                    GADGET_MSG("registerOverContainer2DFixedReference - nested openMP on ... ");
-                }
-                else
-                {
-                    omp_set_nested(0);
-                    GADGET_MSG("registerOverContainer2DFixedReference - nested openMP off ... ");
-                }
-            #endif // USE_OMP
 
             if ( container_reg_transformation_ == GT_IMAGE_REG_TRANSFORMATION_DEFORMATION_FIELD )
             {
@@ -1122,19 +1077,10 @@ namespace Gadgetron
             {
                 GADGET_MSG("To be implemented ...");
             }
-
-            #ifdef USE_OMP
-                omp_set_nested(nested);
-            #endif // USE_OMP
         }
         catch(...)
         {
             GADGET_ERROR_MSG("Error happened in hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::registerOverContainer2DFixedReference(...) ... ");
-
-            #ifdef USE_OMP
-                omp_set_nested(nested);
-            #endif // USE_OMP
-
             return false;
         }
 
@@ -1145,10 +1091,6 @@ namespace Gadgetron
     bool hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::
     registerOverContainer2DProgressive(TargetContinerType& imageContainer, const std::vector<unsigned int>& referenceFrame)
     {
-        #ifdef USE_OMP
-            int nested = omp_get_nested();
-        #endif // USE_OMP
-
         try
         {
             bool warped = true;
@@ -1273,19 +1215,6 @@ namespace Gadgetron
                 }
             }
 
-            #ifdef USE_OMP
-                int numOfProcs = omp_get_num_procs();
-                if ( numOfTasks < numOfProcs-1 )
-                {
-                    omp_set_nested(1);
-                    GADGET_MSG("registerOverContainer2DProgressive - nested openMP on ... ");
-                }
-                else
-                {
-                    omp_set_nested(0);
-                }
-            #endif // USE_OMP
-
             if ( container_reg_transformation_ == GT_IMAGE_REG_TRANSFORMATION_DEFORMATION_FIELD )
             {
                 bool initial = false;
@@ -1353,19 +1282,10 @@ namespace Gadgetron
             {
                 GADGET_MSG("To be implemented ...");
             }
-
-            #ifdef USE_OMP
-                omp_set_nested(nested);
-            #endif // USE_OMP
         }
         catch(...)
         {
             GADGET_ERROR_MSG("Error happened in hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::registerOverContainer2DProgressive(...) ... ");
-
-            #ifdef USE_OMP
-                omp_set_nested(nested);
-            #endif // USE_OMP
-
             return false;
         }
 

--- a/toolboxes/registration/optical_flow/cpu/application/hoImageRegContainer2DRegistration.h
+++ b/toolboxes/registration/optical_flow/cpu/application/hoImageRegContainer2DRegistration.h
@@ -798,6 +798,10 @@ namespace Gadgetron
     bool hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::
     registerOverContainer2DPairWise(TargetContinerType& targetContainer, SourceContinerType& sourceContainer, bool warped)
     {
+        #ifdef USE_OMP
+            int nested = omp_get_nested();
+        #endif // USE_OMP
+
         try
         {
             GADGET_CHECK_RETURN_FALSE(this->initialize(targetContainer, warped));
@@ -822,7 +826,6 @@ namespace Gadgetron
 
             #ifdef USE_OMP
                 int numOfProcs = omp_get_num_procs();
-                int nested = omp_get_nested();
                 if ( numOfImages < numOfProcs-1 )
                 {
                     omp_set_nested(1);
@@ -940,6 +943,11 @@ namespace Gadgetron
         catch(...)
         {
             GADGET_ERROR_MSG("Error happened in hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::registerOverContainer2DPairWise(...) ... ");
+
+            #ifdef USE_OMP
+                omp_set_nested(nested);
+            #endif // USE_OMP
+
             return false;
         }
 
@@ -950,6 +958,10 @@ namespace Gadgetron
     bool hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::
     registerOverContainer2DFixedReference(TargetContinerType& imageContainer, const std::vector<unsigned int>& referenceFrame, bool warped)
     {
+        #ifdef USE_OMP
+            int nested = omp_get_nested();
+        #endif // USE_OMP
+
         try
         {
             GADGET_CHECK_RETURN_FALSE(this->initialize(imageContainer, warped));
@@ -994,7 +1006,6 @@ namespace Gadgetron
 
             #ifdef USE_OMP
                 int numOfProcs = omp_get_num_procs();
-                int nested = omp_get_nested();
                 if ( numOfImages < numOfProcs-1 )
                 {
                     omp_set_nested(1);
@@ -1119,6 +1130,11 @@ namespace Gadgetron
         catch(...)
         {
             GADGET_ERROR_MSG("Error happened in hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::registerOverContainer2DFixedReference(...) ... ");
+
+            #ifdef USE_OMP
+                omp_set_nested(nested);
+            #endif // USE_OMP
+
             return false;
         }
 
@@ -1129,6 +1145,10 @@ namespace Gadgetron
     bool hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::
     registerOverContainer2DProgressive(TargetContinerType& imageContainer, const std::vector<unsigned int>& referenceFrame)
     {
+        #ifdef USE_OMP
+            int nested = omp_get_nested();
+        #endif // USE_OMP
+
         try
         {
             bool warped = true;
@@ -1255,7 +1275,6 @@ namespace Gadgetron
 
             #ifdef USE_OMP
                 int numOfProcs = omp_get_num_procs();
-                int nested = omp_get_nested();
                 if ( numOfTasks < numOfProcs-1 )
                 {
                     omp_set_nested(1);
@@ -1342,6 +1361,11 @@ namespace Gadgetron
         catch(...)
         {
             GADGET_ERROR_MSG("Error happened in hoImageRegContainer2DRegistration<ValueType, CoordType, DIn, DOut>::registerOverContainer2DProgressive(...) ... ");
+
+            #ifdef USE_OMP
+                omp_set_nested(nested);
+            #endif // USE_OMP
+
             return false;
         }
 

--- a/toolboxes/registration/optical_flow/cpu/application/hoImageRegContainer2DRegistration.h
+++ b/toolboxes/registration/optical_flow/cpu/application/hoImageRegContainer2DRegistration.h
@@ -1146,6 +1146,7 @@ namespace Gadgetron
             // for every row, two registration tasks can be formatted
 
             long long numOfTasks = (long long)(2*row);
+            GADGET_MSG("hoImageRegContainer2DRegistration<...>::registerOverContainer2DProgressive(...), numOfTasks : " << numOfTasks);
 
             std::vector< std::vector<TargetType*> > regImages(numOfTasks);
             std::vector< std::vector<TargetType*> > warpedImages(numOfTasks);
@@ -1255,21 +1256,22 @@ namespace Gadgetron
             #ifdef USE_OMP
                 int numOfProcs = omp_get_num_procs();
                 int nested = omp_get_nested();
-                //if ( numOfTasks < numOfProcs-1 )
-                //{
-                //    omp_set_nested(1);
-                //}
-                //else
-                //{
+                if ( numOfTasks < numOfProcs-1 )
+                {
+                    omp_set_nested(1);
+                    GADGET_MSG("registerOverContainer2DProgressive - nested openMP on ... ");
+                }
+                else
+                {
                     omp_set_nested(0);
-                //}
+                }
             #endif // USE_OMP
 
             if ( container_reg_transformation_ == GT_IMAGE_REG_TRANSFORMATION_DEFORMATION_FIELD )
             {
                 bool initial = false;
 
-                #pragma omp parallel default(none) private(n, ii) shared(numOfTasks, initial, regImages, warpedImages, deform) if ( numOfTasks > 6)
+                #pragma omp parallel default(none) private(n, ii) shared(numOfTasks, initial, regImages, warpedImages, deform)
                 {
                     DeformationFieldType* deformCurr[DIn];
 
@@ -1300,7 +1302,7 @@ namespace Gadgetron
             {
                 bool initial = false;
 
-                #pragma omp parallel default(none) private(n, ii) shared(numOfTasks, initial, regImages, warpedImages, deform, deformInv) if ( numOfTasks > 6)
+                #pragma omp parallel default(none) private(n, ii) shared(numOfTasks, initial, regImages, warpedImages, deform, deformInv)
                 {
                     DeformationFieldType* deformCurr[DIn];
                     DeformationFieldType* deformInvCurr[DIn];

--- a/toolboxes/registration/optical_flow/cpu/solver/hoImageRegDeformationFieldBidirectionalSolver.h
+++ b/toolboxes/registration/optical_flow/cpu/solver/hoImageRegDeformationFieldBidirectionalSolver.h
@@ -315,12 +315,12 @@ namespace Gadgetron
                         long long sy = (long long)dim_inverse[1];
 
                         long long y;
-                        #pragma omp parallel default(none) private(y) shared(sx, sy, transform, transform_inverse, deform_delta, deform, deform_inverse) if(sx*sy>64*1024) num_threads(2)
+                        // #pragma omp parallel default(none) private(y) shared(sx, sy, transform, transform_inverse, deform_delta, deform, deform_inverse) if(sx*sy>64*1024) num_threads(2)
                         {
                             CoordType ix, iy, px, py, px_inverse, py_inverse, dx, dy, dx_inverse, dy_inverse;
                             size_t offset;
 
-                            #pragma omp for 
+                            // #pragma omp for 
                             for ( y=0; y<(long long)sy; y++ )
                             {
                                 for ( size_t x=0; x<sx; x++ )
@@ -421,12 +421,12 @@ namespace Gadgetron
                         long long sy = (long long)dim_inverse[1];
 
                         long long y;
-                        #pragma omp parallel default(none) private(y) shared(sx, sy, transform, transform_inverse, deform_delta) if(sx*sy>64*1024) num_threads(2)
+                        // #pragma omp parallel default(none) private(y) shared(sx, sy, transform, transform_inverse, deform_delta) if(sx*sy>64*1024) num_threads(2)
                         {
                             CoordType px, py, dx, dy, dx_inverse, dy_inverse;
                             size_t offset;
 
-                            #pragma omp for 
+                            // #pragma omp for 
                             for ( y=0; y<(long long)sy; y++ )
                             {
                                 for ( size_t x=0; x<sx; x++ )
@@ -537,7 +537,7 @@ namespace Gadgetron
                             DeformationFieldType& dyInv = transform_inverse->getDeformationField(1);
 
                             long long x, y;
-                            #pragma omp parallel for default(none) private(y, x) shared(sx, sy, dxInv, dyInv) if(sx*sy>64*1024) num_threads(2)
+                            // #pragma omp parallel for default(none) private(y, x) shared(sx, sy, dxInv, dyInv) if(sx*sy>64*1024) num_threads(2)
                             for ( y=0; y<sy; y++ )
                             {
                                 for ( x=0; x<sx; x++ )

--- a/toolboxes/registration/optical_flow/cpu/solver/hoImageRegDeformationFieldSolver.h
+++ b/toolboxes/registration/optical_flow/cpu/solver/hoImageRegDeformationFieldSolver.h
@@ -358,7 +358,7 @@ namespace Gadgetron
                     {
                         CoordType ix, iy, wx, wy, pX, pY, deltaWX, deltaWY;
 
-                        #pragma omp parallel for default(none) private(y, x, ix, iy, wx, wy, pX, pY, deltaWX, deltaWY) shared(sx, sy, target, deform_delta, deform_updated, transform) num_threads(2)
+                        // #pragma omp parallel for default(none) private(y, x, ix, iy, wx, wy, pX, pY, deltaWX, deltaWY) shared(sx, sy, target, deform_delta, deform_updated, transform) num_threads(2)
                         for ( y=0; y<sy; y++ )
                         {
                             for ( x=0; x<sx; x++ )
@@ -465,7 +465,7 @@ namespace Gadgetron
                     {
                         CoordType pX, pY;
 
-                        #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_delta, deform_updated, transform) num_threads(2)
+                        // #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_delta, deform_updated, transform) num_threads(2)
                         for ( y=0; y<sy; y++ )
                         {
                             for ( x=0; x<sx; x++ )
@@ -562,7 +562,7 @@ namespace Gadgetron
                         {
                             CoordType pX, pY;
 
-                            #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_updated) num_threads(2)
+                            // #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_updated) num_threads(2)
                             for ( y=0; y<sy; y++ )
                             {
                                 for ( x=0; x<sx; x++ )

--- a/toolboxes/registration/optical_flow/cpu/solver/hoImageRegDeformationFieldSolver.h
+++ b/toolboxes/registration/optical_flow/cpu/solver/hoImageRegDeformationFieldSolver.h
@@ -358,7 +358,7 @@ namespace Gadgetron
                     {
                         CoordType ix, iy, wx, wy, pX, pY, deltaWX, deltaWY;
 
-                        // #pragma omp parallel for default(none) private(y, x, ix, iy, wx, wy, pX, pY, deltaWX, deltaWY) shared(sx, sy, target, deform_delta, deform_updated, transform)
+                        #pragma omp parallel for default(none) private(y, x, ix, iy, wx, wy, pX, pY, deltaWX, deltaWY) shared(sx, sy, target, deform_delta, deform_updated, transform) num_threads(2)
                         for ( y=0; y<sy; y++ )
                         {
                             for ( x=0; x<sx; x++ )
@@ -465,7 +465,7 @@ namespace Gadgetron
                     {
                         CoordType pX, pY;
 
-                        // #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_delta, deform_updated, transform)
+                        #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_delta, deform_updated, transform) num_threads(2)
                         for ( y=0; y<sy; y++ )
                         {
                             for ( x=0; x<sx; x++ )
@@ -562,7 +562,7 @@ namespace Gadgetron
                         {
                             CoordType pX, pY;
 
-                            // #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_updated)
+                            #pragma omp parallel for default(none) private(y, x, pX, pY) shared(sx, sy, deform_updated) num_threads(2)
                             for ( y=0; y<sy; y++ )
                             {
                                 for ( x=0; x<sx; x++ )

--- a/toolboxes/registration/optical_flow/cpu/warper/hoImageRegWarper.h
+++ b/toolboxes/registration/optical_flow/cpu/warper/hoImageRegWarper.h
@@ -168,11 +168,11 @@ namespace Gadgetron
 
                 if ( useWorldCoordinate )
                 {
-                    #pragma omp parallel private(y) shared(sx, sy, target, source, warped) num_threads(2)
+                    // #pragma omp parallel private(y) shared(sx, sy, target, source, warped) num_threads(2)
                     {
                         coord_type px, py, px_source, py_source, ix_source, iy_source;
 
-                        #pragma omp for 
+                        // #pragma omp for 
                         for ( y=0; y<(long long)sy; y++ )
                         {
                             for ( size_t x=0; x<sx; x++ )
@@ -199,11 +199,11 @@ namespace Gadgetron
                 }
                 else
                 {
-                    #pragma omp parallel private(y) shared(sx, sy, target, source, warped)  num_threads(2)
+                    // #pragma omp parallel private(y) shared(sx, sy, target, source, warped) num_threads(2)
                     {
                         coord_type ix_source, iy_source;
 
-                        #pragma omp for 
+                        // #pragma omp for 
                         for ( y=0; y<(long long)sy; y++ )
                         {
                             for ( size_t x=0; x<sx; x++ )
@@ -390,11 +390,11 @@ namespace Gadgetron
 
                 long long y;
 
-                #pragma omp parallel private(y) shared(sx, sy, target, source, warped) num_threads(2)
+                // #pragma omp parallel private(y) shared(sx, sy, target, source, warped) num_threads(2)
                 {
                     coord_type px, py, dx, dy, ix_source, iy_source;
 
-                    #pragma omp for 
+                    // #pragma omp for 
                     for ( y=0; y<(long long)sy; y++ )
                     {
                         for ( size_t x=0; x<sx; x++ )

--- a/toolboxes/registration/optical_flow/cpu/warper/hoImageRegWarper.h
+++ b/toolboxes/registration/optical_flow/cpu/warper/hoImageRegWarper.h
@@ -168,11 +168,11 @@ namespace Gadgetron
 
                 if ( useWorldCoordinate )
                 {
-                    // #pragma omp parallel private(y) shared(sx, sy, target, source, warped)
+                    #pragma omp parallel private(y) shared(sx, sy, target, source, warped) num_threads(2)
                     {
                         coord_type px, py, px_source, py_source, ix_source, iy_source;
 
-                        // #pragma omp for 
+                        #pragma omp for 
                         for ( y=0; y<(long long)sy; y++ )
                         {
                             for ( size_t x=0; x<sx; x++ )
@@ -199,11 +199,11 @@ namespace Gadgetron
                 }
                 else
                 {
-                    // #pragma omp parallel private(y) shared(sx, sy, target, source, warped)
+                    #pragma omp parallel private(y) shared(sx, sy, target, source, warped)  num_threads(2)
                     {
                         coord_type ix_source, iy_source;
 
-                        // #pragma omp for 
+                        #pragma omp for 
                         for ( y=0; y<(long long)sy; y++ )
                         {
                             for ( size_t x=0; x<sx; x++ )
@@ -390,11 +390,11 @@ namespace Gadgetron
 
                 long long y;
 
-                // #pragma omp parallel private(y) shared(sx, sy, target, source, warped)
+                #pragma omp parallel private(y) shared(sx, sy, target, source, warped) num_threads(2)
                 {
                     coord_type px, py, dx, dy, ix_source, iy_source;
 
-                    // #pragma omp for 
+                    #pragma omp for 
                     for ( y=0; y<(long long)sy; y++ )
                     {
                         for ( size_t x=0; x<sx; x++ )


### PR DESCRIPTION
Optimize the threading for registration progressive mode

a) The nested threading is on for progressive mode
b) for 2D warpping and registration solver, the number of threads is set to be 2, based on experiments on typical perfusion datasets and other cases on integration tests (the gtprep testing time reduced from 6min15s to 5min30s).