### PR TITLE
For upstream

### DIFF
--- a/apps/gadgetron/GadgetMessageInterface.h
+++ b/apps/gadgetron/GadgetMessageInterface.h
@@ -4,6 +4,7 @@
 #include "GadgetContainerMessage.h"
 #include "GadgetronExport.h"
 #include "Gadget.h"
+#include "GadgetMessageReaderWriter.h"
 
 #include <ace/SOCK_Stream.h>
 #include <ace/Basic_Types.h>
@@ -11,63 +12,6 @@
 
 namespace Gadgetron
 {
-
-enum GadgetronMessageID {
-  GADGET_MESSAGE_INT_ID_MIN       =   0,
-  GADGET_MESSAGE_CONFIG_FILE      =   1,
-  GADGET_MESSAGE_CONFIG_SCRIPT    =   2,
-  GADGET_MESSAGE_PARAMETER_SCRIPT =   3,
-  GADGET_MESSAGE_CLOSE            =   4,
-  GADGET_MESSAGE_INT_ID_MAX       = 999
-};
-
-struct GadgetMessageIdentifier
-{
-  ACE_UINT16 id;
-};
-
-struct GadgetMessageConfigurationFile
-{
-  char configuration_file[1024];
-};
-
-struct GadgetMessageScript
-{
-  ACE_UINT32 script_length;
-};
-
-
-/**
-   Interface for classes capable of reading a specific message
-
-   This is an abstract class, implementations need to be done for each message type.
- */
-class GadgetMessageReader
-{
- public:
-	virtual ~GadgetMessageReader() {}
-
-  /**
-     Function must be implemented to read a specific message.
-   */
-  virtual ACE_Message_Block* read(ACE_SOCK_Stream* stream) = 0;
-
-};
-
-/**
-   Interface for classes capable of writing for writing a specific message to a socket. 
-   This is an abstract class, implementations need to be done for each message type.
- */
-class GadgetMessageWriter
-{
- public:
-	virtual ~GadgetMessageWriter() {}
-
-   /**
-     Function must be implemented to write a specific message.
-   */
-  virtual int write(ACE_SOCK_Stream* stream, ACE_Message_Block* mb) = 0;
-};
 
 class GadgetMessageWriterContainer
 {
@@ -212,24 +156,6 @@ class GadgetMessageScriptReader : public GadgetMessageReader
     return mb;
   }
 };
-
-/* Macros for handling dyamic linking */
-
-//#define GADGETRON_READER_DECLARE(READER) \
-//  GADGETRON_LOADABLE_DECLARE(READER)
-
-#define GADGETRON_READER_DECLARE(READER) 
-
-#define GADGETRON_READER_FACTORY_DECLARE(READER)	\
-  GADGETRON_LOADABLE_FACTORY_DECLARE(GadgetMessageReader, READER)
-
-//#define GADGETRON_WRITER_DECLARE(WRITER) \
-//  GADGETRON_LOADABLE_DECLARE(WRITER)
-
-#define GADGETRON_WRITER_DECLARE(WRITER) 
-
-#define GADGETRON_WRITER_FACTORY_DECLARE(WRITER)	\
-  GADGETRON_LOADABLE_FACTORY_DECLARE(GadgetMessageWriter, WRITER)
 
 }
 

