### PR TITLE
Replace strcmp with simple '==' for std::string comparison

### DIFF
--- a/gadgets/epi/EPICorrGadget.cpp
+++ b/gadgets/epi/EPICorrGadget.cpp
@@ -30,16 +30,16 @@ int EPICorrGadget::process_config(ACE_Message_Block* mb)
     return GADGET_FAIL;
   }
 
-  if (std::strcmp(traj_desc.identifier.c_str(), "ConventionalEPI")) {
+  if (traj_desc.identifier == "ConventionalEPI") {
     GDEBUG("Expected trajectory description identifier 'ConventionalEPI', not found.");
     return GADGET_FAIL;
   }
 
 
   for (std::vector<ISMRMRD::UserParameterLong>::iterator i (traj_desc.userParameterLong.begin()); i != traj_desc.userParameterLong.end(); ++i) {
-    if (std::strcmp(i->name.c_str(),"numberOfNavigators") == 0) {
+    if (i->name.c_str() == "numberOfNavigators") {
       numNavigators_ = i->value;
-    } else if (std::strcmp(i->name.c_str(),"etl") == 0) {
+    } else if (i->name == "etl") {
       etl_ = i->value;
     }
   }

--- a/gadgets/epi/EPICorrGadget.cpp
+++ b/gadgets/epi/EPICorrGadget.cpp
@@ -37,7 +37,7 @@ int EPICorrGadget::process_config(ACE_Message_Block* mb)
 
 
   for (std::vector<ISMRMRD::UserParameterLong>::iterator i (traj_desc.userParameterLong.begin()); i != traj_desc.userParameterLong.end(); ++i) {
-    if (i->name.c_str() == "numberOfNavigators") {
+    if (i->name == "numberOfNavigators") {
       numNavigators_ = i->value;
     } else if (i->name == "etl") {
       etl_ = i->value;

--- a/gadgets/epi/EPIReconXGadget.cpp
+++ b/gadgets/epi/EPIReconXGadget.cpp
@@ -35,7 +35,7 @@ int EPIReconXGadget::process_config(ACE_Message_Block* mb)
     return GADGET_FAIL;
   }
 
-  if (std::strcmp(traj_desc.identifier.c_str(), "ConventionalEPI")) {
+  if (traj_desc.identifier == "ConventionalEPI") {
     GDEBUG("Expected trajectory description identifier 'ConventionalEPI', not found.");
     return GADGET_FAIL;
   }
@@ -48,15 +48,15 @@ int EPIReconXGadget::process_config(ACE_Message_Block* mb)
   
   // TODO: we need a flag that says it's a balanced readout.
   for (std::vector<ISMRMRD::UserParameterLong>::iterator i (traj_desc.userParameterLong.begin()); i != traj_desc.userParameterLong.end(); ++i) {
-    if (std::strcmp(i->name.c_str(),"rampUpTime") == 0) {
+    if (i->name.c_str() == "rampUpTime") {
       reconx.rampUpTime_ = i->value;
-    } else if (std::strcmp(i->name.c_str(),"rampDownTime") == 0) {
+    } else if (i->name == "rampDownTime") {
       reconx.rampDownTime_ = i->value;
-    } else if (std::strcmp(i->name.c_str(),"flatTopTime") == 0) {
+    } else if (i->name == "flatTopTime") {
       reconx.flatTopTime_ = i->value;
-    } else if (std::strcmp(i->name.c_str(),"acqDelayTime") == 0) {
+    } else if (i->name == "acqDelayTime") {
       reconx.acqDelayTime_ = i->value;
-    } else if (std::strcmp(i->name.c_str(),"numSamples") == 0) {
+    } else if (i->name == "numSamples") {
       reconx.numSamples_ = i->value;
     } else {
       GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());
@@ -65,7 +65,7 @@ int EPIReconXGadget::process_config(ACE_Message_Block* mb)
 
 
   for (std::vector<ISMRMRD::UserParameterDouble>::iterator i (traj_desc.userParameterDouble.begin()); i != traj_desc.userParameterDouble.end(); ++i) {
-    if (std::strcmp(i->name.c_str(),"dwellTime") == 0) {
+    if (i->name == "dwellTime") {
       reconx.dwellTime_ = i->value;
     } else {
       GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());

--- a/gadgets/epi/EPIReconXGadget.cpp
+++ b/gadgets/epi/EPIReconXGadget.cpp
@@ -48,7 +48,7 @@ int EPIReconXGadget::process_config(ACE_Message_Block* mb)
   
   // TODO: we need a flag that says it's a balanced readout.
   for (std::vector<ISMRMRD::UserParameterLong>::iterator i (traj_desc.userParameterLong.begin()); i != traj_desc.userParameterLong.end(); ++i) {
-    if (i->name.c_str() == "rampUpTime") {
+    if (i->name == "rampUpTime") {
       reconx.rampUpTime_ = i->value;
     } else if (i->name == "rampDownTime") {
       reconx.rampDownTime_ = i->value;

--- a/gadgets/gtPlus/GtPlusAccumulatorWorkOrderTriggerGadget.cpp
+++ b/gadgets/gtPlus/GtPlusAccumulatorWorkOrderTriggerGadget.cpp
@@ -251,19 +251,19 @@ int GtPlusAccumulatorWorkOrderTriggerGadget::process_config(ACE_Message_Block* m
     {
         for (std::vector<ISMRMRD::UserParameterLong>::const_iterator  i = h.userParameters->userParameterLong.begin (); i != h.userParameters->userParameterLong.end(); ++i)
         {
-            if (std::strcmp(i->name.c_str(),"RetroGatedImages") == 0)
+            if (i->name == "RetroGatedImages")
             {
                 workOrder_.retro_gated_images_ = i->value;
             }
-            else if ( std::strcmp(i->name.c_str(),"RetroGatedSegmentSize") == 0 )
+            else if ( i->name == "RetroGatedSegmentSize")
             {
                 workOrder_.retro_gated_segment_size_ = i->value;
             }
-            else if ( std::strcmp(i->name.c_str(),"EmbeddedRefLinesE1") == 0 )
+            else if ( i->name == "EmbeddedRefLinesE1")
             {
                 embedded_ref_lines_E1_ = i->value;
             }
-            else if ( std::strcmp(i->name.c_str(),"EmbeddedRefLinesE2") == 0 )
+            else if ( i->name == "EmbeddedRefLinesE2")
             {
                 embedded_ref_lines_E2_ = i->value;
             }

--- a/gadgets/mri_core/MaxwellCorrectionGadget.cpp
+++ b/gadgets/mri_core/MaxwellCorrectionGadget.cpp
@@ -36,13 +36,13 @@ namespace Gadgetron{
             for (std::vector<ISMRMRD::UserParameterDouble>::const_iterator i (h.userParameters->userParameterDouble.begin()); 
                 i != h.userParameters->userParameterDouble.end(); i++)
             {
-                    if (std::strcmp(i->name.c_str(),"MaxwellCoefficient_0") == 0) {
+                    if (i->name == "MaxwellCoefficient_0") {
                         maxwell_coefficients_[0] = i->value;
-                    } else if (std::strcmp(i->name.c_str(),"MaxwellCoefficient_1") == 0) {
+                    } else if (i->name == "MaxwellCoefficient_1") {
                         maxwell_coefficients_[1] = i->value;
-                    } else if (std::strcmp(i->name.c_str(),"MaxwellCoefficient_2") == 0) {
+                    } else if (i->name == "MaxwellCoefficient_2") {
                         maxwell_coefficients_[2] = i->value;
-                    } else if (std::strcmp(i->name.c_str(),"MaxwellCoefficient_3") == 0) {
+                    } else if (i->name == "MaxwellCoefficient_3") {
                         maxwell_coefficients_[3] = i->value;
                     } else {
                         GDEBUG("WARNING: unused user parameter parameter %s found\n", i->name.c_str());

--- a/gadgets/spiral/SpiralToGenericGadget.cpp
+++ b/gadgets/spiral/SpiralToGenericGadget.cpp
@@ -43,7 +43,7 @@ namespace Gadgetron{
     return GADGET_FAIL;
   }
 
-  if (std::strcmp(traj_desc.identifier.c_str(), "HargreavesVDS2000")) {
+  if (traj_desc.identifier == "HargreavesVDS2000") {
     GDEBUG("Expected trajectory description identifier 'HargreavesVDS2000', not found.");
     return GADGET_FAIL;
   }
@@ -59,29 +59,29 @@ namespace Gadgetron{
 
   
   for (std::vector<ISMRMRD::UserParameterLong>::iterator i (traj_desc.userParameterLong.begin()); i != traj_desc.userParameterLong.end(); ++i) {
-    if (std::strcmp(i->name.c_str(),"interleaves") == 0) {
+    if (i->name == "interleaves") {
       interleaves = i->value;
-    } else if (std::strcmp(i->name.c_str(),"fov_coefficients") == 0) {
-	fov_coefficients = i->value;
-      } else if (std::strcmp(i->name.c_str(),"SamplingTime_ns") == 0) {
-	sampling_time_ns = i->value;
+    } else if (i->name == "fov_coefficients") {
+      fov_coefficients = i->value;
+    } else if (i->name == "SamplingTime_ns") {
+      sampling_time_ns = i->value;
     } else {
       GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());
     }
   }
 
   for (std::vector<ISMRMRD::UserParameterDouble>::iterator i (traj_desc.userParameterDouble.begin()); i != traj_desc.userParameterDouble.end(); ++i) {
-    if (std::strcmp(i->name.c_str(),"MaxGradient_G_per_cm") == 0) {
-	max_grad = i->value;
-      } else if (std::strcmp(i->name.c_str(),"MaxSlewRate_G_per_cm_per_s") == 0) {
-	max_slew = i->value;
-      } else if (std::strcmp(i->name.c_str(),"FOVCoeff_1_cm") == 0) {
-	fov_coeff = i->value;
-      } else if (std::strcmp(i->name.c_str(),"krmax_per_cm") == 0) {
-	kr_max= i->value;
-      } else {
-	GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());
-      }
+    if (i->name == "MaxGradient_G_per_cm") {
+      max_grad = i->value;
+    } else if (i->name == "MaxSlewRate_G_per_cm_per_s") {
+        max_slew = i->value;
+    } else if (i->name == "FOVCoeff_1_cm") {
+      fov_coeff = i->value;
+    } else if (i->name == "krmax_per_cm") {
+      kr_max= i->value;
+    } else {
+      GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());
+    }
   }
   
   if ((interleaves < 0) || (fov_coefficients < 0) || (sampling_time_ns < 0) || (max_grad < 0) || (max_slew < 0) || (fov_coeff < 0) || (kr_max < 0)) {

--- a/gadgets/spiral/gpuSpiralSensePrepGadget.cpp
+++ b/gadgets/spiral/gpuSpiralSensePrepGadget.cpp
@@ -131,7 +131,7 @@ namespace Gadgetron{
       return GADGET_FAIL;
     }
     
-    if (std::strcmp(traj_desc.identifier.c_str(), "HargreavesVDS2000")) {
+    if (traj_desc.identifier == "HargreavesVDS2000") {
       GDEBUG("Expected trajectory description identifier 'HargreavesVDS2000', not found.");
       return GADGET_FAIL;
     }
@@ -147,25 +147,25 @@ namespace Gadgetron{
     
     
     for (std::vector<ISMRMRD::UserParameterLong>::iterator i (traj_desc.userParameterLong.begin()); i != traj_desc.userParameterLong.end(); ++i) {
-      if (std::strcmp(i->name.c_str(),"interleaves") == 0) {
-	interleaves = i->value;
-      } else if (std::strcmp(i->name.c_str(),"fov_coefficients") == 0) {
-	fov_coefficients = i->value;
-      } else if (std::strcmp(i->name.c_str(),"SamplingTime_ns") == 0) {
-	sampling_time_ns = i->value;
+      if (i->name == "interleaves") {
+        interleaves = i->value;
+      } else if (i->name == "fov_coefficients") {
+        fov_coefficients = i->value;
+      } else if (i->name == "SamplingTime_ns") {
+        sampling_time_ns = i->value;
       } else {
-	GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());
+        GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());
       }
     }
 
     for (std::vector<ISMRMRD::UserParameterDouble>::iterator i (traj_desc.userParameterDouble.begin()); i != traj_desc.userParameterDouble.end(); ++i) {
-      if (std::strcmp(i->name.c_str(),"MaxGradient_G_per_cm") == 0) {
+      if (i->name == "MaxGradient_G_per_cm") {
 	max_grad = i->value;
-      } else if (std::strcmp(i->name.c_str(),"MaxSlewRate_G_per_cm_per_s") == 0) {
+      } else if (i->name == "MaxSlewRate_G_per_cm_per_s") {
 	max_slew = i->value;
-      } else if (std::strcmp(i->name.c_str(),"FOVCoeff_1_cm") == 0) {
+      } else if (i->name == "FOVCoeff_1_cm") {
 	fov_coeff = i->value;
-      } else if (std::strcmp(i->name.c_str(),"krmax_per_cm") == 0) {
+      } else if (i->name == "krmax_per_cm") {
 	kr_max= i->value;
       } else {
 	GDEBUG("WARNING: unused trajectory parameter %s found\n", i->name.c_str());


### PR DESCRIPTION
The 'strcmp' only caused problem in gpuSpiralSensePrepGadget.cpp file, and my original thought is that it is caused by the different include rules between MSVC and gcc/g++, so I changed a single include file to fix it. But now since we are discussing the std::string comparison, I just changed all unnecessary 'strcmp' to '==', please take a look.

Also may I suggest that an official rules for code format be setup. During my edit, I noticed that both spaces and tabs are used and because the tabs are interpreted differently, it makes the code hard to read. Any rule is better than no rules at all. Linux kernel uses a set of good rules, for example. 

Thanks.