### PR TITLE
remove gt_index_type

### DIFF
--- a/toolboxes/core/NDArray.h
+++ b/toolboxes/core/NDArray.h
@@ -738,63 +738,63 @@ namespace Gadgetron{
     inline bool NDArray<T>::point_in_range(size_t x) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==1);
-        return (x<(*dimensions_)[0] && x>=0);
+        return (x<(*dimensions_)[0]);
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==2);
-        return ((x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && x>=0 && y>=0);
+        return ((x<(*dimensions_)[0]) && (y<(*dimensions_)[1]));
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==3);
-        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && x>=0 && y>=0 && z>=0);
+        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]));
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==4);
-        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && x>=0 && y>=0 && z>=0 && s>=0);
+        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]));
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==5);
-        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0);
+        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]));
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==6);
-        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0);
+        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]));
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==7);
-        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0);
+        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]));
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==8);
-        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0 && q>=0);
+        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]));
     }
 
     template <typename T> 
     inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q, size_t u) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==9);
-        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]) && (u<(*dimensions_)[8]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0 && q>=0 && u>=0);
+        return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]) && (u<(*dimensions_)[8]));
     }
 }
 

--- a/toolboxes/core/NDArray.h
+++ b/toolboxes/core/NDArray.h
@@ -19,9 +19,6 @@
 
 namespace Gadgetron{
 
-    //TODO: This definition should probably be removed or renamed at least
-    typedef long long gt_index_type;
-  
     template <typename T> class NDArray
     {
     public:
@@ -90,7 +87,6 @@ namespace Gadgetron{
         void delete_data_on_destruct(bool d);
 
         size_t calculate_offset(const std::vector<size_t>& ind) const;
-        size_t calculate_offset(const std::vector<gt_index_type>& ind) const;
         static size_t calculate_offset(const std::vector<size_t>& ind, const std::vector<size_t>& offsetFactors);
 
         size_t calculate_offset(size_t x, size_t y) const;
@@ -120,9 +116,6 @@ namespace Gadgetron{
         T& operator()( const std::vector<size_t>& ind );
         const T& operator()( const std::vector<size_t>& ind ) const;
 
-        T& operator()( const std::vector<gt_index_type>& ind );
-        const T& operator()( const std::vector<gt_index_type>& ind ) const;
-
         T& operator()( size_t x );
         const T& operator()( size_t x ) const;
 
@@ -151,17 +144,17 @@ namespace Gadgetron{
         const T& operator()( size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q, size_t u ) const;
 
         /// whether a point is within the array range
-        bool point_in_range(const std::vector<gt_index_type>& ind) const;
+        bool point_in_range(const std::vector<long long>& ind) const;
         bool point_in_range(const std::vector<size_t>& ind) const;
-        bool point_in_range(gt_index_type x) const;
-        bool point_in_range(gt_index_type x, gt_index_type y) const;
-        bool point_in_range(gt_index_type x, gt_index_type y, gt_index_type z) const;
-        bool point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s) const;
-        bool point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p) const;
-        bool point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r) const;
-        bool point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a) const;
-        bool point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q) const;
-        bool point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u) const;
+        bool point_in_range(long long x) const;
+        bool point_in_range(long long x, long long y) const;
+        bool point_in_range(long long x, long long y, long long z) const;
+        bool point_in_range(long long x, long long y, long long z, long long s) const;
+        bool point_in_range(long long x, long long y, long long z, long long s, long long p) const;
+        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r) const;
+        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a) const;
+        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q) const;
+        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u) const;
 
     protected:
 
@@ -389,15 +382,6 @@ namespace Gadgetron{
     }
 
     template <typename T> 
-    inline size_t NDArray<T>::calculate_offset(const std::vector<gt_index_type>& ind) const
-    {
-        size_t offset = (size_t)(ind[0]);
-        for( size_t i = 1; i < dimensions_->size(); i++ )
-            offset += (size_t)(ind[i]) * (*offsetFactors_)[i];
-        return offset;
-    }
-
-    template <typename T> 
     inline size_t NDArray<T>::calculate_offset(size_t x, size_t y) const
     {
         GADGET_DEBUG_CHECK_THROW(dimensions_->size()==2);
@@ -592,22 +576,6 @@ namespace Gadgetron{
     }
 
     template <typename T> 
-    inline T& NDArray<T>::operator()( const std::vector<gt_index_type>& ind )
-    {
-        size_t idx = this->calculate_offset(ind);
-        GADGET_DEBUG_CHECK_THROW(idx < this->get_number_of_elements());
-        return this->data_[idx];
-    }
-
-    template <typename T> 
-    inline const T& NDArray<T>::operator()( const std::vector<gt_index_type>& ind ) const
-    {
-        size_t idx = this->calculate_offset(ind);
-        GADGET_DEBUG_CHECK_THROW(idx < this->get_number_of_elements());
-        return this->data_[idx];
-    }
-
-    template <typename T> 
     inline T& NDArray<T>::operator()( size_t x )
     {
         GADGET_DEBUG_CHECK_THROW(x < this->get_number_of_elements());
@@ -750,7 +718,7 @@ namespace Gadgetron{
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(const std::vector<gt_index_type>& ind) const
+    inline bool NDArray<T>::point_in_range(const std::vector<long long>& ind) const
     {
         unsigned int D = (*dimensions_).size();
         if ( ind.size() != D ) return false;
@@ -758,7 +726,7 @@ namespace Gadgetron{
         unsigned int ii;
         for ( ii=0; ii<D; ii++ )
         {
-            if ( (ind[ii]>= (gt_index_type)(*dimensions_)[ii]) || (ind[ii]<0) )
+            if ( (ind[ii]>= (long long)(*dimensions_)[ii]) || (ind[ii]<0) )
             {
                 return false;
             }
@@ -786,63 +754,63 @@ namespace Gadgetron{
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x) const
+    inline bool NDArray<T>::point_in_range(long long x) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==1);
         return (x<(*dimensions_)[0] && x>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==2);
         return ((x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && x>=0 && y>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y, gt_index_type z) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==3);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && x>=0 && y>=0 && z>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==4);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && x>=0 && y>=0 && z>=0 && s>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==5);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==6);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==7);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==8);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0 && q>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u) const
+    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==9);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]) && (u<(*dimensions_)[8]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0 && q>=0 && u>=0);

--- a/toolboxes/core/NDArray.h
+++ b/toolboxes/core/NDArray.h
@@ -144,17 +144,16 @@ namespace Gadgetron{
         const T& operator()( size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q, size_t u ) const;
 
         /// whether a point is within the array range
-        bool point_in_range(const std::vector<long long>& ind) const;
         bool point_in_range(const std::vector<size_t>& ind) const;
-        bool point_in_range(long long x) const;
-        bool point_in_range(long long x, long long y) const;
-        bool point_in_range(long long x, long long y, long long z) const;
-        bool point_in_range(long long x, long long y, long long z, long long s) const;
-        bool point_in_range(long long x, long long y, long long z, long long s, long long p) const;
-        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r) const;
-        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a) const;
-        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q) const;
-        bool point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u) const;
+        bool point_in_range(size_t x) const;
+        bool point_in_range(size_t x, size_t y) const;
+        bool point_in_range(size_t x, size_t y, size_t z) const;
+        bool point_in_range(size_t x, size_t y, size_t z, size_t s) const;
+        bool point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p) const;
+        bool point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r) const;
+        bool point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a) const;
+        bool point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q) const;
+        bool point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q, size_t u) const;
 
     protected:
 
@@ -718,24 +717,6 @@ namespace Gadgetron{
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(const std::vector<long long>& ind) const
-    {
-        unsigned int D = (*dimensions_).size();
-        if ( ind.size() != D ) return false;
-
-        unsigned int ii;
-        for ( ii=0; ii<D; ii++ )
-        {
-            if ( (ind[ii]>= (long long)(*dimensions_)[ii]) || (ind[ii]<0) )
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    template <typename T> 
     inline bool NDArray<T>::point_in_range(const std::vector<size_t>& ind) const
     {
         unsigned int D = (*dimensions_).size();
@@ -754,63 +735,63 @@ namespace Gadgetron{
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x) const
+    inline bool NDArray<T>::point_in_range(size_t x) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==1);
         return (x<(*dimensions_)[0] && x>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==2);
         return ((x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && x>=0 && y>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==3);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && x>=0 && y>=0 && z>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==4);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && x>=0 && y>=0 && z>=0 && s>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==5);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==6);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==7);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==8);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0 && q>=0);
     }
 
     template <typename T> 
-    inline bool NDArray<T>::point_in_range(long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u) const
+    inline bool NDArray<T>::point_in_range(size_t x, size_t y, size_t z, size_t s, size_t p, size_t r, size_t a, size_t q, size_t u) const
     {
         GADGET_DEBUG_CHECK_THROW((*dimensions_).size()==9);
         return ( (x<(*dimensions_)[0]) && (y<(*dimensions_)[1]) && (z<(*dimensions_)[2]) && (s<(*dimensions_)[3]) && (p<(*dimensions_)[4]) && (r<(*dimensions_)[5]) && (a<(*dimensions_)[6]) && (q<(*dimensions_)[7]) && (u<(*dimensions_)[8]) && x>=0 && y>=0 && z>=0 && s>=0 && p>=0 && r>=0 && a>=0 && q>=0 && u>=0);

--- a/toolboxes/core/cpu/ho2DArray.h
+++ b/toolboxes/core/cpu/ho2DArray.h
@@ -38,9 +38,6 @@ public:
     T& operator()( const std::vector<size_t>& ind ) { return (*this)(ind[0], ind[1]); }
     const T& operator()( const std::vector<size_t>& ind ) const  { return (*this)(ind[0], ind[1]); }
 
-    T& operator()( const std::vector<gt_index_type>& ind ) { return (*this)( (size_t)ind[0], (size_t)ind[1]); }
-    const T& operator()( const std::vector<gt_index_type>& ind ) const { return (*this)( (size_t)ind[0], (size_t)ind[1]); }
-
     T& operator()( size_t x ) { return (*this)(x, 0); }
     const T& operator()( size_t x ) const { return (*this)(x, 0); }
 

--- a/toolboxes/core/cpu/hoNDBoundaryHandler.h
+++ b/toolboxes/core/cpu/hoNDBoundaryHandler.h
@@ -94,21 +94,21 @@ namespace Gadgetron
         virtual ~hoNDBoundaryHandler() { array_ = NULL ; }
 
         /// access the pixel value
-        virtual T operator()( const std::vector<gt_index_type>& ind ) = 0;
-        virtual T operator()( gt_index_type x ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q ) = 0;
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u ) = 0;
+        virtual T operator()( const std::vector<long long>& ind ) = 0;
+        virtual T operator()( long long x ) = 0;
+        virtual T operator()( long long x, long long y ) = 0;
+        virtual T operator()( long long x, long long y, long long z ) = 0;
+        virtual T operator()( long long x, long long y, long long z, long long s ) = 0;
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p ) = 0;
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r ) = 0;
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a ) = 0;
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q ) = 0;
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u ) = 0;
 
         void setArray(ArrayType& a) { array_ = &a; };
 
         /// return a%b
-        inline gt_index_type mod(gt_index_type a, gt_index_type b)
+        inline long long mod(long long a, long long b)
         {
             a %= b;
 
@@ -139,16 +139,16 @@ namespace Gadgetron
         virtual ~hoNDBoundaryHandlerFixedValue() {}
 
         /// access the pixel value
-        virtual T operator()( const std::vector<gt_index_type>& ind );
-        virtual T operator()( gt_index_type x );
-        virtual T operator()( gt_index_type x, gt_index_type y );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u );
+        virtual T operator()( const std::vector<long long>& ind );
+        virtual T operator()( long long x );
+        virtual T operator()( long long x, long long y );
+        virtual T operator()( long long x, long long y, long long z );
+        virtual T operator()( long long x, long long y, long long z, long long s );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u );
 
     protected:
         using BaseClass::array_;
@@ -169,16 +169,16 @@ namespace Gadgetron
         virtual ~hoNDBoundaryHandlerBorderValue() {}
 
         /// access the pixel value
-        virtual T operator()( const std::vector<gt_index_type>& ind );
-        virtual T operator()( gt_index_type x );
-        virtual T operator()( gt_index_type x, gt_index_type y );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u );
+        virtual T operator()( const std::vector<long long>& ind );
+        virtual T operator()( long long x );
+        virtual T operator()( long long x, long long y );
+        virtual T operator()( long long x, long long y, long long z );
+        virtual T operator()( long long x, long long y, long long z, long long s );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u );
 
     protected:
         using BaseClass::array_;
