### PR TITLE
add control in NoiseAdjust to pass nonconformant data

### DIFF
--- a/gadgets/mri_core/NoiseAdjustGadget.cpp
+++ b/gadgets/mri_core/NoiseAdjustGadget.cpp
@@ -33,6 +33,7 @@ namespace Gadgetron{
     measurement_id_of_noise_dependency_.clear();
     noise_dwell_time_us_preset_ = 0.0;
     perform_noise_adjust_ = true;
+    pass_nonconformant_data_ = false;
   }
 
   NoiseAdjustGadget::~NoiseAdjustGadget()
@@ -63,6 +64,10 @@ namespace Gadgetron{
 
     perform_noise_adjust_ = this->get_string_value("perform_noise_adjust")->size() ? this->get_bool_value("perform_noise_adjust") : true;
     GDEBUG("NoiseAdjustGadget::perform_noise_adjust_ is %d\n", perform_noise_adjust_);
+
+    str = this->get_string_value("pass_nonconformant_data");
+    if ( !str->empty() ) pass_nonconformant_data_ = this->get_bool_value("pass_nonconformant_data");;
+    GDEBUG("NoiseAdjustGadget::pass_nonconformant_data_ is %d\n", pass_nonconformant_data_);
 
     noise_dwell_time_us_preset_ = (float)this->get_double_value("noise_dwell_time_us_preset");
 
@@ -428,9 +433,19 @@ namespace Gadgetron{
       }
 
       if (noise_decorrelation_calculated_) {
-	//Apply prewhitener
-	hoNDArray<std::complex<float> > tmp(*m2->getObjectPtr());
-	gemm(*m2->getObjectPtr(), tmp, noise_prewhitener_matrixf_);
+          //Apply prewhitener
+          bool applyPerwhitenter = true;
+          if ( pass_nonconformant_data_ ) {
+              if ( noise_prewhitener_matrixf_.get_size(0) != m2->getObjectPtr()->get_size(1) ) 
+              {
+                  applyPerwhitenter = false;
+              }
+          }
+
+          if ( applyPerwhitenter ) {
+              hoNDArray<std::complex<float> > tmp(*m2->getObjectPtr());
+              gemm(*m2->getObjectPtr(), tmp, noise_prewhitener_matrixf_);
+          }
       }
     }
 

--- a/gadgets/mri_core/NoiseAdjustGadget.cpp
+++ b/gadgets/mri_core/NoiseAdjustGadget.cpp
@@ -65,8 +65,7 @@ namespace Gadgetron{
     perform_noise_adjust_ = this->get_string_value("perform_noise_adjust")->size() ? this->get_bool_value("perform_noise_adjust") : true;
     GDEBUG("NoiseAdjustGadget::perform_noise_adjust_ is %d\n", perform_noise_adjust_);
 
-    str = this->get_string_value("pass_nonconformant_data");
-    if ( !str->empty() ) pass_nonconformant_data_ = this->get_bool_value("pass_nonconformant_data");;
+    pass_nonconformant_data_ = this->get_bool_value("pass_nonconformant_data");
     GDEBUG("NoiseAdjustGadget::pass_nonconformant_data_ is %d\n", pass_nonconformant_data_);
 
     noise_dwell_time_us_preset_ = (float)this->get_double_value("noise_dwell_time_us_preset");

--- a/gadgets/mri_core/NoiseAdjustGadget.cpp
+++ b/gadgets/mri_core/NoiseAdjustGadget.cpp
@@ -433,17 +433,15 @@ namespace Gadgetron{
 
       if (noise_decorrelation_calculated_) {
           //Apply prewhitener
-          bool applyPerwhitenter = true;
-          if ( pass_nonconformant_data_ ) {
-              if ( noise_prewhitener_matrixf_.get_size(0) != m2->getObjectPtr()->get_size(1) ) 
-              {
-                  applyPerwhitenter = false;
-              }
-          }
-
-          if ( applyPerwhitenter ) {
-              hoNDArray<std::complex<float> > tmp(*m2->getObjectPtr());
-              gemm(*m2->getObjectPtr(), tmp, noise_prewhitener_matrixf_);
+          if ( noise_prewhitener_matrixf_.get_size(0) == m2->getObjectPtr()->get_size(1) ) {
+               hoNDArray<std::complex<float> > tmp(*m2->getObjectPtr());
+               gemm(*m2->getObjectPtr(), tmp, noise_prewhitener_matrixf_);
+          } else {
+               if (!pass_nonconformant_data_) {
+                     m1->release();
+                     GERROR("Number of channels in noise prewhitener %d is incompatible with incoming data %d\n", noise_prewhitener_matrixf_.get_size(0), m2->getObjectPtr()->get_size(1));
+                     return GADGET_FAIL;
+               }
           }
       }
     }

--- a/gadgets/mri_core/NoiseAdjustGadget.h
+++ b/gadgets/mri_core/NoiseAdjustGadget.h
@@ -40,6 +40,7 @@ namespace Gadgetron {
       float receiver_noise_bandwidth_;
       bool noiseCovarianceLoaded_;
       bool perform_noise_adjust_;
+      bool pass_nonconformant_data_;
 
       std::string noise_dependency_folder_;
       std::string noise_dependency_prefix_;

--- a/gadgets/mri_core/default_measurement_dependencies.xml
+++ b/gadgets/mri_core/default_measurement_dependencies.xml
@@ -24,6 +24,12 @@
             <value>GadgetronNoiseCovarianceMatrix</value>
         </property>
 
+        <!-- Whether to pass the nonconformant data without applyting the prewhitening -->
+        <property>
+            <name>pass_nonconformant_data</name>
+            <value>true</value>
+        </property>
+
         <!-- Whether to perform timing -->
         <property>
             <name>performTiming</name>


### PR DESCRIPTION
Add controls in the NoiseAdjust gadget to pass the nonconformant data, such as the body coil surface coil correction data