--- a/apps/gadgetron/GadgetMessageReaderWriter.h
+++ b/apps/gadgetron/GadgetMessageReaderWriter.h
@@ -1,0 +1,87 @@
+#ifndef GADGETMESSAGEREADERWRITER_H
+#define GADGETMESSAGEREADERWRITER_H
+
+#include <ace/SOCK_Stream.h>
+#include <ace/Basic_Types.h>
+
+namespace Gadgetron
+{
+
+enum GadgetronMessageID {
+  GADGET_MESSAGE_INT_ID_MIN       =   0,
+  GADGET_MESSAGE_CONFIG_FILE      =   1,
+  GADGET_MESSAGE_CONFIG_SCRIPT    =   2,
+  GADGET_MESSAGE_PARAMETER_SCRIPT =   3,
+  GADGET_MESSAGE_CLOSE            =   4,
+  GADGET_MESSAGE_INT_ID_MAX       = 999
+};
+
+struct GadgetMessageIdentifier
+{
+  ACE_UINT16 id;
+};
+
+struct GadgetMessageConfigurationFile
+{
+  char configuration_file[1024];
+};
+
+struct GadgetMessageScript
+{
+  ACE_UINT32 script_length;
+};
+
+/**
+   Interface for classes capable of reading a specific message
+
+   This is an abstract class, implementations need to be done for each message type.
+ */
+class GadgetMessageReader
+{
+ public:
+	virtual ~GadgetMessageReader() {}
+
+  /**
+     Function must be implemented to read a specific message.
+   */
+  virtual ACE_Message_Block* read(ACE_SOCK_Stream* stream) = 0;
+
+};
+
+/**
+   Interface for classes capable of writing for writing a specific message to a socket. 
+   This is an abstract class, implementations need to be done for each message type.
+ */
+class GadgetMessageWriter
+{
+ public:
+	virtual ~GadgetMessageWriter() {}
+
+   /**
+     Function must be implemented to write a specific message.
+   */
+  virtual int write(ACE_SOCK_Stream* stream, ACE_Message_Block* mb) = 0;
+};
+
+
+/* Macros for handling dyamic linking */
+
+//#define GADGETRON_READER_DECLARE(READER) \
+//  GADGETRON_LOADABLE_DECLARE(READER)
+
+#define GADGETRON_READER_DECLARE(READER) 
+
+#define GADGETRON_READER_FACTORY_DECLARE(READER)	\
+  GADGETRON_LOADABLE_FACTORY_DECLARE(GadgetMessageReader, READER)
+
+//#define GADGETRON_WRITER_DECLARE(WRITER) \
+//  GADGETRON_LOADABLE_DECLARE(WRITER)
+
+#define GADGETRON_WRITER_DECLARE(WRITER) 
+
+#define GADGETRON_WRITER_FACTORY_DECLARE(WRITER)	\
+  GADGETRON_LOADABLE_FACTORY_DECLARE(GadgetMessageWriter, WRITER)
+
+}
+
+#endif

--- a/apps/gadgetron/GadgetStreamController.h
+++ b/apps/gadgetron/GadgetStreamController.h
@@ -15,6 +15,7 @@
 #include "gadgetbase_export.h"
 #include "gadgetron_paths.h"
 #include "GadgetronConnector.h"
+#include "GadgetMessageInterface.h"
 
 typedef ACE_Module<ACE_MT_SYNCH> GadgetModule;
 

--- a/toolboxes/gadgettools/GadgetronCloudConnector.h
+++ b/toolboxes/gadgettools/GadgetronCloudConnector.h
@@ -254,8 +254,8 @@ public:
     GadgetronCloudConnector();
     virtual ~GadgetronCloudConnector();
 
-    int openImpl (std::string hostname, std::string port);
-    int open (std::string hostname, std::string port);
+    int openImpl (const std::string &hostname, const std::string & port);
+    int open (const std::string & hostname, const std::string & port);
 
     virtual int process(size_t messageid, ACE_Message_Block* mb);
 
@@ -323,9 +323,9 @@ public:
         mtx_.release();
     }
 
-    int send_gadgetron_configuration_file(std::string config_xml_name);
-    int send_gadgetron_configuration_script(std::string config_xml_name);
-    int send_gadgetron_parameters(std::string xml_string);
+    int send_gadgetron_configuration_file(const std::string & config_xml_name);
+    int send_gadgetron_configuration_script(const std::string & config_xml_name);
+    int send_gadgetron_parameters(const std::string & xml_string);
 
     ACE_SOCK_Stream& peer()
     {
@@ -370,7 +370,7 @@ GadgetronCloudConnector<JobType>::~GadgetronCloudConnector()
 }
 
 template<typename JobType> 