@@ -198,16 +198,16 @@ namespace Gadgetron
         virtual ~hoNDBoundaryHandlerPeriodic() {}
 
         /// access the pixel value
-        virtual T operator()( const std::vector<gt_index_type>& ind );
-        virtual T operator()( gt_index_type x );
-        virtual T operator()( gt_index_type x, gt_index_type y );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u );
+        virtual T operator()( const std::vector<long long>& ind );
+        virtual T operator()( long long x );
+        virtual T operator()( long long x, long long y );
+        virtual T operator()( long long x, long long y, long long z );
+        virtual T operator()( long long x, long long y, long long z, long long s );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u );
 
     protected:
         using BaseClass::array_;
@@ -227,16 +227,16 @@ namespace Gadgetron
         virtual ~hoNDBoundaryHandlerMirror() {}
 
         /// access the pixel value
-        virtual T operator()( const std::vector<gt_index_type>& ind );
-        virtual T operator()( gt_index_type x );
-        virtual T operator()( gt_index_type x, gt_index_type y );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q );
-        virtual T operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u );
+        virtual T operator()( const std::vector<long long>& ind );
+        virtual T operator()( long long x );
+        virtual T operator()( long long x, long long y );
+        virtual T operator()( long long x, long long y, long long z );
+        virtual T operator()( long long x, long long y, long long z, long long s );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q );
+        virtual T operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u );
 
     protected:
         using BaseClass::array_;

--- a/toolboxes/core/cpu/hoNDBoundaryHandler.hxx
+++ b/toolboxes/core/cpu/hoNDBoundaryHandler.hxx
@@ -13,14 +13,26 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( const std::vector<long long>& ind )
     {
-        if (array_->point_in_range(ind))
+        size_t D = ind.size();
+
+        bool inside = true;
+
+        size_t d;
+        for ( d=0; d<D; d++)
+        {
+            if ( (ind[d]<0) || (ind[d]>=array_->get_size(d)) )
+            {
+                inside = false;
+                break;
+            }
+        }
+
+        if (inside)
         {
             size_t offset = ind[0];
-
-            size_t i;
-            for ( i=1; i<ind.size(); i++ )
+            for ( d=1; d<D; d++ )
             {
-                offset += ind[i]*array_->get_offset_factor(i);
+                offset += ind[d]*array_->get_offset_factor(d);
             }
 
             return (*array_)(offset);
@@ -34,55 +46,55 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x )
     {
-        return (array_->point_in_range(x)) ? (*array_)( size_t(x) ) : value_;
+        return ((x >= 0) && array_->point_in_range( size_t(x) )) ? (*array_)( size_t(x) ) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y )
     {
-        return (array_->point_in_range(x, y)) ? (*array_)( size_t(x), size_t(y) ) : value_;
+        return ((x >=0 ) && (y >= 0) && array_->point_in_range(size_t(x), size_t(y) )) ? (*array_)(size_t(x), size_t(y)) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z )
     {
-        return (array_->point_in_range(x, y, z)) ? (*array_)( size_t(x), size_t(y), size_t(z) ) : value_;
+        return ((x >= 0) && (y >= 0) && (z >= 0) && array_->point_in_range(size_t(x), size_t(y), size_t(z))) ? (*array_)(size_t(x), size_t(y), size_t(z)) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s )
     {
-        return (array_->point_in_range(x, y, z, s)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s) ) : value_;
+        return ((x >= 0) && (y >= 0) && (z >= 0) && (s >= 0) && array_->point_in_range(size_t(x), size_t(y), size_t(z), size_t(s))) ? (*array_)(size_t(x), size_t(y), size_t(z), size_t(s)) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p )
     {
-        return (array_->point_in_range(x, y, z, s, p)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p) ) : value_;
+        return ((x >= 0) && (y >= 0) && (z >= 0) && (s >= 0) && (p >= 0) && array_->point_in_range(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p))) ? (*array_)(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p)) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r )
     {
-        return (array_->point_in_range(x, y, z, s, p, r)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r) ) : value_;
+        return ((x >= 0) && (y >= 0) && (z >= 0) && (s >= 0) && (p >= 0) && (r >= 0) && array_->point_in_range(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r))) ? (*array_)(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r)) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a )
     {
-        return (array_->point_in_range(x, y, z, s, p, r, a)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a) ) : value_;
+        return ((x >= 0) && (y >= 0) && (z >= 0) && (s >= 0) && (p >= 0) && (r >= 0) && (a >= 0) && array_->point_in_range(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a))) ? (*array_)(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a)) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q )
     {
-        return (array_->point_in_range(x, y, z, s, p, r, a, q)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q) ) : value_;
+        return ((x >= 0) && (y >= 0) && (z >= 0) && (s >= 0) && (p >= 0) && (r >= 0) && (a >= 0) && (q >= 0) && array_->point_in_range(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q))) ? (*array_)(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q)) : value_;
     }
 
     template <typename ArrayType> 
     inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u )
     {
-        return (array_->point_in_range(x, y, z, s, p, r, a, q, u)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q), size_t(u) ) : value_;
+        return ((x >= 0) && (y >= 0) && (z >= 0) && (s >= 0) && (p >= 0) && (r >= 0) && (a >= 0) && (q >= 0) && (u >= 0) && array_->point_in_range(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q), size_t(u))) ? (*array_)(size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q), size_t(u)) : value_;
     }
 
     /// hoNDBoundaryHandlerBorderValue

