### PR TITLE
Python math

### DIFF
--- a/toolboxes/CMakeLists.txt
+++ b/toolboxes/CMakeLists.txt
@@ -36,3 +36,10 @@ ENDIF()
 
 find_package(BLAS)
 find_package(LAPACK)
+
+# Should we compile the python_math toolbox
+find_package(Boost COMPONENTS python system thread REQUIRED)
+if (Boost_PYTHON_FOUND AND PYTHONLIBS_FOUND AND NUMPY_FOUND)
+    add_subdirectory(python_math)
+endif (Boost_PYTHON_FOUND AND PYTHONLIBS_FOUND AND NUMPY_FOUND)
+

--- a/toolboxes/python_math/CMakeLists.txt
+++ b/toolboxes/python_math/CMakeLists.txt
@@ -1,0 +1,40 @@
+include_directories(${ACE_INCLUDE_DIR}
+                    ${Boost_INCLUDE_DIR} 
+		    ${PYTHON_INCLUDE_PATH}
+		    ${NUMPY_INCLUDE_DIRS}
+		    ${CMAKE_SOURCE_DIR}/toolboxes/core
+		    ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu
+                    )
+
+add_library(gadgetron_toolbox_python_math SHARED
+  PythonMath.cpp
+  PythonMath.h
+  python_math_export.h
+)
+
+target_link_libraries(gadgetron_toolbox_python_math
+                      gadgetron_toolbox_cpucore
+                      	${PYTHON_LIBRARIES}
+			${Boost_LIBRARIES}
+			${ACE_LIBRARIES}
+			gadgetron_toolbox_log)
+
+add_executable(gadgetron_test_python_math
+  test_python_math.cpp)
+
+target_link_libraries(gadgetron_test_python_math
+  gadgetron_toolbox_python_math
+  gadgetron_toolbox_cpucore
+  ${PYTHON_LIBRARIES}
+  ${Boost_LIBRARIES}
+  gadgetron_toolbox_log)
+
+set_target_properties(gadgetron_toolbox_python_math  PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
+
+install(TARGETS gadgetron_toolbox_python_math DESTINATION lib COMPONENT main)
+install(TARGETS gadgetron_test_python_math DESTINATION bin COMPONENT main)
+
+install(FILES 
+  PythonMath.h
+  python_math_export.h
+  DESTINATION include COMPONENT main)

--- a/toolboxes/python_math/CMakeLists.txt
+++ b/toolboxes/python_math/CMakeLists.txt
@@ -1,11 +1,3 @@
-find_library (BOOST_NUMPY_LIBRARY boost_numpy )
-
-if (NOT BOOST_NUMPY_LIBRARY)
-  message(FATAL_ERROR "Unable to locate boost_numpy")
-endif()
-
-message("BOOST_NUMPY_LIBRARY: ${BOOST_NUMPY_LIBRARY}")
-
 include_directories(${ACE_INCLUDE_DIR}
                     ${Boost_INCLUDE_DIR} 
 		    ${PYTHON_INCLUDE_PATH}
@@ -24,7 +16,6 @@ target_link_libraries(gadgetron_toolbox_python_math
                       gadgetron_toolbox_cpucore
                       	${PYTHON_LIBRARIES}
 			${Boost_LIBRARIES}
-			${BOOST_NUMPY_LIBRARY}
 			${ACE_LIBRARIES}
 			gadgetron_toolbox_log)
 
@@ -36,7 +27,6 @@ target_link_libraries(gadgetron_test_python_math
   gadgetron_toolbox_cpucore
   ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
-  ${BOOST_NUMPY_LIBRARY}
   gadgetron_toolbox_log)
 
 set_target_properties(gadgetron_toolbox_python_math  PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})

--- a/toolboxes/python_math/CMakeLists.txt
+++ b/toolboxes/python_math/CMakeLists.txt
@@ -1,3 +1,11 @@
+find_library (BOOST_NUMPY_LIBRARY boost_numpy )
+
+if (NOT BOOST_NUMPY_LIBRARY)
+  message(FATAL_ERROR "Unable to locate boost_numpy")
+endif()
+
+message("BOOST_NUMPY_LIBRARY: ${BOOST_NUMPY_LIBRARY}")
+
 include_directories(${ACE_INCLUDE_DIR}
                     ${Boost_INCLUDE_DIR} 
 		    ${PYTHON_INCLUDE_PATH}
@@ -16,6 +24,7 @@ target_link_libraries(gadgetron_toolbox_python_math
                       gadgetron_toolbox_cpucore
                       	${PYTHON_LIBRARIES}
 			${Boost_LIBRARIES}
+			${BOOST_NUMPY_LIBRARY}
 			${ACE_LIBRARIES}
 			gadgetron_toolbox_log)
 
@@ -27,6 +36,7 @@ target_link_libraries(gadgetron_test_python_math
   gadgetron_toolbox_cpucore
   ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${BOOST_NUMPY_LIBRARY}
   gadgetron_toolbox_log)
 
 set_target_properties(gadgetron_toolbox_python_math  PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})

--- a/toolboxes/python_math/PythonMath.cpp
+++ b/toolboxes/python_math/PythonMath.cpp
@@ -3,15 +3,69 @@
 
 #include <stdexcept>
 
-#include <boost/python.hpp>
-#include <boost/numpy.hpp>
-
-#include <numpy/numpyconfig.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <boost/python.hpp>
+//#include <boost/numpy.hpp>
+#include <numpy/numpyconfig.h>
 #include <numpy/arrayobject.h>
+
+namespace bp = boost::python;
 
 namespace Gadgetron
 {
+
+  template <typename T> void bp_object_to_hondarray(bp::object& obj, hoNDArray< T >* arr)
+  {
+    if (!arr) {
+      throw std::runtime_error("bp_object_to_hondarray received null pointer array");
+    }
+
+    if (sizeof(T) != PyArray_ITEMSIZE((PyArrayObject*)obj.ptr())) {
+      GERROR("sizeof(T): %d, ITEMSIZE: %d\n", sizeof(T), PyArray_ITEMSIZE((PyArrayObject*)obj.ptr()));
+      throw std::runtime_error("bp_object_to_hondarray: python object and array data type sizes do not match");
+    }
+
+    size_t ndim = PyArray_NDIM((PyArrayObject*)obj.ptr());
+    std::vector<size_t> dims(ndim);
+    for (size_t i = 0; i < ndim; i++) {
+      dims[ndim-i-1] = PyArray_DIM((PyArrayObject*)obj.ptr(),i);
+    }
+
+    if (!arr->dimensions_equal(&dims)) {
+      arr->create(dims);
+    }
+
+    memcpy(arr->get_data_ptr(), PyArray_DATA((PyArrayObject*)obj.ptr()), sizeof(T)*arr->get_number_of_elements());
+  }
+
+  template <typename T> int get_numpy_type();
+  template <> int get_numpy_type< std::complex<float> >() {return NPY_COMPLEX64;}
+  template <> int get_numpy_type< std::complex<double> >() {return NPY_COMPLEX128;}
+  template <> int get_numpy_type< float >() {return NPY_FLOAT32;}
+  template <> int get_numpy_type< unsigned int >() {return NPY_UINT32;}
+
+  template <typename T> bp::object hondarray_to_bp_object(hoNDArray< T >* arr)
+  {
+    if (!arr) {
+      throw std::runtime_error("hondarray_to_bp_object: null pointer passed for arr");
+    }
+
+    size_t ndim = arr->get_number_of_dimensions();
+    std::vector<int> dims2(ndim);
+    for (unsigned int i = 0; i < ndim; i++) dims2[ndim-i-1] = static_cast<int>(arr->get_size(i));
+    bp::object obj(bp::handle<>(PyArray_FromDims(dims2.size(), &dims2[0], get_numpy_type<T>())));
+    
+    if (sizeof(T) != PyArray_ITEMSIZE((PyArrayObject*)obj.ptr())) {
+      GERROR("sizeof(T): %d, ITEMSIZE: %d\n", sizeof(T), PyArray_ITEMSIZE((PyArrayObject*)obj.ptr()));
+      throw std::runtime_error("hondarray_to_bp_object: python object and array data type sizes do not match");
+    }
+
+    //Copy data
+    memcpy(PyArray_DATA((PyArrayObject*)obj.ptr()), arr->get_data_ptr(), arr->get_number_of_elements()*sizeof(std::complex<float>));
+
+    return obj;
+  }
+  
   PythonMath* PythonMath::instance_ = 0;
 
   PythonMath* PythonMath::instance()
@@ -26,8 +80,8 @@ namespace Gadgetron
   PythonMath::PythonMath()
   {
     Py_Initialize();
-    boost::numpy::initialize();
-    //_import_array();
+    //boost::numpy::initialize();
+    _import_array();
     
     PyEval_InitThreads();
     
@@ -45,7 +99,7 @@ namespace Gadgetron
 					    float regularization_factor, hoNDArray< std::complex<float> >* target_data, 
 					    hoNDArray< float >* gmap_out)
   {
-    GDEBUG("Called calculate grappa unmixing\n");
+    GDEBUG("Called calculate grappa unmixing.\n");
     
     if (!source_data) {
       throw std::runtime_error("Source data is NULL");
@@ -55,49 +109,61 @@ namespace Gadgetron
       throw std::runtime_error("source_data input array has wrong number of dimensions");
     }
 
-    size_t nx = source_data->get_size(0);
-    size_t ny = source_data->get_size(1);
-    size_t coils = source_data->get_size(2);
-
-
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
     try {
-      boost::python::object mod = boost::python::import("ismrmrdtools.grappa"); 
-      boost::python::object fcn = mod.attr("calculate_grappa_unmixing");
-      boost::python::tuple dims = boost::python::make_tuple((int)coils,(int)ny,(int)nx);
+      bp::object mod = bp::import("ismrmrdtools.grappa"); 
+      bp::object fcn = mod.attr("calculate_grappa_unmixing");
+      bp::object source_data_obj = hondarray_to_bp_object(source_data);
+      bp::tuple kernel_size_obj;
+      bp::object data_mask_obj; //None
+      bp::object csm_obj; //None
+      bp::object target_data_obj; //None
+      
+      if (kernel_size) {
+	kernel_size_obj = bp::make_tuple(kernel_size[0],kernel_size[1]);
+      } else {
+	kernel_size_obj = bp::make_tuple(4,5);
+      }
 
-      boost::numpy::ndarray py_array = 
-	boost::numpy::from_data(source_data->get_data_ptr(), 
-				boost::numpy::dtype::get_builtin< std::complex<float> >() , 
-				dims, dims, boost::python::object());
-      
-      /*
-      size_t ndim = source_data->get_number_of_dimensions();
-      std::vector<int> dims2(ndim);
-      for (unsigned int i = 0; i < ndim; i++) dims2[ndim-i-1] = static_cast<int>(source_data->get_size(i));
-      
-      boost::python::object obj(boost::python::handle<>(PyArray_FromDims(dims2.size(), &dims2[0], NPY_COMPLEX64)));
-      //boost::python::object data = boost::python::extract<boost::python::numeric::array>(obj);
-      
-      //Copy data
-      memcpy(PyArray_DATA((PyArrayObject*)obj.ptr()), source_data->get_data_ptr(), source_data->get_number_of_elements()*sizeof(std::complex<float>));
-      */
+      if (data_mask) data_mask_obj = hondarray_to_bp_object(data_mask);
+      if (csm) csm_obj = hondarray_to_bp_object(csm);
+      if (target_data) target_data_obj = hondarray_to_bp_object(target_data);
 
-      //boost::python::object ret = fcn(obj,acc_factor);
-      boost::python::object result = fcn(py_array,acc_factor);
-      GINFO("result length: %d\n", boost::python::len(result));
-      boost::python::tuple result_ex = boost::python::extract<boost::python::tuple>(result);
-      
-      boost::numpy::ndarray umx = boost::python::extract<boost::numpy::ndarray>(result_ex[0]);
-      boost::numpy::ndarray gmap = boost::python::extract<boost::numpy::ndarray>(result_ex[1]);
+      bp::object result = fcn(source_data_obj,acc_factor,kernel_size_obj, data_mask_obj, csm_obj, regularization_factor, target_data_obj);
 
-      GDEBUG("Object returned\n");
-    } catch(boost::python::error_already_set const &) {
-      GDEBUG("Error loading python modules\n");
+      if (bp::len(result) != 2) {
+	throw std::runtime_error("Wrong number of results from python function");
+      }
+
+      bp::tuple result_ex = bp::extract<bp::tuple>(result);      
+      bp::object umx = bp::extract<bp::object>(result_ex[0]);
+      bp::object gmap = bp::extract<bp::object>(result_ex[1]);
+
+      if (PyArray_NDIM((PyArrayObject*)umx.ptr()) != 3) {
+	throw std::runtime_error("Returned unmixing coefficients have wrong number of dimensions");
+      } 
+
+      if (PyArray_NDIM((PyArrayObject*)gmap.ptr()) != 2) {
+	throw std::runtime_error("Returned gmap coefficients have wrong number of dimensions");
+      } 
+
+      bp_object_to_hondarray(umx, unmix_out);
+
+      if (gmap_out) {
+	bp_object_to_hondarray(gmap, gmap_out);
+      }
+
+      GDEBUG("Grappa unmixing calculation returned.\n");
+    } catch(bp::error_already_set const &) {
+      GERROR("Error calling python code in PythonMath\n");
       PyErr_Print();
       PyGILState_Release(gstate);
+    } catch (std::exception const & e) {
+      GERROR("Run time error in PythonMath\n");
+      PyGILState_Release(gstate);
+      throw;
     }
     PyGILState_Release(gstate);
 

--- a/toolboxes/python_math/PythonMath.cpp
+++ b/toolboxes/python_math/PythonMath.cpp
@@ -1,7 +1,10 @@
 #include "PythonMath.h"
 #include "log.h"
 
+#include <stdexcept>
+
 #include <boost/python.hpp>
+#include <boost/numpy.hpp>
 
 #include <numpy/numpyconfig.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
@@ -23,7 +26,8 @@ namespace Gadgetron
   PythonMath::PythonMath()
   {
     Py_Initialize();
-    _import_array();
+    boost::numpy::initialize();
+    //_import_array();
     
     PyEval_InitThreads();
     
@@ -42,24 +46,59 @@ namespace Gadgetron
 					    hoNDArray< float >* gmap_out)
   {
     GDEBUG("Called calculate grappa unmixing\n");
+    
+    if (!source_data) {
+      throw std::runtime_error("Source data is NULL");
+    }
+
+    if (source_data->get_number_of_dimensions() != 3) {
+      throw std::runtime_error("source_data input array has wrong number of dimensions");
+    }
+
+    size_t nx = source_data->get_size(0);
+    size_t ny = source_data->get_size(1);
+    size_t coils = source_data->get_size(2);
+
+
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
-    
-    boost::python::object mod = boost::python::import("ismrmrdtools.grappa"); 
-    boost::python::object fcn = mod.attr("calculate_grappa_unmixing");
-    
-    size_t ndim = source_data->get_number_of_dimensions();
-    std::vector<int> dims2(ndim);
-    for (unsigned int i = 0; i < ndim; i++) dims2[ndim-i-1] = static_cast<int>(source_data->get_size(i));
-    
-    boost::python::object obj(boost::python::handle<>(PyArray_FromDims(dims2.size(), &dims2[0], NPY_COMPLEX64)));
-    //boost::python::object data = boost::python::extract<boost::python::numeric::array>(obj);
-    
-    //Copy data
-    memcpy(PyArray_DATA((PyArrayObject*)obj.ptr()), source_data->get_data_ptr(), source_data->get_number_of_elements()*sizeof(std::complex<float>));
-  
-    boost::python::object ret = fcn(obj,acc_factor);
-    
+
+    try {
+      boost::python::object mod = boost::python::import("ismrmrdtools.grappa"); 
+      boost::python::object fcn = mod.attr("calculate_grappa_unmixing");
+      boost::python::tuple dims = boost::python::make_tuple((int)coils,(int)ny,(int)nx);
+
+      boost::numpy::ndarray py_array = 
+	boost::numpy::from_data(source_data->get_data_ptr(), 
+				boost::numpy::dtype::get_builtin< std::complex<float> >() , 
+				dims, dims, boost::python::object());
+      
+      /*
+      size_t ndim = source_data->get_number_of_dimensions();
+      std::vector<int> dims2(ndim);
+      for (unsigned int i = 0; i < ndim; i++) dims2[ndim-i-1] = static_cast<int>(source_data->get_size(i));
+      
+      boost::python::object obj(boost::python::handle<>(PyArray_FromDims(dims2.size(), &dims2[0], NPY_COMPLEX64)));
+      //boost::python::object data = boost::python::extract<boost::python::numeric::array>(obj);
+      
+      //Copy data
+      memcpy(PyArray_DATA((PyArrayObject*)obj.ptr()), source_data->get_data_ptr(), source_data->get_number_of_elements()*sizeof(std::complex<float>));
+      */
+
+      //boost::python::object ret = fcn(obj,acc_factor);
+      boost::python::object result = fcn(py_array,acc_factor);
+      GINFO("result length: %d\n", boost::python::len(result));
+      boost::python::tuple result_ex = boost::python::extract<boost::python::tuple>(result);
+      
+      boost::numpy::ndarray umx = boost::python::extract<boost::numpy::ndarray>(result_ex[0]);
+      boost::numpy::ndarray gmap = boost::python::extract<boost::numpy::ndarray>(result_ex[1]);
+
+      GDEBUG("Object returned\n");
+    } catch(boost::python::error_already_set const &) {
+      GDEBUG("Error loading python modules\n");
+      PyErr_Print();
+      PyGILState_Release(gstate);
+    }
     PyGILState_Release(gstate);
 
   }

--- a/toolboxes/python_math/PythonMath.cpp
+++ b/toolboxes/python_math/PythonMath.cpp
@@ -1,0 +1,67 @@
+#include "PythonMath.h"
+#include "log.h"
+
+#include <boost/python.hpp>
+
+#include <numpy/numpyconfig.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+namespace Gadgetron
+{
+  PythonMath* PythonMath::instance_ = 0;
+
+  PythonMath* PythonMath::instance()
+  {
+    if (!instance_)
+      {
+	instance_ = new PythonMath();
+      }
+    return instance_;
+  }
+
+  PythonMath::PythonMath()
+  {
+    Py_Initialize();
+    _import_array();
+    
+    PyEval_InitThreads();
+    
+    //Swap out and return current thread state and release the GIL
+    //Must be done, otherwise subsequent calls to PyGILState_Ensure() will not be guaranteed to acuire lock
+    PyThreadState* tstate = PyEval_SaveThread();
+    if (!tstate) {
+      GDEBUG("Error occurred returning lock to Python\n");
+    }
+
+  }
+
+  void PythonMath::calculate_grappa_unmixing(hoNDArray< std::complex<float> >* source_data, unsigned int acc_factor, hoNDArray< std::complex<float> >* unmix_out,
+					    unsigned int* kernel_size, hoNDArray< unsigned int >* data_mask, hoNDArray< std::complex<float> >* csm,
+					    float regularization_factor, hoNDArray< std::complex<float> >* target_data, 
+					    hoNDArray< float >* gmap_out)
+  {
+    GDEBUG("Called calculate grappa unmixing\n");
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+    
+    boost::python::object mod = boost::python::import("ismrmrdtools.grappa"); 
+    boost::python::object fcn = mod.attr("calculate_grappa_unmixing");
+    
+    size_t ndim = source_data->get_number_of_dimensions();
+    std::vector<int> dims2(ndim);
+    for (unsigned int i = 0; i < ndim; i++) dims2[ndim-i-1] = static_cast<int>(source_data->get_size(i));
+    
+    boost::python::object obj(boost::python::handle<>(PyArray_FromDims(dims2.size(), &dims2[0], NPY_COMPLEX64)));
+    //boost::python::object data = boost::python::extract<boost::python::numeric::array>(obj);
+    
+    //Copy data
+    memcpy(PyArray_DATA((PyArrayObject*)obj.ptr()), source_data->get_data_ptr(), source_data->get_number_of_elements()*sizeof(std::complex<float>));
+  
+    boost::python::object ret = fcn(obj,acc_factor);
+    
+    PyGILState_Release(gstate);
+
+  }
+  
+}

--- a/toolboxes/python_math/PythonMath.h
+++ b/toolboxes/python_math/PythonMath.h
@@ -19,7 +19,7 @@ namespace Gadgetron
      */
     void calculate_grappa_unmixing(hoNDArray< std::complex<float> >* source_data, unsigned int acc_factor, hoNDArray< std::complex<float> >* unmix_out,
 				  unsigned int* kernel_size = 0, hoNDArray< unsigned int >* data_mask = 0, hoNDArray< std::complex<float> >* csm = 0,
-				  float regularization_factor = 0.01, hoNDArray< std::complex<float> >* target_data = 0, 
+				  float regularization_factor = 0.001, hoNDArray< std::complex<float> >* target_data = 0, 
 				  hoNDArray< float >* gmap_out = 0);
 
   protected:

--- a/toolboxes/python_math/PythonMath.h
+++ b/toolboxes/python_math/PythonMath.h
@@ -1,0 +1,36 @@
+#ifndef GADGETRON_PYTHON_MATH_H
+#define GADGETRON_PYTHON_MATH_H
+
+#include "python_math_export.h"
+#include <boost/thread/mutex.hpp>
+#include "hoNDArray.h"
+
+namespace Gadgetron
+{
+
+  class EXPORTPYTHONMATH PythonMath
+  {
+
+  public:
+    static PythonMath* instance();
+
+    /**
+       Wrapper for ismrmrdtools.grappa.calculate_grappa_unmixing(source_data, acc_factor, kernel_size=(4,5), data_mask=None, csm=None, regularization_factor=0.001, target_data=None):
+     */
+    void calculate_grappa_unmixing(hoNDArray< std::complex<float> >* source_data, unsigned int acc_factor, hoNDArray< std::complex<float> >* unmix_out,
+				  unsigned int* kernel_size = 0, hoNDArray< unsigned int >* data_mask = 0, hoNDArray< std::complex<float> >* csm = 0,
+				  float regularization_factor = 0.01, hoNDArray< std::complex<float> >* target_data = 0, 
+				  hoNDArray< float >* gmap_out = 0);
+
+  protected:
+    ///Protected constructor. 
+    PythonMath();
+
+    static PythonMath* instance_;
+    boost::mutex mtx_;
+  };
+
+
+}
+
+#endif

--- a/toolboxes/python_math/python_math_export.h
+++ b/toolboxes/python_math/python_math_export.h
@@ -1,0 +1,14 @@
+#ifndef PYTHON_MATH_EXPORT_H_
+#define PYTHON_MATH_EXPORT_H_
+
+#if defined (WIN32)
+    #if defined (__BUILD_GADGETRON_PYTHON_MATH__) || defined (gadgetron_toolbox_python_math_EXPORTS)
+        #define EXPORTPYTHONMATH __declspec(dllexport)
+    #else
+        #define EXPORTPYTHONMATH __declspec(dllimport)
+    #endif
+#else
+    #define EXPORTPYTHONMATH
+#endif
+
+#endif

--- a/toolboxes/python_math/test_python_math.cpp
+++ b/toolboxes/python_math/test_python_math.cpp
@@ -28,11 +28,12 @@ int main(int argc, char** argv)
   dims.push_back(ny);
   dims.push_back(coils);
   
-  
   hoNDArray< std::complex<float> > unmix(dims);
   
   PythonMath::instance()->calculate_grappa_unmixing(source_data.get(), 3, &unmix);
   
+  write_nd_array(&unmix, "unmix.cplx");
+
   return 0;
 
 }

--- a/toolboxes/python_math/test_python_math.cpp
+++ b/toolboxes/python_math/test_python_math.cpp
@@ -1,0 +1,38 @@
+#include "log.h"
+#include "PythonMath.h"
+#include "hoNDArray_fileio.h"
+
+
+using namespace Gadgetron;
+
+int main(int argc, char** argv)
+{
+
+  GINFO("This is the PythonMath test application\n");
+
+  if (argc < 2) {
+    GERROR("You must supply an input file\n");
+    return -1;
+  }
+
+  boost::shared_ptr< hoNDArray< std::complex<float> > > source_data = read_nd_array< std::complex<float> >(argv[1]);
+
+  size_t coils = source_data->get_size(2);
+  size_t ny = source_data->get_size(1);
+  size_t nx = source_data->get_size(0);
+  
+  GINFO("Array dimensions [%d, %d, %d]\n", nx, ny, coils);
+
+  std::vector<size_t> dims;
+  dims.push_back(nx);
+  dims.push_back(ny);
+  dims.push_back(coils);
+  
+  
+  hoNDArray< std::complex<float> > unmix(dims);
+  
+  PythonMath::instance()->calculate_grappa_unmixing(source_data.get(), 3, &unmix);
+  
+  return 0;
+
+}


### PR DESCRIPTION
Could you guys @inati @naegelejd @dchansen take a look at this and see what you think. This is an example of a general Python wrapper class where an explicit function (ismrmrd.grappa.calculate_grappa_unmixing) is exposed from the ismrmrd-python-tools library. It is a fairly complicated function, but I thought it made a good example. 

There are some general functions for getting to and from hoNDArrays and with those, it might actually be possible to do a generic wrapper which could call most python functions, but that could be a next step. 

Let me know what you think. 