-int GadgetronCloudConnector<JobType>::openImpl(std::string hostname, std::string port)
+int GadgetronCloudConnector<JobType>::openImpl(const std::string & hostname, const std::string & port)
 {
     hostname_= hostname;
     port_ = port;
@@ -395,7 +395,7 @@ int GadgetronCloudConnector<JobType>::openImpl(std::string hostname, std::string
 }
 
 template<typename JobType> 
-int GadgetronCloudConnector<JobType>::open(std::string hostname, std::string port)
+int GadgetronCloudConnector<JobType>::open(const std::string &hostname, const std::string &port)
 {
     this->cloud_writer_task_.set_cloud_connector(this);
     this->cloud_reader_task_.set_cloud_connector(this);
@@ -495,7 +495,7 @@ int GadgetronCloudConnector<JobType>::setJobTobeCompletedAndNoticeController(int
 }
 
 template<typename JobType> 
-int GadgetronCloudConnector<JobType>::send_gadgetron_configuration_file(std::string config_xml_name)
+int GadgetronCloudConnector<JobType>::send_gadgetron_configuration_file(const std::string & config_xml_name)
 {
     GadgetMessageIdentifier id;
     id.id = GADGET_MESSAGE_CONFIG_FILE;
@@ -519,7 +519,7 @@ int GadgetronCloudConnector<JobType>::send_gadgetron_configuration_file(std::str
 }
 
 template<typename JobType> 
-int GadgetronCloudConnector<JobType>::send_gadgetron_configuration_script(std::string config_xml)
+int GadgetronCloudConnector<JobType>::send_gadgetron_configuration_script(const std::string & config_xml)
 {
     GadgetMessageIdentifier id;
     id.id = GADGET_MESSAGE_CONFIG_SCRIPT;
@@ -549,7 +549,7 @@ int GadgetronCloudConnector<JobType>::send_gadgetron_configuration_script(std::s
 }
 
 template<typename JobType> 
-int GadgetronCloudConnector<JobType>::send_gadgetron_parameters(std::string xml_string)
+int GadgetronCloudConnector<JobType>::send_gadgetron_parameters(const std::string & xml_string)
 {
     GadgetMessageIdentifier id;
     id.id = GADGET_MESSAGE_PARAMETER_SCRIPT;

--- a/toolboxes/gadgettools/GadgetronConnector.cpp
+++ b/toolboxes/gadgettools/GadgetronConnector.cpp
@@ -62,7 +62,7 @@ int GadgetronConnector::open(std::string hostname, std::string port)
     return this->activate( THR_NEW_LWP | THR_JOINABLE, 1); //Run single threaded. TODO: Add multithreaded support
 }
 
-int GadgetronConnector::handle_input(ACE_HANDLE fd)
+int GadgetronConnector::handle_input(ACE_HANDLE /*fd*/)
 {
     ssize_t recv_count = 0;
     GadgetMessageIdentifier mid;
@@ -99,7 +99,7 @@ int GadgetronConnector::handle_input(ACE_HANDLE fd)
     return 0;
 }
 
-int GadgetronConnector::handle_close(ACE_HANDLE handle, ACE_Reactor_Mask close_mask)
+int GadgetronConnector::handle_close(ACE_HANDLE /*handle*/, ACE_Reactor_Mask /*close_mask*/)
 {
   GDEBUG("Handling close...\n");
   this->reactor()->end_reactor_event_loop();
@@ -173,7 +173,7 @@ int GadgetronConnector::send_gadgetron_configuration_script(std::string config_x
       return -1;
     }
 
-    if (this->peer().send_n(config_xml.c_str(), ini.script_length) != ini.script_length) {
+    if (this->peer().send_n(config_xml.c_str(), ini.script_length) != static_cast<ssize_t>(ini.script_length)) {
       GERROR("Unable to send parameter xml\n");
       return -1;
     }
@@ -198,7 +198,7 @@ int GadgetronConnector::send_gadgetron_parameters(std::string xml_string)
       return -1;
     }
 
-    if (this->peer().send_n(xml_string.c_str(), conf.script_length) != conf.script_length) {
+    if (this->peer().send_n(xml_string.c_str(), conf.script_length) != static_cast<ssize_t>(conf.script_length)) {
       GERROR("Unable to send parameter xml\n");
       return -1;
     }

--- a/toolboxes/gadgettools/GadgetronConnector.cpp
+++ b/toolboxes/gadgettools/GadgetronConnector.cpp
@@ -16,7 +16,7 @@ GadgetronConnector::~GadgetronConnector() {
     //writers_.clear();
 }
 
-int GadgetronConnector::openImpl(std::string hostname, std::string port)
+int GadgetronConnector::openImpl(const std::string & hostname, const std::string & port)
 {
     hostname_= hostname;
     port_ = port;
@@ -42,7 +42,7 @@ int GadgetronConnector::openImpl(std::string hostname, std::string port)
     return 0;
 }
 
-int GadgetronConnector::open(std::string hostname, std::string port)
+int GadgetronConnector::open(const std::string & hostname, const std::string & port)
 {
     //Make sure we have a reactor, otherwise assign one from the singleton instance
     if (!this->reactor()) {
@@ -133,7 +133,7 @@ int GadgetronConnector::register_reader(size_t slot, GadgetMessageReader *reader
     return readers_.insert( (unsigned short)slot,reader);
 }
 
-int GadgetronConnector::send_gadgetron_configuration_file(std::string config_xml_name)
+int GadgetronConnector::send_gadgetron_configuration_file(const std::string & config_xml_name)
 {
     GadgetMessageIdentifier id;
     id.id = GADGET_MESSAGE_CONFIG_FILE;
@@ -155,7 +155,7 @@ int GadgetronConnector::send_gadgetron_configuration_file(std::string config_xml
     return 0;
 }
 
-int GadgetronConnector::send_gadgetron_configuration_script(std::string config_xml)
+int GadgetronConnector::send_gadgetron_configuration_script(const std::string & config_xml)
 {
     GadgetMessageIdentifier id;
     id.id = GADGET_MESSAGE_CONFIG_SCRIPT;
@@ -181,7 +181,7 @@ int GadgetronConnector::send_gadgetron_configuration_script(std::string config_x
     return 0;
 }
 
-int GadgetronConnector::send_gadgetron_parameters(std::string xml_string)
+int GadgetronConnector::send_gadgetron_parameters(const std::string & xml_string)
 {
     GadgetMessageIdentifier id;
     id.id = GADGET_MESSAGE_PARAMETER_SCRIPT;

--- a/toolboxes/gadgettools/GadgetronConnector.h
+++ b/toolboxes/gadgettools/GadgetronConnector.h
@@ -2,8 +2,10 @@
 #define GADGETRONCONNECTOR_H_
 
 #include "GadgetronSlotContainer.h"
-#include "GadgetMessageInterface.h"
+#include "GadgetMessageReaderWriter.h"
+#include "GadgetContainerMessage.h"
 #include "gadgettools_export.h"
+#include "log.h"
 
 #include <ace/Svc_Handler.h>
 #include <ace/Reactor.h>
@@ -43,7 +45,7 @@ public:
 	}
 
 	int register_writer(size_t slot, GadgetMessageWriter* writer) {
-		return writers_.insert( (unsigned int)slot,writer);
+		return writers_.insert( (unsigned short)slot,writer);
 	}
 
 	virtual int close(unsigned long flags)
@@ -129,7 +131,7 @@ public:
 		return writer_task_.putq(mb,timeout);
 	}
 
-	virtual int process(size_t messageid, ACE_Message_Block* mb) {
+	virtual int process(size_t /*messageid*/, ACE_Message_Block* mb) {
 		mb->release();
 		return 0;
 	}

--- a/toolboxes/gadgettools/GadgetronConnector.h
+++ b/toolboxes/gadgettools/GadgetronConnector.h
@@ -120,8 +120,8 @@ public:
 	GadgetronConnector();
 	virtual ~GadgetronConnector();
 
-    int openImpl (std::string hostname, std::string port);
-	int open (std::string hostname, std::string port);
+    int openImpl (const std::string & hostname, const std::string & port);
+	int open (const std::string & hostname, const std::string & port);
 	virtual int handle_input (ACE_HANDLE fd = ACE_INVALID_HANDLE);
 	//virtual int handle_output (ACE_HANDLE fd = ACE_INVALID_HANDLE);
 	virtual int handle_close (ACE_HANDLE handle, ACE_Reactor_Mask close_mask);
@@ -141,9 +141,9 @@ public:
 		return writer_task_.register_writer(slot,writer);
 	}
 
-	int send_gadgetron_configuration_file(std::string config_xml_name);
-	int send_gadgetron_configuration_script(std::string config_xml_name);
-	int send_gadgetron_parameters(std::string xml_string);
+	int send_gadgetron_configuration_file(const std::string & config_xml_name);
+	int send_gadgetron_configuration_script(const std::string & config_xml_name);
+	int send_gadgetron_parameters(const std::string & xml_string);
 
 protected:
 	//ACE_Reactor_Notification_Strategy notifier_;


### PR DESCRIPTION
Two sets of changes:
 1. Changed toolboxes/gadgetrontools classes to by strings by ```const std::string &``` instead of ```std::string``` to save on making extra copies of potential large string variables.
 1. Modifications to permit VB17 ICE to compile GadgetronConnector
   1. MSVC++ 6 does not support variadic templates, so a macro was added to disable their usage in GadgetContainerMessage.
   1. MSVC++ 6 does not support templated functions from which the template cannot be determined from the function arguments. Added a dummy argument to ```template <typename T> magic_number_for_type(T* = NULL)``` so that ```magic_number_for_type(reinterpret_cast<T *>(NULL))``` is used instead of using ```magic_number_for_type<T>()```.
   1. Reduce the required dependencies of GadgetronConnector by splitting GadgetronMessageInterface.h into two files. The new GadgetronMessageReaderWriter.h contains only those parts required by GadgetronConnecter, thereby eliminating adding the Boost dependence of Gadget.h on which some of the other classes in GadgetronMessageInterface.h depend.
