### PR TITLE
Fix 'strcmp' is not a member of 'std' error on Debian Jessie

### DIFF
--- a/apps/gadgetron/Gadget.h
+++ b/apps/gadgetron/Gadget.h
@@ -11,7 +11,7 @@
 #include <ace/SOCK_Stream.h>
 
 #include <map>
-#include <string>
+#include <cstring>
 #include <boost/shared_ptr.hpp>
 
 #include "gadgetbase_export.h"


### PR DESCRIPTION
Change include file from 'string' to 'cstring'.