--- a/toolboxes/core/cpu/hoNDBoundaryHandler.hxx
+++ b/toolboxes/core/cpu/hoNDBoundaryHandler.hxx
@@ -11,61 +11,76 @@ namespace Gadgetron
     /// hoNDBoundaryHandlerFixedValue
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( const std::vector<gt_index_type>& ind )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( const std::vector<long long>& ind )
     {
-        return (array_->point_in_range(ind)) ? (*array_)(ind) : value_;
+        if (array_->point_in_range(ind))
+        {
+            size_t offset = ind[0];
+
+            size_t i;
+            for ( i=1; i<ind.size(); i++ )
+            {
+                offset += ind[i]*array_->get_offset_factor(i);
+            }
+
+            return (*array_)(offset);
+        }
+        else
+        {
+            return value_;
+        }
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x )
     {
         return (array_->point_in_range(x)) ? (*array_)( size_t(x) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y )
     {
         return (array_->point_in_range(x, y)) ? (*array_)( size_t(x), size_t(y) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z )
     {
         return (array_->point_in_range(x, y, z)) ? (*array_)( size_t(x), size_t(y), size_t(z) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s )
     {
         return (array_->point_in_range(x, y, z, s)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p )
     {
         return (array_->point_in_range(x, y, z, s, p)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r )
     {
         return (array_->point_in_range(x, y, z, s, p, r)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a )
     {
         return (array_->point_in_range(x, y, z, s, p, r, a)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q )
     {
         return (array_->point_in_range(x, y, z, s, p, r, a, q)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q) ) : value_;
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u )
+    inline typename hoNDBoundaryHandlerFixedValue<ArrayType>::T hoNDBoundaryHandlerFixedValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u )
     {
         return (array_->point_in_range(x, y, z, s, p, r, a, q, u)) ? (*array_)( size_t(x), size_t(y), size_t(z), size_t(s), size_t(p), size_t(r), size_t(a), size_t(q), size_t(u) ) : value_;
     }
@@ -73,7 +88,7 @@ namespace Gadgetron
     /// hoNDBoundaryHandlerBorderValue
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( const std::vector<gt_index_type>& ind )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( const std::vector<long long>& ind )
     {
         std::vector<size_t> indInside(array_->get_number_of_dimensions());
         unsigned int D = array_->get_number_of_dimensions();
@@ -97,109 +112,109 @@ namespace Gadgetron
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
 
         return (*array_)(x_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
 
         return (*array_)(x_inside, y_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y, long long z )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
-        size_t z_inside = (z<0) ? 0 : ( (z>=(gt_index_type)array_->get_size(2)) ? array_->get_size(2)-1 : z );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t z_inside = (z<0) ? 0 : ( (z>=(long long)array_->get_size(2)) ? array_->get_size(2)-1 : z );
 
         return (*array_)(x_inside, y_inside, z_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y, long long z, long long s )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
-        size_t z_inside = (z<0) ? 0 : ( (z>=(gt_index_type)array_->get_size(2)) ? array_->get_size(2)-1 : z );
-        size_t s_inside = (s<0) ? 0 : ( (s>=(gt_index_type)array_->get_size(3)) ? array_->get_size(3)-1 : s );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t z_inside = (z<0) ? 0 : ( (z>=(long long)array_->get_size(2)) ? array_->get_size(2)-1 : z );
+        size_t s_inside = (s<0) ? 0 : ( (s>=(long long)array_->get_size(3)) ? array_->get_size(3)-1 : s );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
-        size_t z_inside = (z<0) ? 0 : ( (z>=(gt_index_type)array_->get_size(2)) ? array_->get_size(2)-1 : z );
-        size_t s_inside = (s<0) ? 0 : ( (s>=(gt_index_type)array_->get_size(3)) ? array_->get_size(3)-1 : s );
-        size_t p_inside = (p<0) ? 0 : ( (p>=(gt_index_type)array_->get_size(4)) ? array_->get_size(4)-1 : p );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t z_inside = (z<0) ? 0 : ( (z>=(long long)array_->get_size(2)) ? array_->get_size(2)-1 : z );
+        size_t s_inside = (s<0) ? 0 : ( (s>=(long long)array_->get_size(3)) ? array_->get_size(3)-1 : s );
+        size_t p_inside = (p<0) ? 0 : ( (p>=(long long)array_->get_size(4)) ? array_->get_size(4)-1 : p );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
-        size_t z_inside = (z<0) ? 0 : ( (z>=(gt_index_type)array_->get_size(2)) ? array_->get_size(2)-1 : z );
-        size_t s_inside = (s<0) ? 0 : ( (s>=(gt_index_type)array_->get_size(3)) ? array_->get_size(3)-1 : s );
-        size_t p_inside = (p<0) ? 0 : ( (p>=(gt_index_type)array_->get_size(4)) ? array_->get_size(4)-1 : p );
-        size_t r_inside = (r<0) ? 0 : ( (r>=(gt_index_type)array_->get_size(5)) ? array_->get_size(5)-1 : r );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t z_inside = (z<0) ? 0 : ( (z>=(long long)array_->get_size(2)) ? array_->get_size(2)-1 : z );
+        size_t s_inside = (s<0) ? 0 : ( (s>=(long long)array_->get_size(3)) ? array_->get_size(3)-1 : s );
+        size_t p_inside = (p<0) ? 0 : ( (p>=(long long)array_->get_size(4)) ? array_->get_size(4)-1 : p );
+        size_t r_inside = (r<0) ? 0 : ( (r>=(long long)array_->get_size(5)) ? array_->get_size(5)-1 : r );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
-        size_t z_inside = (z<0) ? 0 : ( (z>=(gt_index_type)array_->get_size(2)) ? array_->get_size(2)-1 : z );
-        size_t s_inside = (s<0) ? 0 : ( (s>=(gt_index_type)array_->get_size(3)) ? array_->get_size(3)-1 : s );
-        size_t p_inside = (p<0) ? 0 : ( (p>=(gt_index_type)array_->get_size(4)) ? array_->get_size(4)-1 : p );
-        size_t r_inside = (r<0) ? 0 : ( (r>=(gt_index_type)array_->get_size(5)) ? array_->get_size(5)-1 : r );
-        size_t a_inside = (a<0) ? 0 : ( (a>=(gt_index_type)array_->get_size(6)) ? array_->get_size(6)-1 : a );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t z_inside = (z<0) ? 0 : ( (z>=(long long)array_->get_size(2)) ? array_->get_size(2)-1 : z );
+        size_t s_inside = (s<0) ? 0 : ( (s>=(long long)array_->get_size(3)) ? array_->get_size(3)-1 : s );
+        size_t p_inside = (p<0) ? 0 : ( (p>=(long long)array_->get_size(4)) ? array_->get_size(4)-1 : p );
+        size_t r_inside = (r<0) ? 0 : ( (r>=(long long)array_->get_size(5)) ? array_->get_size(5)-1 : r );
+        size_t a_inside = (a<0) ? 0 : ( (a>=(long long)array_->get_size(6)) ? array_->get_size(6)-1 : a );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
-        size_t z_inside = (z<0) ? 0 : ( (z>=(gt_index_type)array_->get_size(2)) ? array_->get_size(2)-1 : z );
-        size_t s_inside = (s<0) ? 0 : ( (s>=(gt_index_type)array_->get_size(3)) ? array_->get_size(3)-1 : s );
-        size_t p_inside = (p<0) ? 0 : ( (p>=(gt_index_type)array_->get_size(4)) ? array_->get_size(4)-1 : p );
-        size_t r_inside = (r<0) ? 0 : ( (r>=(gt_index_type)array_->get_size(5)) ? array_->get_size(5)-1 : r );
-        size_t a_inside = (a<0) ? 0 : ( (a>=(gt_index_type)array_->get_size(6)) ? array_->get_size(6)-1 : a );
-        size_t q_inside = (q<0) ? 0 : ( (q>=(gt_index_type)array_->get_size(7)) ? array_->get_size(7)-1 : q );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t z_inside = (z<0) ? 0 : ( (z>=(long long)array_->get_size(2)) ? array_->get_size(2)-1 : z );
+        size_t s_inside = (s<0) ? 0 : ( (s>=(long long)array_->get_size(3)) ? array_->get_size(3)-1 : s );
+        size_t p_inside = (p<0) ? 0 : ( (p>=(long long)array_->get_size(4)) ? array_->get_size(4)-1 : p );
+        size_t r_inside = (r<0) ? 0 : ( (r>=(long long)array_->get_size(5)) ? array_->get_size(5)-1 : r );
+        size_t a_inside = (a<0) ? 0 : ( (a>=(long long)array_->get_size(6)) ? array_->get_size(6)-1 : a );
+        size_t q_inside = (q<0) ? 0 : ( (q>=(long long)array_->get_size(7)) ? array_->get_size(7)-1 : q );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside, q_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u )
+    inline typename hoNDBoundaryHandlerBorderValue<ArrayType>::T hoNDBoundaryHandlerBorderValue<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u )
     {
-        size_t x_inside = (x<0) ? 0 : ( (x>=(gt_index_type)array_->get_size(0)) ? array_->get_size(0)-1 : x );
-        size_t y_inside = (y<0) ? 0 : ( (y>=(gt_index_type)array_->get_size(1)) ? array_->get_size(1)-1 : y );
-        size_t z_inside = (z<0) ? 0 : ( (z>=(gt_index_type)array_->get_size(2)) ? array_->get_size(2)-1 : z );
-        size_t s_inside = (s<0) ? 0 : ( (s>=(gt_index_type)array_->get_size(3)) ? array_->get_size(3)-1 : s );
-        size_t p_inside = (p<0) ? 0 : ( (p>=(gt_index_type)array_->get_size(4)) ? array_->get_size(4)-1 : p );
-        size_t r_inside = (r<0) ? 0 : ( (r>=(gt_index_type)array_->get_size(5)) ? array_->get_size(5)-1 : r );
-        size_t a_inside = (a<0) ? 0 : ( (a>=(gt_index_type)array_->get_size(6)) ? array_->get_size(6)-1 : a );
-        size_t q_inside = (q<0) ? 0 : ( (q>=(gt_index_type)array_->get_size(7)) ? array_->get_size(7)-1 : q );
-        size_t u_inside = (u<0) ? 0 : ( (u>=(gt_index_type)array_->get_size(8)) ? array_->get_size(8)-1 : u );
+        size_t x_inside = (x<0) ? 0 : ( (x>=(long long)array_->get_size(0)) ? array_->get_size(0)-1 : x );
+        size_t y_inside = (y<0) ? 0 : ( (y>=(long long)array_->get_size(1)) ? array_->get_size(1)-1 : y );
+        size_t z_inside = (z<0) ? 0 : ( (z>=(long long)array_->get_size(2)) ? array_->get_size(2)-1 : z );
+        size_t s_inside = (s<0) ? 0 : ( (s>=(long long)array_->get_size(3)) ? array_->get_size(3)-1 : s );
+        size_t p_inside = (p<0) ? 0 : ( (p>=(long long)array_->get_size(4)) ? array_->get_size(4)-1 : p );
+        size_t r_inside = (r<0) ? 0 : ( (r>=(long long)array_->get_size(5)) ? array_->get_size(5)-1 : r );
+        size_t a_inside = (a<0) ? 0 : ( (a>=(long long)array_->get_size(6)) ? array_->get_size(6)-1 : a );
+        size_t q_inside = (q<0) ? 0 : ( (q>=(long long)array_->get_size(7)) ? array_->get_size(7)-1 : q );
+        size_t u_inside = (u<0) ? 0 : ( (u>=(long long)array_->get_size(8)) ? array_->get_size(8)-1 : u );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside, q_inside, u_inside);
     }
@@ -207,14 +222,14 @@ namespace Gadgetron
     /// hoNDBoundaryHandlerPeriodic
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( const std::vector<gt_index_type>& ind )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( const std::vector<long long>& ind )
     {
         unsigned int D = (unsigned int)array_->get_number_of_dimensions();
         std::vector<size_t> indInside(D);
         unsigned int ii;
         for ( ii=0; ii<D; ii++ )
         {
-            if ( (ind[ii]<0) || (ind[ii]>=(gt_index_type)array_->get_size(ii)) )
+            if ( (ind[ii]<0) || (ind[ii]>=(long long)array_->get_size(ii)) )
             {
                 indInside[ii] = this->mod(ind[ii], array_->get_size(ii));
             }
@@ -227,109 +242,109 @@ namespace Gadgetron
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
 
         return (*array_)(x_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
 
         return (*array_)(x_inside, y_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y, long long z )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
-        size_t z_inside = (z<0 || z>=(gt_index_type)array_->get_size(2)) ? (this->mod(z, (gt_index_type)array_->get_size(2))) : z;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
+        size_t z_inside = (z<0 || z>=(long long)array_->get_size(2)) ? (this->mod(z, (long long)array_->get_size(2))) : z;
 
         return (*array_)(x_inside, y_inside, z_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y, long long z, long long s )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
-        size_t z_inside = (z<0 || z>=(gt_index_type)array_->get_size(2)) ? (this->mod(z, (gt_index_type)array_->get_size(2))) : z;
-        size_t s_inside = (s<0 || s>=(gt_index_type)array_->get_size(3)) ? (this->mod(s, (gt_index_type)array_->get_size(3))) : s;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
+        size_t z_inside = (z<0 || z>=(long long)array_->get_size(2)) ? (this->mod(z, (long long)array_->get_size(2))) : z;
+        size_t s_inside = (s<0 || s>=(long long)array_->get_size(3)) ? (this->mod(s, (long long)array_->get_size(3))) : s;
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
-        size_t z_inside = (z<0 || z>=(gt_index_type)array_->get_size(2)) ? (this->mod(z, (gt_index_type)array_->get_size(2))) : z;
-        size_t s_inside = (s<0 || s>=(gt_index_type)array_->get_size(3)) ? (this->mod(s, (gt_index_type)array_->get_size(3))) : s;
-        size_t p_inside = (p<0 || p>=(gt_index_type)array_->get_size(4)) ? (this->mod(p, (gt_index_type)array_->get_size(4))) : p;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
+        size_t z_inside = (z<0 || z>=(long long)array_->get_size(2)) ? (this->mod(z, (long long)array_->get_size(2))) : z;
+        size_t s_inside = (s<0 || s>=(long long)array_->get_size(3)) ? (this->mod(s, (long long)array_->get_size(3))) : s;
+        size_t p_inside = (p<0 || p>=(long long)array_->get_size(4)) ? (this->mod(p, (long long)array_->get_size(4))) : p;
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
-        size_t z_inside = (z<0 || z>=(gt_index_type)array_->get_size(2)) ? (this->mod(z, (gt_index_type)array_->get_size(2))) : z;
-        size_t s_inside = (s<0 || s>=(gt_index_type)array_->get_size(3)) ? (this->mod(s, (gt_index_type)array_->get_size(3))) : s;
-        size_t p_inside = (p<0 || p>=(gt_index_type)array_->get_size(4)) ? (this->mod(p, (gt_index_type)array_->get_size(4))) : p;
-        size_t r_inside = (r<0 || r>=(gt_index_type)array_->get_size(5)) ? (this->mod(r, (gt_index_type)array_->get_size(5))) : r;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
+        size_t z_inside = (z<0 || z>=(long long)array_->get_size(2)) ? (this->mod(z, (long long)array_->get_size(2))) : z;
+        size_t s_inside = (s<0 || s>=(long long)array_->get_size(3)) ? (this->mod(s, (long long)array_->get_size(3))) : s;
+        size_t p_inside = (p<0 || p>=(long long)array_->get_size(4)) ? (this->mod(p, (long long)array_->get_size(4))) : p;
+        size_t r_inside = (r<0 || r>=(long long)array_->get_size(5)) ? (this->mod(r, (long long)array_->get_size(5))) : r;
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
-        size_t z_inside = (z<0 || z>=(gt_index_type)array_->get_size(2)) ? (this->mod(z, (gt_index_type)array_->get_size(2))) : z;
-        size_t s_inside = (s<0 || s>=(gt_index_type)array_->get_size(3)) ? (this->mod(s, (gt_index_type)array_->get_size(3))) : s;
-        size_t p_inside = (p<0 || p>=(gt_index_type)array_->get_size(4)) ? (this->mod(p, (gt_index_type)array_->get_size(4))) : p;
-        size_t r_inside = (r<0 || r>=(gt_index_type)array_->get_size(5)) ? (this->mod(r, (gt_index_type)array_->get_size(5))) : r;
-        size_t a_inside = (a<0 || a>=(gt_index_type)array_->get_size(6)) ? (this->mod(a, (gt_index_type)array_->get_size(6))) : a;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
+        size_t z_inside = (z<0 || z>=(long long)array_->get_size(2)) ? (this->mod(z, (long long)array_->get_size(2))) : z;
+        size_t s_inside = (s<0 || s>=(long long)array_->get_size(3)) ? (this->mod(s, (long long)array_->get_size(3))) : s;
+        size_t p_inside = (p<0 || p>=(long long)array_->get_size(4)) ? (this->mod(p, (long long)array_->get_size(4))) : p;
+        size_t r_inside = (r<0 || r>=(long long)array_->get_size(5)) ? (this->mod(r, (long long)array_->get_size(5))) : r;
+        size_t a_inside = (a<0 || a>=(long long)array_->get_size(6)) ? (this->mod(a, (long long)array_->get_size(6))) : a;
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
-        size_t z_inside = (z<0 || z>=(gt_index_type)array_->get_size(2)) ? (this->mod(z, (gt_index_type)array_->get_size(2))) : z;
-        size_t s_inside = (s<0 || s>=(gt_index_type)array_->get_size(3)) ? (this->mod(s, (gt_index_type)array_->get_size(3))) : s;
-        size_t p_inside = (p<0 || p>=(gt_index_type)array_->get_size(4)) ? (this->mod(p, (gt_index_type)array_->get_size(4))) : p;
-        size_t r_inside = (r<0 || r>=(gt_index_type)array_->get_size(5)) ? (this->mod(r, (gt_index_type)array_->get_size(5))) : r;
-        size_t a_inside = (a<0 || a>=(gt_index_type)array_->get_size(6)) ? (this->mod(a, (gt_index_type)array_->get_size(6))) : a;
-        size_t q_inside = (q<0 || q>=(gt_index_type)array_->get_size(7)) ? (this->mod(q, (gt_index_type)array_->get_size(7))) : q;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
+        size_t z_inside = (z<0 || z>=(long long)array_->get_size(2)) ? (this->mod(z, (long long)array_->get_size(2))) : z;
+        size_t s_inside = (s<0 || s>=(long long)array_->get_size(3)) ? (this->mod(s, (long long)array_->get_size(3))) : s;
+        size_t p_inside = (p<0 || p>=(long long)array_->get_size(4)) ? (this->mod(p, (long long)array_->get_size(4))) : p;
+        size_t r_inside = (r<0 || r>=(long long)array_->get_size(5)) ? (this->mod(r, (long long)array_->get_size(5))) : r;
+        size_t a_inside = (a<0 || a>=(long long)array_->get_size(6)) ? (this->mod(a, (long long)array_->get_size(6))) : a;
+        size_t q_inside = (q<0 || q>=(long long)array_->get_size(7)) ? (this->mod(q, (long long)array_->get_size(7))) : q;
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside, q_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u )
+    inline typename hoNDBoundaryHandlerPeriodic<ArrayType>::T hoNDBoundaryHandlerPeriodic<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u )
     {
-        size_t x_inside = (x<0 || x>=(gt_index_type)array_->get_size(0)) ? (this->mod(x, (gt_index_type)array_->get_size(0))) : x;
-        size_t y_inside = (y<0 || y>=(gt_index_type)array_->get_size(1)) ? (this->mod(y, (gt_index_type)array_->get_size(1))) : y;
-        size_t z_inside = (z<0 || z>=(gt_index_type)array_->get_size(2)) ? (this->mod(z, (gt_index_type)array_->get_size(2))) : z;
-        size_t s_inside = (s<0 || s>=(gt_index_type)array_->get_size(3)) ? (this->mod(s, (gt_index_type)array_->get_size(3))) : s;
-        size_t p_inside = (p<0 || p>=(gt_index_type)array_->get_size(4)) ? (this->mod(p, (gt_index_type)array_->get_size(4))) : p;
-        size_t r_inside = (r<0 || r>=(gt_index_type)array_->get_size(5)) ? (this->mod(r, (gt_index_type)array_->get_size(5))) : r;
-        size_t a_inside = (a<0 || a>=(gt_index_type)array_->get_size(6)) ? (this->mod(a, (gt_index_type)array_->get_size(6))) : a;
-        size_t q_inside = (q<0 || q>=(gt_index_type)array_->get_size(7)) ? (this->mod(q, (gt_index_type)array_->get_size(7))) : q;
-        size_t u_inside = (u<0 || u>=(gt_index_type)array_->get_size(8)) ? (this->mod(u, (gt_index_type)array_->get_size(8))) : u;
+        size_t x_inside = (x<0 || x>=(long long)array_->get_size(0)) ? (this->mod(x, (long long)array_->get_size(0))) : x;
+        size_t y_inside = (y<0 || y>=(long long)array_->get_size(1)) ? (this->mod(y, (long long)array_->get_size(1))) : y;
+        size_t z_inside = (z<0 || z>=(long long)array_->get_size(2)) ? (this->mod(z, (long long)array_->get_size(2))) : z;
+        size_t s_inside = (s<0 || s>=(long long)array_->get_size(3)) ? (this->mod(s, (long long)array_->get_size(3))) : s;
+        size_t p_inside = (p<0 || p>=(long long)array_->get_size(4)) ? (this->mod(p, (long long)array_->get_size(4))) : p;
+        size_t r_inside = (r<0 || r>=(long long)array_->get_size(5)) ? (this->mod(r, (long long)array_->get_size(5))) : r;
+        size_t a_inside = (a<0 || a>=(long long)array_->get_size(6)) ? (this->mod(a, (long long)array_->get_size(6))) : a;
+        size_t q_inside = (q<0 || q>=(long long)array_->get_size(7)) ? (this->mod(q, (long long)array_->get_size(7))) : q;
+        size_t u_inside = (u<0 || u>=(long long)array_->get_size(8)) ? (this->mod(u, (long long)array_->get_size(8))) : u;
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside, q_inside, u_inside);
     }
@@ -337,7 +352,7 @@ namespace Gadgetron
     /// hoNDBoundaryHandlerMirror
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( const std::vector<gt_index_type>& ind )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( const std::vector<long long>& ind )
     {
         unsigned int D = array_->get_number_of_dimensions();
         std::vector<size_t> indInside(D);
@@ -348,9 +363,9 @@ namespace Gadgetron
             {
                 indInside[ii] = -ind[ii];
             }
-            else if ( ind[ii] >= (gt_index_type)array_->get_size(ii) )
+            else if ( ind[ii] >= (long long)array_->get_size(ii) )
             {
-                indInside[ii] = 2*(gt_index_type)array_->get_size(ii) - ind[ii] -2;
+                indInside[ii] = 2*(long long)array_->get_size(ii) - ind[ii] -2;
             }
             else
             {
@@ -361,109 +376,109 @@ namespace Gadgetron
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
 
         return (*array_)(x_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
 
         return (*array_)(x_inside, y_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y, long long z )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
-        size_t z_inside = (z<0) ? -z : ( (z>=(gt_index_type)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t z_inside = (z<0) ? -z : ( (z>=(long long)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
 
         return (*array_)(x_inside, y_inside, z_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y, long long z, long long s )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
-        size_t z_inside = (z<0) ? -z : ( (z>=(gt_index_type)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
-        size_t s_inside = (s<0) ? -s : ( (s>=(gt_index_type)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t z_inside = (z<0) ? -z : ( (z>=(long long)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
+        size_t s_inside = (s<0) ? -s : ( (s>=(long long)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
-        size_t z_inside = (z<0) ? -z : ( (z>=(gt_index_type)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
-        size_t s_inside = (s<0) ? -s : ( (s>=(gt_index_type)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
-        size_t p_inside = (p<0) ? -p : ( (p>=(gt_index_type)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t z_inside = (z<0) ? -z : ( (z>=(long long)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
+        size_t s_inside = (s<0) ? -s : ( (s>=(long long)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
+        size_t p_inside = (p<0) ? -p : ( (p>=(long long)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
-        size_t z_inside = (z<0) ? -z : ( (z>=(gt_index_type)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
-        size_t s_inside = (s<0) ? -s : ( (s>=(gt_index_type)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
-        size_t p_inside = (p<0) ? -p : ( (p>=(gt_index_type)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
-        size_t r_inside = (r<0) ? -r : ( (r>=(gt_index_type)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t z_inside = (z<0) ? -z : ( (z>=(long long)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
+        size_t s_inside = (s<0) ? -s : ( (s>=(long long)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
+        size_t p_inside = (p<0) ? -p : ( (p>=(long long)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
+        size_t r_inside = (r<0) ? -r : ( (r>=(long long)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
-        size_t z_inside = (z<0) ? -z : ( (z>=(gt_index_type)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
-        size_t s_inside = (s<0) ? -s : ( (s>=(gt_index_type)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
-        size_t p_inside = (p<0) ? -p : ( (p>=(gt_index_type)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
-        size_t r_inside = (r<0) ? -r : ( (r>=(gt_index_type)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
-        size_t a_inside = (a<0) ? -a : ( (a>=(gt_index_type)array_->get_size(6)) ? (2*array_->get_size(6)-a-2) : a );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t z_inside = (z<0) ? -z : ( (z>=(long long)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
+        size_t s_inside = (s<0) ? -s : ( (s>=(long long)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
+        size_t p_inside = (p<0) ? -p : ( (p>=(long long)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
+        size_t r_inside = (r<0) ? -r : ( (r>=(long long)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
+        size_t a_inside = (a<0) ? -a : ( (a>=(long long)array_->get_size(6)) ? (2*array_->get_size(6)-a-2) : a );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
-        size_t z_inside = (z<0) ? -z : ( (z>=(gt_index_type)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
-        size_t s_inside = (s<0) ? -s : ( (s>=(gt_index_type)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
-        size_t p_inside = (p<0) ? -p : ( (p>=(gt_index_type)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
-        size_t r_inside = (r<0) ? -r : ( (r>=(gt_index_type)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
-        size_t a_inside = (a<0) ? -a : ( (a>=(gt_index_type)array_->get_size(6)) ? (2*array_->get_size(6)-a-2) : a );
-        size_t q_inside = (q<0) ? -q : ( (q>=(gt_index_type)array_->get_size(7)) ? (2*array_->get_size(7)-q-2) : q );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t z_inside = (z<0) ? -z : ( (z>=(long long)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
+        size_t s_inside = (s<0) ? -s : ( (s>=(long long)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
+        size_t p_inside = (p<0) ? -p : ( (p>=(long long)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
+        size_t r_inside = (r<0) ? -r : ( (r>=(long long)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
+        size_t a_inside = (a<0) ? -a : ( (a>=(long long)array_->get_size(6)) ? (2*array_->get_size(6)-a-2) : a );
+        size_t q_inside = (q<0) ? -q : ( (q>=(long long)array_->get_size(7)) ? (2*array_->get_size(7)-q-2) : q );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside, q_inside);
     }
 
     template <typename ArrayType> 
-    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( gt_index_type x, gt_index_type y, gt_index_type z, gt_index_type s, gt_index_type p, gt_index_type r, gt_index_type a, gt_index_type q, gt_index_type u )
+    inline typename hoNDBoundaryHandlerMirror<ArrayType>::T hoNDBoundaryHandlerMirror<ArrayType>::operator()( long long x, long long y, long long z, long long s, long long p, long long r, long long a, long long q, long long u )
     {
-        size_t x_inside = (x<0) ? -x : ( (x>=(gt_index_type)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
-        size_t y_inside = (y<0) ? -y : ( (y>=(gt_index_type)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
-        size_t z_inside = (z<0) ? -z : ( (z>=(gt_index_type)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
-        size_t s_inside = (s<0) ? -s : ( (s>=(gt_index_type)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
-        size_t p_inside = (p<0) ? -p : ( (p>=(gt_index_type)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
-        size_t r_inside = (r<0) ? -r : ( (r>=(gt_index_type)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
-        size_t a_inside = (a<0) ? -a : ( (a>=(gt_index_type)array_->get_size(6)) ? (2*array_->get_size(6)-a-2) : a );
-        size_t q_inside = (q<0) ? -q : ( (q>=(gt_index_type)array_->get_size(7)) ? (2*array_->get_size(7)-q-2) : q );
-        size_t u_inside = (u<0) ? -u : ( (u>=(gt_index_type)array_->get_size(8)) ? (2*array_->get_size(8)-u-2) : u );
+        size_t x_inside = (x<0) ? -x : ( (x>=(long long)array_->get_size(0)) ? (2*array_->get_size(0)-x-2) : x );
+        size_t y_inside = (y<0) ? -y : ( (y>=(long long)array_->get_size(1)) ? (2*array_->get_size(1)-y-2) : y );
+        size_t z_inside = (z<0) ? -z : ( (z>=(long long)array_->get_size(2)) ? (2*array_->get_size(2)-z-2) : z );
+        size_t s_inside = (s<0) ? -s : ( (s>=(long long)array_->get_size(3)) ? (2*array_->get_size(3)-s-2) : s );
+        size_t p_inside = (p<0) ? -p : ( (p>=(long long)array_->get_size(4)) ? (2*array_->get_size(4)-p-2) : p );
+        size_t r_inside = (r<0) ? -r : ( (r>=(long long)array_->get_size(5)) ? (2*array_->get_size(5)-r-2) : r );
+        size_t a_inside = (a<0) ? -a : ( (a>=(long long)array_->get_size(6)) ? (2*array_->get_size(6)-a-2) : a );
+        size_t q_inside = (q<0) ? -q : ( (q>=(long long)array_->get_size(7)) ? (2*array_->get_size(7)-q-2) : q );
+        size_t u_inside = (u<0) ? -u : ( (u>=(long long)array_->get_size(8)) ? (2*array_->get_size(8)-u-2) : u );
 
         return (*array_)(x_inside, y_inside, z_inside, s_inside, p_inside, r_inside, a_inside, q_inside, u_inside);
     }

--- a/toolboxes/core/cpu/hoNDInterpolatorBSpline.hxx
+++ b/toolboxes/core/cpu/hoNDInterpolatorBSpline.hxx
@@ -48,12 +48,12 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( const coord_type* pos )
     {
-        std::vector<gt_index_type> anchor(D);
+        std::vector<long long> anchor(D);
 
         unsigned int ii;
         for ( ii=0; ii<D; ii++ )
         {
-            anchor[ii] = static_cast<gt_index_type>(std::floor(pos[ii]));
+            anchor[ii] = static_cast<long long>(std::floor(pos[ii]));
         }
 
         bool inRange = true;
@@ -85,9 +85,9 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
+        long long ix = static_cast<long long>(std::floor(x));
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), dimension_[0], order_, derivative_[0], x);
         }
@@ -100,8 +100,8 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
+        long long ix = static_cast<long long>(std::floor(x));
+        long long iy = static_cast<long long>(std::floor(y));
 
         /*x = (x<0) ? 0 : x;
         x = (x>array_->get_size(0)-1) ? array_->get_size(0)-1 : x;
@@ -109,7 +109,7 @@ namespace Gadgetron
         y = (y<0) ? 0 : y;
         y = (y>array_->get_size(1)-1) ? array_->get_size(1)-1 : y;*/
 
-        /*if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 )
+        /*if ( ix>=0 && ix<(long long)array_->get_size(0)-1 && iy>=0 && iy<(long long)array_->get_size(1)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), dimension_[0], dimension_[1], order_, derivative_[0], derivative_[1], x, y);
         }
@@ -131,13 +131,13 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y, coord_type z )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
+        long long ix = static_cast<long long>(std::floor(x));
+        long long iy = static_cast<long long>(std::floor(y));
+        long long iz = static_cast<long long>(std::floor(z));
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 
-            && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 
-            && iz>=0 && iz<(gt_index_type)array_->get_size(2)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 
+            && iy>=0 && iy<(long long)array_->get_size(1)-1 
+            && iz>=0 && iz<(long long)array_->get_size(2)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), 
                 dimension_[0], dimension_[1], dimension_[2], 
@@ -154,15 +154,15 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y, coord_type z, coord_type s )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
-        gt_index_type is = static_cast<gt_index_type>(std::floor(s));
+        long long ix = static_cast<long long>(std::floor(x));
+        long long iy = static_cast<long long>(std::floor(y));
+        long long iz = static_cast<long long>(std::floor(z));
+        long long is = static_cast<long long>(std::floor(s));
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 
-            && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 
-            && iz>=0 && iz<(gt_index_type)array_->get_size(2)-1 
-            && is>=0 && is<(gt_index_type)array_->get_size(3)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 
+            && iy>=0 && iy<(long long)array_->get_size(1)-1 
+            && iz>=0 && iz<(long long)array_->get_size(2)-1 
+            && is>=0 && is<(long long)array_->get_size(3)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), 
                 dimension_[0], dimension_[1], dimension_[2], dimension_[3], 
@@ -179,17 +179,17 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
-        gt_index_type is = static_cast<gt_index_type>(std::floor(s));
-        gt_index_type ip = static_cast<gt_index_type>(std::floor(p));
+        long long ix = static_cast<long long>(std::floor(x));
+        long long iy = static_cast<long long>(std::floor(y));
+        long long iz = static_cast<long long>(std::floor(z));
+        long long is = static_cast<long long>(std::floor(s));
+        long long ip = static_cast<long long>(std::floor(p));
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 
-            && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 
-            && iz>=0 && iz<(gt_index_type)array_->get_size(2)-1 
-            && is>=0 && is<(gt_index_type)array_->get_size(3)-1 
-            && ip>=0 && ip<(gt_index_type)array_->get_size(4)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 
+            && iy>=0 && iy<(long long)array_->get_size(1)-1 
+            && iz>=0 && iz<(long long)array_->get_size(2)-1 
+            && is>=0 && is<(long long)array_->get_size(3)-1 
+            && ip>=0 && ip<(long long)array_->get_size(4)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), 
                 dimension_[0], dimension_[1], dimension_[2], dimension_[3], dimension_[4], 
@@ -206,19 +206,19 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
-        gt_index_type is = static_cast<gt_index_type>(std::floor(s));
-        gt_index_type ip = static_cast<gt_index_type>(std::floor(p));
-        gt_index_type ir = static_cast<gt_index_type>(std::floor(r));
+        long long ix = static_cast<long long>(std::floor(x));
+        long long iy = static_cast<long long>(std::floor(y));
+        long long iz = static_cast<long long>(std::floor(z));
+        long long is = static_cast<long long>(std::floor(s));
+        long long ip = static_cast<long long>(std::floor(p));
+        long long ir = static_cast<long long>(std::floor(r));
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 
-            && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 
-            && iz>=0 && iz<(gt_index_type)array_->get_size(2)-1 
-            && is>=0 && is<(gt_index_type)array_->get_size(3)-1 
-            && ip>=0 && ip<(gt_index_type)array_->get_size(4)-1 
-            && ir>=0 && ir<(gt_index_type)array_->get_size(5)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 
+            && iy>=0 && iy<(long long)array_->get_size(1)-1 
+            && iz>=0 && iz<(long long)array_->get_size(2)-1 
+            && is>=0 && is<(long long)array_->get_size(3)-1 
+            && ip>=0 && ip<(long long)array_->get_size(4)-1 
+            && ir>=0 && ir<(long long)array_->get_size(5)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), 
                 dimension_[0], dimension_[1], dimension_[2], dimension_[3], dimension_[4], dimension_[5], 
@@ -235,23 +235,23 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a )
     {
-        gt_index_type anchor[7];
+        long long anchor[7];
 
-        anchor[0] = static_cast<gt_index_type>(std::floor(x));
-        anchor[1] = static_cast<gt_index_type>(std::floor(y));
-        anchor[2] = static_cast<gt_index_type>(std::floor(z));
-        anchor[3] = static_cast<gt_index_type>(std::floor(s));
-        anchor[4] = static_cast<gt_index_type>(std::floor(p));
-        anchor[5] = static_cast<gt_index_type>(std::floor(r));
-        anchor[6] = static_cast<gt_index_type>(std::floor(a));
+        anchor[0] = static_cast<long long>(std::floor(x));
+        anchor[1] = static_cast<long long>(std::floor(y));
+        anchor[2] = static_cast<long long>(std::floor(z));
+        anchor[3] = static_cast<long long>(std::floor(s));
+        anchor[4] = static_cast<long long>(std::floor(p));
+        anchor[5] = static_cast<long long>(std::floor(r));
+        anchor[6] = static_cast<long long>(std::floor(a));
 
-        if ( anchor[0]>=0 && anchor[0]<(gt_index_type)array_->get_size(0)-1 
-            && anchor[1]>=0 && anchor[1]<(gt_index_type)array_->get_size(1)-1 
-            && anchor[2]>=0 && anchor[2]<(gt_index_type)array_->get_size(2)-1 
-            && anchor[3]>=0 && anchor[3]<(gt_index_type)array_->get_size(3)-1 
-            && anchor[4]>=0 && anchor[4]<(gt_index_type)array_->get_size(4)-1 
-            && anchor[5]>=0 && anchor[5]<(gt_index_type)array_->get_size(5)-1
-            && anchor[6]>=0 && anchor[6]<(gt_index_type)array_->get_size(6)-1 )
+        if ( anchor[0]>=0 && anchor[0]<(long long)array_->get_size(0)-1 
+            && anchor[1]>=0 && anchor[1]<(long long)array_->get_size(1)-1 
+            && anchor[2]>=0 && anchor[2]<(long long)array_->get_size(2)-1 
+            && anchor[3]>=0 && anchor[3]<(long long)array_->get_size(3)-1 
+            && anchor[4]>=0 && anchor[4]<(long long)array_->get_size(4)-1 
+            && anchor[5]>=0 && anchor[5]<(long long)array_->get_size(5)-1
+            && anchor[6]>=0 && anchor[6]<(long long)array_->get_size(6)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), 
                 dimension_[0], dimension_[1], dimension_[2], dimension_[3], dimension_[4], dimension_[5], dimension_[6], 
@@ -268,25 +268,25 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a, coord_type q )
     {
-        gt_index_type anchor[8];
+        long long anchor[8];
 
-        anchor[0] = static_cast<gt_index_type>(std::floor(x));
-        anchor[1] = static_cast<gt_index_type>(std::floor(y));
-        anchor[2] = static_cast<gt_index_type>(std::floor(z));
-        anchor[3] = static_cast<gt_index_type>(std::floor(s));
-        anchor[4] = static_cast<gt_index_type>(std::floor(p));
-        anchor[5] = static_cast<gt_index_type>(std::floor(r));
-        anchor[6] = static_cast<gt_index_type>(std::floor(a));
-        anchor[7] = static_cast<gt_index_type>(std::floor(q));
+        anchor[0] = static_cast<long long>(std::floor(x));
+        anchor[1] = static_cast<long long>(std::floor(y));
+        anchor[2] = static_cast<long long>(std::floor(z));
+        anchor[3] = static_cast<long long>(std::floor(s));
+        anchor[4] = static_cast<long long>(std::floor(p));
+        anchor[5] = static_cast<long long>(std::floor(r));
+        anchor[6] = static_cast<long long>(std::floor(a));
+        anchor[7] = static_cast<long long>(std::floor(q));
 
-        if ( anchor[0]>=0 && anchor[0]<(gt_index_type)array_->get_size(0)-1 
-            && anchor[1]>=0 && anchor[1]<(gt_index_type)array_->get_size(1)-1 
-            && anchor[2]>=0 && anchor[2]<(gt_index_type)array_->get_size(2)-1 
-            && anchor[3]>=0 && anchor[3]<(gt_index_type)array_->get_size(3)-1 
-            && anchor[4]>=0 && anchor[4]<(gt_index_type)array_->get_size(4)-1 
-            && anchor[5]>=0 && anchor[5]<(gt_index_type)array_->get_size(5)-1 
-            && anchor[6]>=0 && anchor[6]<(gt_index_type)array_->get_size(6)-1 
-            && anchor[7]>=0 && anchor[7]<(gt_index_type)array_->get_size(7)-1 )
+        if ( anchor[0]>=0 && anchor[0]<(long long)array_->get_size(0)-1 
+            && anchor[1]>=0 && anchor[1]<(long long)array_->get_size(1)-1 
+            && anchor[2]>=0 && anchor[2]<(long long)array_->get_size(2)-1 
+            && anchor[3]>=0 && anchor[3]<(long long)array_->get_size(3)-1 
+            && anchor[4]>=0 && anchor[4]<(long long)array_->get_size(4)-1 
+            && anchor[5]>=0 && anchor[5]<(long long)array_->get_size(5)-1 
+            && anchor[6]>=0 && anchor[6]<(long long)array_->get_size(6)-1 
+            && anchor[7]>=0 && anchor[7]<(long long)array_->get_size(7)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), 
                 dimension_[0], dimension_[1], dimension_[2], dimension_[3], dimension_[4], dimension_[5], dimension_[6], dimension_[7], 
@@ -303,27 +303,27 @@ namespace Gadgetron
     template <typename ArrayType, unsigned int D> 
     inline typename hoNDInterpolatorBSpline<ArrayType, D>::T hoNDInterpolatorBSpline<ArrayType, D>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a, coord_type q, coord_type u )
     {
-        gt_index_type anchor[9];
+        long long anchor[9];
 
-        anchor[0] = static_cast<gt_index_type>(std::floor(x));
-        anchor[1] = static_cast<gt_index_type>(std::floor(y));
-        anchor[2] = static_cast<gt_index_type>(std::floor(z));
-        anchor[3] = static_cast<gt_index_type>(std::floor(s));
-        anchor[4] = static_cast<gt_index_type>(std::floor(p));
-        anchor[5] = static_cast<gt_index_type>(std::floor(r));
-        anchor[6] = static_cast<gt_index_type>(std::floor(a));
-        anchor[7] = static_cast<gt_index_type>(std::floor(q));
-        anchor[8] = static_cast<gt_index_type>(std::floor(u));
+        anchor[0] = static_cast<long long>(std::floor(x));
+        anchor[1] = static_cast<long long>(std::floor(y));
+        anchor[2] = static_cast<long long>(std::floor(z));
+        anchor[3] = static_cast<long long>(std::floor(s));
+        anchor[4] = static_cast<long long>(std::floor(p));
+        anchor[5] = static_cast<long long>(std::floor(r));
+        anchor[6] = static_cast<long long>(std::floor(a));
+        anchor[7] = static_cast<long long>(std::floor(q));
+        anchor[8] = static_cast<long long>(std::floor(u));
 
-        if ( anchor[0]>=0 && anchor[0]<(gt_index_type)array_->get_size(0)-1 
-            && anchor[1]>=0 && anchor[1]<(gt_index_type)array_->get_size(1)-1 
-            && anchor[2]>=0 && anchor[2]<(gt_index_type)array_->get_size(2)-1 
-            && anchor[3]>=0 && anchor[3]<(gt_index_type)array_->get_size(3)-1 
-            && anchor[4]>=0 && anchor[4]<(gt_index_type)array_->get_size(4)-1 
-            && anchor[5]>=0 && anchor[5]<(gt_index_type)array_->get_size(5)-1 
-            && anchor[6]>=0 && anchor[6]<(gt_index_type)array_->get_size(6)-1 
-            && anchor[7]>=0 && anchor[7]<(gt_index_type)array_->get_size(7)-1 
-            && anchor[8]>=0 && anchor[8]<(gt_index_type)array_->get_size(8)-1 )
+        if ( anchor[0]>=0 && anchor[0]<(long long)array_->get_size(0)-1 
+            && anchor[1]>=0 && anchor[1]<(long long)array_->get_size(1)-1 
+            && anchor[2]>=0 && anchor[2]<(long long)array_->get_size(2)-1 
+            && anchor[3]>=0 && anchor[3]<(long long)array_->get_size(3)-1 
+            && anchor[4]>=0 && anchor[4]<(long long)array_->get_size(4)-1 
+            && anchor[5]>=0 && anchor[5]<(long long)array_->get_size(5)-1 
+            && anchor[6]>=0 && anchor[6]<(long long)array_->get_size(6)-1 
+            && anchor[7]>=0 && anchor[7]<(long long)array_->get_size(7)-1 
+            && anchor[8]>=0 && anchor[8]<(long long)array_->get_size(8)-1 )
         {
             return bspline_.evaluateBSpline(coeff_.begin(), 
                 dimension_[0], dimension_[1], dimension_[2], dimension_[3], dimension_[4], dimension_[5], dimension_[6], dimension_[7], dimension_[8], 

--- a/toolboxes/core/cpu/hoNDInterpolatorLinear.hxx
+++ b/toolboxes/core/cpu/hoNDInterpolatorLinear.hxx
@@ -21,14 +21,14 @@ namespace Gadgetron
     {
         unsigned int D = array_->get_number_of_dimensions();
 
-        gt_index_type* anchor = reinterpret_cast<gt_index_type*>(alloca(D * sizeof(gt_index_type)));
+        long long* anchor = reinterpret_cast<long long*>(alloca(D * sizeof(long long)));
         coord_type* weights = reinterpret_cast<coord_type*>(alloca(D * sizeof(coord_type)));
         coord_type* weightsMinusOne = reinterpret_cast<coord_type*>(alloca(D * sizeof(coord_type)));
 
         unsigned int ii;
         for ( ii=0; ii<D; ii++ )
         {
-            anchor[ii] = static_cast<gt_index_type>(std::floor(pos[ii]));
+            anchor[ii] = static_cast<long long>(std::floor(pos[ii]));
             weights[ii] = pos[ii] - anchor[ii];
             weightsMinusOne[ii] = coord_type(1.0) - weights[ii];
         }
@@ -79,7 +79,7 @@ namespace Gadgetron
         }
         else
         {
-            std::vector<gt_index_type> ind(D);
+            std::vector<long long> ind(D);
 
             unsigned int n;
             for ( n=0; n<number_of_points_; n++ )
@@ -120,10 +120,10 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
+        long long ix = static_cast<long long>(std::floor(x));
         coord_type dx = x - ix;
 
-        if ( ix>=0 && ix<(gt_index_type)sx_-1 )
+        if ( ix>=0 && ix<(long long)sx_-1 )
         {
             return ( (*array_)( size_t(ix) )*(1-dx) + (*array_)( size_t(ix)+1 )*dx );
         }
@@ -136,11 +136,11 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
+        long long ix = static_cast<long long>(std::floor(x));
         coord_type dx = x - ix;
         coord_type dx_prime = coord_type(1.0)-dx;
 
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
+        long long iy = static_cast<long long>(std::floor(y));
         coord_type dy = y - iy;
         coord_type dy_prime = coord_type(1.0)-dy;
 
@@ -176,15 +176,15 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y, coord_type z )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
+        long long ix = static_cast<long long>(std::floor(x));
         coord_type dx = x - ix;
         coord_type dx_prime = coord_type(1.0)-dx;
 
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
+        long long iy = static_cast<long long>(std::floor(y));
         coord_type dy = y - iy;
         coord_type dy_prime = coord_type(1.0)-dy;
 
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
+        long long iz = static_cast<long long>(std::floor(z));
         coord_type dz = z - iz;
         coord_type dz_prime = coord_type(1.0)-dz;
 
@@ -228,26 +228,26 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
+        long long ix = static_cast<long long>(std::floor(x));
         coord_type dx = x - ix;
         coord_type dx_prime = coord_type(1.0)-dx;
 
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
+        long long iy = static_cast<long long>(std::floor(y));
         coord_type dy = y - iy;
         coord_type dy_prime = coord_type(1.0)-dy;
 
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
+        long long iz = static_cast<long long>(std::floor(z));
         coord_type dz = z - iz;
         coord_type dz_prime = coord_type(1.0)-dz;
 
-        gt_index_type is = static_cast<gt_index_type>(std::floor(s));
+        long long is = static_cast<long long>(std::floor(s));
         coord_type ds = s - is;
         coord_type ds_prime = coord_type(1.0)-ds;
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 
-            && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 
-            && iz>=0 && iz<(gt_index_type)array_->get_size(2)-1 
-            && is>=0 && is<(gt_index_type)array_->get_size(3)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 
+            && iy>=0 && iy<(long long)array_->get_size(1)-1 
+            && iz>=0 && iz<(long long)array_->get_size(2)-1 
+            && is>=0 && is<(long long)array_->get_size(3)-1 )
         {
             return (    ((*array_)(size_t(ix),   size_t(iy),     size_t(iz),    size_t(is) )   *   dx_prime     *dy_prime   *dz_prime   *ds_prime 
                     +   (*array_)(size_t(ix)+1, size_t(iy),     size_t(iz),     size_t(is) )   *   dx           *dy_prime   *dz_prime   *ds_prime) 
@@ -290,31 +290,31 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
+        long long ix = static_cast<long long>(std::floor(x));
         coord_type dx = x - ix;
         coord_type dx_prime = coord_type(1.0)-dx;
 
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
+        long long iy = static_cast<long long>(std::floor(y));
         coord_type dy = y - iy;
         coord_type dy_prime = coord_type(1.0)-dy;
 
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
+        long long iz = static_cast<long long>(std::floor(z));
         coord_type dz = z - iz;
         coord_type dz_prime = coord_type(1.0)-dz;
 
-        gt_index_type is = static_cast<gt_index_type>(std::floor(s));
+        long long is = static_cast<long long>(std::floor(s));
         coord_type ds = s - is;
         coord_type ds_prime = coord_type(1.0)-ds;
 
-        gt_index_type ip = static_cast<gt_index_type>(std::floor(p));
+        long long ip = static_cast<long long>(std::floor(p));
         coord_type dp = p - ip;
         coord_type dp_prime = coord_type(1.0)-dp;
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 
-            && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 
-            && iz>=0 && iz<(gt_index_type)array_->get_size(2)-1 
-            && is>=0 && is<(gt_index_type)array_->get_size(3)-1 
-            && ip>=0 && ip<(gt_index_type)array_->get_size(4)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 
+            && iy>=0 && iy<(long long)array_->get_size(1)-1 
+            && iz>=0 && iz<(long long)array_->get_size(2)-1 
+            && is>=0 && is<(long long)array_->get_size(3)-1 
+            && ip>=0 && ip<(long long)array_->get_size(4)-1 )
         {
             return (    ((*array_)(size_t(ix),   size_t(iy),     size_t(iz),    size_t(is),     size_t(ip) )   *   dx_prime     *dy_prime   *dz_prime   *ds_prime   *dp_prime
                     +   (*array_)(size_t(ix)+1, size_t(iy),     size_t(iz),     size_t(is),     size_t(ip) )   *   dx           *dy_prime   *dz_prime   *ds_prime   *dp_prime) 
@@ -389,36 +389,36 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r )
     {
-        gt_index_type ix = static_cast<gt_index_type>(std::floor(x));
+        long long ix = static_cast<long long>(std::floor(x));
         coord_type dx = x - ix;
         coord_type dx_prime = coord_type(1.0)-dx;
 
-        gt_index_type iy = static_cast<gt_index_type>(std::floor(y));
+        long long iy = static_cast<long long>(std::floor(y));
         coord_type dy = y - iy;
         coord_type dy_prime = coord_type(1.0)-dy;
 
-        gt_index_type iz = static_cast<gt_index_type>(std::floor(z));
+        long long iz = static_cast<long long>(std::floor(z));
         coord_type dz = z - iz;
         coord_type dz_prime = coord_type(1.0)-dz;
 
-        gt_index_type is = static_cast<gt_index_type>(std::floor(s));
+        long long is = static_cast<long long>(std::floor(s));
         coord_type ds = s - is;
         coord_type ds_prime = coord_type(1.0)-ds;
 
-        gt_index_type ip = static_cast<gt_index_type>(std::floor(p));
+        long long ip = static_cast<long long>(std::floor(p));
         coord_type dp = p - ip;
         coord_type dp_prime = coord_type(1.0)-dp;
 
-        gt_index_type ir = static_cast<gt_index_type>(std::floor(r));
+        long long ir = static_cast<long long>(std::floor(r));
         coord_type dr = r - ir;
         coord_type dr_prime = coord_type(1.0)-dr;
 
-        if ( ix>=0 && ix<(gt_index_type)array_->get_size(0)-1 
-            && iy>=0 && iy<(gt_index_type)array_->get_size(1)-1 
-            && iz>=0 && iz<(gt_index_type)array_->get_size(2)-1 
-            && is>=0 && is<(gt_index_type)array_->get_size(3)-1 
-            && ip>=0 && ip<(gt_index_type)array_->get_size(4)-1 
-            && ir>=0 && ir<(gt_index_type)array_->get_size(5)-1 )
+        if ( ix>=0 && ix<(long long)array_->get_size(0)-1 
+            && iy>=0 && iy<(long long)array_->get_size(1)-1 
+            && iz>=0 && iz<(long long)array_->get_size(2)-1 
+            && is>=0 && is<(long long)array_->get_size(3)-1 
+            && ip>=0 && ip<(long long)array_->get_size(4)-1 
+            && ir>=0 && ir<(long long)array_->get_size(5)-1 )
         {
             return (    ((*array_)(size_t(ix),   size_t(iy),     size_t(iz),    size_t(is),     size_t(ip),     size_t(ir) )   *   dx_prime     *dy_prime   *dz_prime   *ds_prime   *dp_prime   *dr_prime
                     +   (*array_)(size_t(ix)+1, size_t(iy),     size_t(iz),     size_t(is),     size_t(ip),     size_t(ir) )   *   dx           *dy_prime   *dz_prime   *ds_prime   *dp_prime   *dr_prime) 
@@ -557,17 +557,17 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a )
     {
-        gt_index_type anchor[7];
+        long long anchor[7];
         coord_type d[7];
         coord_type d_prime[7];
 
-        anchor[0] = static_cast<gt_index_type>(std::floor(x));
-        anchor[1] = static_cast<gt_index_type>(std::floor(y));
-        anchor[2] = static_cast<gt_index_type>(std::floor(z));
-        anchor[3] = static_cast<gt_index_type>(std::floor(s));
-        anchor[4] = static_cast<gt_index_type>(std::floor(p));
-        anchor[5] = static_cast<gt_index_type>(std::floor(r));
-        anchor[6] = static_cast<gt_index_type>(std::floor(a));
+        anchor[0] = static_cast<long long>(std::floor(x));
+        anchor[1] = static_cast<long long>(std::floor(y));
+        anchor[2] = static_cast<long long>(std::floor(z));
+        anchor[3] = static_cast<long long>(std::floor(s));
+        anchor[4] = static_cast<long long>(std::floor(p));
+        anchor[5] = static_cast<long long>(std::floor(r));
+        anchor[6] = static_cast<long long>(std::floor(a));
 
         d[0] = x - anchor[0];
         d[1] = y - anchor[1];
@@ -589,13 +589,13 @@ namespace Gadgetron
 
         unsigned int n;
 
-        if ( anchor[0]>=0 && anchor[0]<(gt_index_type)array_->get_size(0)-1 
-            && anchor[1]>=0 && anchor[1]<(gt_index_type)array_->get_size(1)-1 
-            && anchor[2]>=0 && anchor[2]<(gt_index_type)array_->get_size(2)-1 
-            && anchor[3]>=0 && anchor[3]<(gt_index_type)array_->get_size(3)-1 
-            && anchor[4]>=0 && anchor[4]<(gt_index_type)array_->get_size(4)-1 
-            && anchor[5]>=0 && anchor[5]<(gt_index_type)array_->get_size(5)-1
-            && anchor[6]>=0 && anchor[6]<(gt_index_type)array_->get_size(6)-1 )
+        if ( anchor[0]>=0 && anchor[0]<(long long)array_->get_size(0)-1 
+            && anchor[1]>=0 && anchor[1]<(long long)array_->get_size(1)-1 
+            && anchor[2]>=0 && anchor[2]<(long long)array_->get_size(2)-1 
+            && anchor[3]>=0 && anchor[3]<(long long)array_->get_size(3)-1 
+            && anchor[4]>=0 && anchor[4]<(long long)array_->get_size(4)-1 
+            && anchor[5]>=0 && anchor[5]<(long long)array_->get_size(5)-1
+            && anchor[6]>=0 && anchor[6]<(long long)array_->get_size(6)-1 )
         {
             std::vector<size_t> ind(7);
 
@@ -626,7 +626,7 @@ namespace Gadgetron
         }
         else
         {
-            std::vector<gt_index_type> ind(7);
+            std::vector<long long> ind(7);
 
             for ( n=0; n<number_of_points_; n++ )
             {
@@ -660,18 +660,18 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a, coord_type q )
     {
-        gt_index_type anchor[8];
+        long long anchor[8];
         coord_type d[8];
         coord_type d_prime[8];
 
-        anchor[0] = static_cast<gt_index_type>(std::floor(x));
-        anchor[1] = static_cast<gt_index_type>(std::floor(y));
-        anchor[2] = static_cast<gt_index_type>(std::floor(z));
-        anchor[3] = static_cast<gt_index_type>(std::floor(s));
-        anchor[4] = static_cast<gt_index_type>(std::floor(p));
-        anchor[5] = static_cast<gt_index_type>(std::floor(r));
-        anchor[6] = static_cast<gt_index_type>(std::floor(a));
-        anchor[7] = static_cast<gt_index_type>(std::floor(q));
+        anchor[0] = static_cast<long long>(std::floor(x));
+        anchor[1] = static_cast<long long>(std::floor(y));
+        anchor[2] = static_cast<long long>(std::floor(z));
+        anchor[3] = static_cast<long long>(std::floor(s));
+        anchor[4] = static_cast<long long>(std::floor(p));
+        anchor[5] = static_cast<long long>(std::floor(r));
+        anchor[6] = static_cast<long long>(std::floor(a));
+        anchor[7] = static_cast<long long>(std::floor(q));
 
         d[0] = x - anchor[0];
         d[1] = y - anchor[1];
@@ -694,14 +694,14 @@ namespace Gadgetron
 
         unsigned int n;
 
-        if ( anchor[0]>=0 && anchor[0]<(gt_index_type)array_->get_size(0)-1 
-            && anchor[1]>=0 && anchor[1]<(gt_index_type)array_->get_size(1)-1 
-            && anchor[2]>=0 && anchor[2]<(gt_index_type)array_->get_size(2)-1 
-            && anchor[3]>=0 && anchor[3]<(gt_index_type)array_->get_size(3)-1 
-            && anchor[4]>=0 && anchor[4]<(gt_index_type)array_->get_size(4)-1 
-            && anchor[5]>=0 && anchor[5]<(gt_index_type)array_->get_size(5)-1
-            && anchor[6]>=0 && anchor[6]<(gt_index_type)array_->get_size(6)-1
-            && anchor[7]>=0 && anchor[7]<(gt_index_type)array_->get_size(7)-1 )
+        if ( anchor[0]>=0 && anchor[0]<(long long)array_->get_size(0)-1 
+            && anchor[1]>=0 && anchor[1]<(long long)array_->get_size(1)-1 
+            && anchor[2]>=0 && anchor[2]<(long long)array_->get_size(2)-1 
+            && anchor[3]>=0 && anchor[3]<(long long)array_->get_size(3)-1 
+            && anchor[4]>=0 && anchor[4]<(long long)array_->get_size(4)-1 
+            && anchor[5]>=0 && anchor[5]<(long long)array_->get_size(5)-1
+            && anchor[6]>=0 && anchor[6]<(long long)array_->get_size(6)-1
+            && anchor[7]>=0 && anchor[7]<(long long)array_->get_size(7)-1 )
         {
             std::vector<size_t> ind(8);
 
@@ -732,7 +732,7 @@ namespace Gadgetron
         }
         else
         {
-            std::vector<gt_index_type> ind(8);
+            std::vector<long long> ind(8);
 
             for ( n=0; n<number_of_points_; n++ )
             {
@@ -766,19 +766,19 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorLinear<ArrayType>::T hoNDInterpolatorLinear<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a, coord_type q, coord_type u )
     {
-        gt_index_type anchor[9];
+        long long anchor[9];
         coord_type d[9];
         coord_type d_prime[9];
 
-        anchor[0] = static_cast<gt_index_type>(std::floor(x));
-        anchor[1] = static_cast<gt_index_type>(std::floor(y));
-        anchor[2] = static_cast<gt_index_type>(std::floor(z));
-        anchor[3] = static_cast<gt_index_type>(std::floor(s));
-        anchor[4] = static_cast<gt_index_type>(std::floor(p));
-        anchor[5] = static_cast<gt_index_type>(std::floor(r));
-        anchor[6] = static_cast<gt_index_type>(std::floor(a));
-        anchor[7] = static_cast<gt_index_type>(std::floor(q));
-        anchor[8] = static_cast<gt_index_type>(std::floor(u));
+        anchor[0] = static_cast<long long>(std::floor(x));
+        anchor[1] = static_cast<long long>(std::floor(y));
+        anchor[2] = static_cast<long long>(std::floor(z));
+        anchor[3] = static_cast<long long>(std::floor(s));
+        anchor[4] = static_cast<long long>(std::floor(p));
+        anchor[5] = static_cast<long long>(std::floor(r));
+        anchor[6] = static_cast<long long>(std::floor(a));
+        anchor[7] = static_cast<long long>(std::floor(q));
+        anchor[8] = static_cast<long long>(std::floor(u));
 
         d[0] = x - anchor[0];
         d[1] = y - anchor[1];
@@ -802,15 +802,15 @@ namespace Gadgetron
 
         unsigned int n;
 
-        if ( anchor[0]>=0 && anchor[0]<(gt_index_type)array_->get_size(0)-1 
-            && anchor[1]>=0 && anchor[1]<(gt_index_type)array_->get_size(1)-1 
-            && anchor[2]>=0 && anchor[2]<(gt_index_type)array_->get_size(2)-1 
-            && anchor[3]>=0 && anchor[3]<(gt_index_type)array_->get_size(3)-1 
-            && anchor[4]>=0 && anchor[4]<(gt_index_type)array_->get_size(4)-1 
-            && anchor[5]>=0 && anchor[5]<(gt_index_type)array_->get_size(5)-1
-            && anchor[6]>=0 && anchor[6]<(gt_index_type)array_->get_size(6)-1
-            && anchor[7]>=0 && anchor[7]<(gt_index_type)array_->get_size(7)-1
-            && anchor[8]>=0 && anchor[8]<(gt_index_type)array_->get_size(8)-1 )
+        if ( anchor[0]>=0 && anchor[0]<(long long)array_->get_size(0)-1 
+            && anchor[1]>=0 && anchor[1]<(long long)array_->get_size(1)-1 
+            && anchor[2]>=0 && anchor[2]<(long long)array_->get_size(2)-1 
+            && anchor[3]>=0 && anchor[3]<(long long)array_->get_size(3)-1 
+            && anchor[4]>=0 && anchor[4]<(long long)array_->get_size(4)-1 
+            && anchor[5]>=0 && anchor[5]<(long long)array_->get_size(5)-1
+            && anchor[6]>=0 && anchor[6]<(long long)array_->get_size(6)-1
+            && anchor[7]>=0 && anchor[7]<(long long)array_->get_size(7)-1
+            && anchor[8]>=0 && anchor[8]<(long long)array_->get_size(8)-1 )
         {
             std::vector<size_t> ind(9);
 
@@ -841,7 +841,7 @@ namespace Gadgetron
         }
         else
         {
-            std::vector<gt_index_type> ind(9);
+            std::vector<long long> ind(9);
 
             for ( n=0; n<number_of_points_; n++ )
             {

--- a/toolboxes/core/cpu/hoNDInterpolatorNearestNeighbor.hxx
+++ b/toolboxes/core/cpu/hoNDInterpolatorNearestNeighbor.hxx
@@ -14,11 +14,11 @@ namespace Gadgetron
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( const coord_type* pos )
     {
         unsigned int D = array_->get_number_of_dimensions();
-        std::vector<gt_index_type> ind(D);
+        std::vector<long long> ind(D);
         unsigned int ii;
         for ( ii=0; ii<D; ii++ )
         {
-            ind[ii] = static_cast<gt_index_type>(pos[ii]+0.5);
+            ind[ii] = static_cast<long long>(pos[ii]+0.5);
         }
 
         return (*bh_)(ind);
@@ -27,12 +27,12 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( const std::vector<coord_type>& pos )
     {
-        std::vector<gt_index_type> ind(pos.size());
+        std::vector<long long> ind(pos.size());
         unsigned int ii;
         unsigned int D = array_->get_number_of_dimensions();
         for ( ii=0; ii<D; ii++ )
         {
-            ind[ii] = static_cast<gt_index_type>(pos[ii]+0.5);
+            ind[ii] = static_cast<long long>(pos[ii]+0.5);
         }
 
         return (*bh_)(ind);
@@ -41,54 +41,54 @@ namespace Gadgetron
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y, coord_type z )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5), static_cast<gt_index_type>(z+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5), static_cast<long long>(z+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5), static_cast<gt_index_type>(z+0.5), static_cast<gt_index_type>(s+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5), static_cast<long long>(z+0.5), static_cast<long long>(s+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5), static_cast<gt_index_type>(z+0.5), static_cast<gt_index_type>(s+0.5), static_cast<gt_index_type>(p+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5), static_cast<long long>(z+0.5), static_cast<long long>(s+0.5), static_cast<long long>(p+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5), static_cast<gt_index_type>(z+0.5), static_cast<gt_index_type>(s+0.5), static_cast<gt_index_type>(p+0.5), static_cast<gt_index_type>(r+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5), static_cast<long long>(z+0.5), static_cast<long long>(s+0.5), static_cast<long long>(p+0.5), static_cast<long long>(r+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5), static_cast<gt_index_type>(z+0.5), static_cast<gt_index_type>(s+0.5), static_cast<gt_index_type>(p+0.5), static_cast<gt_index_type>(r+0.5), static_cast<gt_index_type>(a+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5), static_cast<long long>(z+0.5), static_cast<long long>(s+0.5), static_cast<long long>(p+0.5), static_cast<long long>(r+0.5), static_cast<long long>(a+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a, coord_type q )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5), static_cast<gt_index_type>(z+0.5), static_cast<gt_index_type>(s+0.5), static_cast<gt_index_type>(p+0.5), static_cast<gt_index_type>(r+0.5), static_cast<gt_index_type>(a+0.5), static_cast<gt_index_type>(q+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5), static_cast<long long>(z+0.5), static_cast<long long>(s+0.5), static_cast<long long>(p+0.5), static_cast<long long>(r+0.5), static_cast<long long>(a+0.5), static_cast<long long>(q+0.5));
     }
 
     template <typename ArrayType> 
     inline typename hoNDInterpolatorNearestNeighbor<ArrayType>::T hoNDInterpolatorNearestNeighbor<ArrayType>::operator()( coord_type x, coord_type y, coord_type z, coord_type s, coord_type p, coord_type r, coord_type a, coord_type q, coord_type u )
     {
-        return (*bh_)(static_cast<gt_index_type>(x+0.5), static_cast<gt_index_type>(y+0.5), static_cast<gt_index_type>(z+0.5), static_cast<gt_index_type>(s+0.5), static_cast<gt_index_type>(p+0.5), static_cast<gt_index_type>(r+0.5), static_cast<gt_index_type>(a+0.5), static_cast<gt_index_type>(q+0.5), static_cast<gt_index_type>(u+0.5));
+        return (*bh_)(static_cast<long long>(x+0.5), static_cast<long long>(y+0.5), static_cast<long long>(z+0.5), static_cast<long long>(s+0.5), static_cast<long long>(p+0.5), static_cast<long long>(r+0.5), static_cast<long long>(a+0.5), static_cast<long long>(q+0.5), static_cast<long long>(u+0.5));
     }
 }

--- a/toolboxes/core/cpu/image/hoNDImage.h
+++ b/toolboxes/core/cpu/image/hoNDImage.h
@@ -299,7 +299,7 @@ namespace Gadgetron
 
         size_t calculate_offset(const size_t* ind) const;
         size_t calculate_offset(const std::vector<size_t>& ind) const;
-        size_t calculate_offset(const std::vector<gt_index_type>& ind) const;
+        size_t calculate_offset(const std::vector<long long>& ind) const;
 
         size_t calculate_offset(size_t x, size_t y) const;
         size_t calculate_offset(size_t x, size_t y, size_t z) const;
@@ -331,8 +331,8 @@ namespace Gadgetron
         T& operator()( const std::vector<size_t>& ind );
         const T& operator()( const std::vector<size_t>& ind ) const;
 
-        T& operator()( const std::vector<gt_index_type>& ind );
-        const T& operator()( const std::vector<gt_index_type>& ind ) const;
+        T& operator()( const std::vector<long long>& ind );
+        const T& operator()( const std::vector<long long>& ind ) const;
 
         T& operator[]( size_t x );
         const T& operator[]( size_t x ) const;

--- a/toolboxes/core/cpu/image/hoNDImage.h
+++ b/toolboxes/core/cpu/image/hoNDImage.h
@@ -299,7 +299,6 @@ namespace Gadgetron
 
         size_t calculate_offset(const size_t* ind) const;
         size_t calculate_offset(const std::vector<size_t>& ind) const;
-        size_t calculate_offset(const std::vector<long long>& ind) const;
 
         size_t calculate_offset(size_t x, size_t y) const;
         size_t calculate_offset(size_t x, size_t y, size_t z) const;
@@ -330,9 +329,6 @@ namespace Gadgetron
 
         T& operator()( const std::vector<size_t>& ind );
         const T& operator()( const std::vector<size_t>& ind ) const;
-
-        T& operator()( const std::vector<long long>& ind );
-        const T& operator()( const std::vector<long long>& ind ) const;
 
         T& operator[]( size_t x );
         const T& operator[]( size_t x ) const;

--- a/toolboxes/core/cpu/image/hoNDImage.hxx
+++ b/toolboxes/core/cpu/image/hoNDImage.hxx
@@ -1213,7 +1213,7 @@ namespace Gadgetron
     }
 
     template <typename T, unsigned int D> 
-    inline size_t hoNDImage<T, D>::calculate_offset(const std::vector<gt_index_type>& ind) const
+    inline size_t hoNDImage<T, D>::calculate_offset(const std::vector<long long>& ind) const
     {
         size_t offset = (size_t)(ind[0]);
         for( size_t i = 1; i < D; i++ )
@@ -1506,7 +1506,7 @@ namespace Gadgetron
     }
 
     template <typename T, unsigned int D> 
-    inline T& hoNDImage<T, D>::operator()( const std::vector<gt_index_type>& ind )
+    inline T& hoNDImage<T, D>::operator()( const std::vector<long long>& ind )
     {
         size_t idx = this->calculate_offset(ind);
         GADGET_DEBUG_CHECK_THROW(idx < this->elements_);
@@ -1514,7 +1514,7 @@ namespace Gadgetron
     }
 
     template <typename T, unsigned int D> 
-    inline const T& hoNDImage<T, D>::operator()( const std::vector<gt_index_type>& ind ) const
+    inline const T& hoNDImage<T, D>::operator()( const std::vector<long long>& ind ) const
     {
         size_t idx = this->calculate_offset(ind);
         GADGET_DEBUG_CHECK_THROW(idx < this->elements_);

--- a/toolboxes/core/cpu/image/hoNDImage.hxx
+++ b/toolboxes/core/cpu/image/hoNDImage.hxx
@@ -1213,15 +1213,6 @@ namespace Gadgetron
     }
 
     template <typename T, unsigned int D> 
-    inline size_t hoNDImage<T, D>::calculate_offset(const std::vector<long long>& ind) const
-    {
-        size_t offset = (size_t)(ind[0]);
-        for( size_t i = 1; i < D; i++ )
-            offset += (size_t)(ind[i]) * (*offsetFactors_)[i];
-        return offset;
-    }
-
-    template <typename T, unsigned int D> 
     inline size_t hoNDImage<T, D>::calculate_offset(size_t x, size_t y) const
     {
         GADGET_DEBUG_CHECK_THROW(D==2);
@@ -1499,22 +1490,6 @@ namespace Gadgetron
 
     template <typename T, unsigned int D> 
     inline const T& hoNDImage<T, D>::operator()( const std::vector<size_t>& ind ) const
-    {
-        size_t idx = this->calculate_offset(ind);
-        GADGET_DEBUG_CHECK_THROW(idx < this->elements_);
-        return this->data_[idx];
-    }
-
-    template <typename T, unsigned int D> 
-    inline T& hoNDImage<T, D>::operator()( const std::vector<long long>& ind )
-    {
-        size_t idx = this->calculate_offset(ind);
-        GADGET_DEBUG_CHECK_THROW(idx < this->elements_);
-        return this->data_[idx];
-    }
-
-    template <typename T, unsigned int D> 
-    inline const T& hoNDImage<T, D>::operator()( const std::vector<long long>& ind ) const
     {
         size_t idx = this->calculate_offset(ind);
         GADGET_DEBUG_CHECK_THROW(idx < this->elements_);

--- a/toolboxes/core/cpu/math/hoNDImage_util.hxx
+++ b/toolboxes/core/cpu/math/hoNDImage_util.hxx
@@ -310,21 +310,21 @@ namespace Gadgetron
 
             if ( D == 2 )
             {
-                gt_index_type sx = (gt_index_type)dim_out[0];
-                gt_index_type sy = (gt_index_type)dim_out[1];
+                size_t sx = dim_out[0];
+                size_t sy = dim_out[1];
 
                 T weight = 1.0/5;
 
-                gt_index_type x, y;
+                long long x, y;
 
                 #pragma omp parallel for default(none) private(x, y) shared(sx, sy, bh, out)
-                for ( y=0; y<sy; y++ )
+                for ( y=0; y<(long long)sy; y++ )
                 {
-                    gt_index_type iy = y<<1;
+                    long long iy = y<<1;
 
-                    for ( x=0; x<sx; x++ )
+                    for ( x=0; x<(long long)sx; x++ )
                     {
-                        gt_index_type ix = x<<1;
+                        long long ix = x<<1;
                         out( (size_t)(x+y*sx) ) = bh(ix, iy) + ( bh(ix+1, iy) + bh(ix-1, iy) ) + ( bh(ix, iy+1) + bh(ix, iy-1) );
                     }
                 }
@@ -333,28 +333,28 @@ namespace Gadgetron
             }
             else if ( D == 3 )
             {
-                gt_index_type sx = (gt_index_type)dim_out[0];
-                gt_index_type sy = (gt_index_type)dim_out[1];
-                gt_index_type sz = (gt_index_type)dim_out[2];
+                size_t sx = dim_out[0];
+                size_t sy = dim_out[1];
+                size_t sz = dim_out[2];
 
                 T weight = 1.0/7;
 
-                gt_index_type x, y, z;
+                long long x, y, z;
 
                 #pragma omp parallel for default(none) private(x, y, z) shared(sx, sy, sz, bh, out)
                 for ( z=0; z<sz; z++ )
                 {
-                    gt_index_type iz = z<<1;
+                    long long iz = z<<1;
 
                     for ( y=0; y<sy; y++ )
                     {
-                        gt_index_type iy = y<<1;
+                        long long iy = y<<1;
 
                         size_t offset = y*sx + z*sx*sy;
 
                         for ( x=0; x<sx; x++ )
                         {
-                            gt_index_type ix = x<<1;
+                            long long ix = x<<1;
 
                             out( (size_t)(x+offset) ) = bh(ix, iy, iz) 
                                         + ( bh(ix+1, iy, iz) + bh(ix-1, iy, iz) ) 
@@ -368,33 +368,33 @@ namespace Gadgetron
             }
             else if ( D == 4 )
             {
-                gt_index_type sx = (gt_index_type)dim_out[0];
-                gt_index_type sy = (gt_index_type)dim_out[1];
-                gt_index_type sz = (gt_index_type)dim_out[2];
-                gt_index_type st = (gt_index_type)dim_out[3];
+                size_t sx = dim_out[0];
+                size_t sy = dim_out[1];
+                size_t sz = dim_out[2];
+                size_t st = dim_out[3];
 
                 T weight = 1.0/9;
 
-                gt_index_type x, y, z, t;
+                long long x, y, z, t;
 
                 #pragma omp parallel for default(none) private(x, y, z, t) shared(sx, sy, sz, st, bh, out)
                 for ( t=0; t<st; t++ )
                 {
-                    gt_index_type it = t<<1;
+                    long long it = t<<1;
 
                     for ( z=0; z<sz; z++ )
                     {
-                        gt_index_type iz = z<<1;
+                        long long iz = z<<1;
 
                         for ( y=0; y<sy; y++ )
                         {
-                            gt_index_type iy = y<<1;
+                            long long iy = y<<1;
 
                             size_t offset = y*sx + z*sx*sy + t*sx*sy*sz;
 
                             for ( x=0; x<sx; x++ )
                             {
-                                gt_index_type ix = x<<1;
+                                long long ix = x<<1;
 
                                 out( (size_t)(x+offset) ) = bh(ix, iy, iz, it) 
                                             + ( bh(ix+1, iy, iz, it) + bh(ix-1, iy, iz, it) ) 
@@ -412,14 +412,14 @@ namespace Gadgetron
             {
                 T weight = 1.0/(2*D+1);
 
-                gt_index_type N = out.get_number_of_elements();
+                size_t N = out.get_number_of_elements();
 
-                gt_index_type n;
+                long long n;
 
                 #pragma omp parallel default(none) private(n) shared(N, bh, out, dim_out)
                 {
                     std::vector<size_t> ind_out(D);
-                    std::vector<gt_index_type> ind_in(D);
+                    std::vector<long long> ind_in(D);
 
                     #pragma omp for 
                     for ( n=0; n<N; n++ )
@@ -499,10 +499,10 @@ namespace Gadgetron
 
             if ( D == 2 )
             {
-                gt_index_type sx = (gt_index_type)dim[0];
-                gt_index_type sy = (gt_index_type)dim[1];
+                size_t sx = dim[0];
+                size_t sy = dim[1];
 
-                gt_index_type x, y;
+                long long x, y;
 
                 #pragma omp parallel for default(none) private(x, y) shared(sx, sy, bh, out)
                 for ( y=0; y<sy; y++ )
@@ -526,8 +526,8 @@ namespace Gadgetron
                 }
 
                 // if out has odd sizes
-                gt_index_type sx_out = (gt_index_type)out.get_size(0);
-                gt_index_type sy_out = (gt_index_type)out.get_size(1);
+                size_t sx_out = out.get_size(0);
+                size_t sy_out = out.get_size(1);
 
                 if ( (2*sx) < sx_out )
                 {
@@ -545,11 +545,11 @@ namespace Gadgetron
             }
             else if ( D == 3 )
             {
-                gt_index_type sx = (gt_index_type)dim[0];
-                gt_index_type sy = (gt_index_type)dim[1];
-                gt_index_type sz = (gt_index_type)dim[2];
+                size_t sx = dim[0];
+                size_t sy = dim[1];
+                size_t sz = dim[2];
 
-                gt_index_type x, y, z;
+                long long x, y, z;
 
                 #pragma omp parallel for default(none) private(x, y, z) shared(sx, sy, sz, bh, out)
                 for ( z=0; z<sz; z++ )
@@ -588,9 +588,9 @@ namespace Gadgetron
                 }
 
                 // if out has odd sizes
-                gt_index_type sx_out = (gt_index_type)out.get_size(0);
-                gt_index_type sy_out = (gt_index_type)out.get_size(1);
-                gt_index_type sz_out = (gt_index_type)out.get_size(2);
+                size_t sx_out = out.get_size(0);
+                size_t sy_out = out.get_size(1);
+                size_t sz_out = out.get_size(2);
 
                 if ( (2*sx) < sx_out )
                 {
@@ -627,9 +627,9 @@ namespace Gadgetron
             {
                 hoNDInterpolatorLinear<hoNDImage<T, D> > interp(const_cast< hoNDImage<T, D>& >(in), bh);
 
-                gt_index_type N = (gt_index_type)(out.get_number_of_elements());
+                size_t N = out.get_number_of_elements();
 
-                gt_index_type n;
+                long long n;
 
                 #pragma omp parallel default(none) private(n) shared(N, bh, in, out, interp)
                 {


### PR DESCRIPTION
Following the discussion, 

a) remove gt_index_type
b) make sure all array access using size_t
c) the boundary condition check and interpolator use long long, since they need to handle negative indices
