### PR TITLE
Gadget properties

### DIFF
--- a/apps/gadgetron/Gadget.cpp
+++ b/apps/gadgetron/Gadget.cpp
@@ -10,29 +10,40 @@ namespace Gadgetron
       return boost::shared_ptr<std::string>(new std::string(""));
     }
 
-    std::map<std::string,std::string>::iterator it;
-    parameter_mutex_.acquire();
-    it = parameters_.find(std::string(name));
-    parameter_mutex_.release();
-    if (it != parameters_.end()) {
-      //If string contains an @ sign, we should look for this parameter on another gadget
-      size_t at_pos = it->second.find('@');
-      if (at_pos != std::string::npos) {
-	//There was an add sign, which means look for that parameter on another gadget
-	std::string parm = it->second.substr(0,at_pos);
-	std::string gadget = it->second.substr(at_pos+1);
-	  
-	Gadget* ref_gadget = this->controller_->find_gadget(gadget.c_str());
-
-	if (ref_gadget) {
-	  recursive++;
-	  return ref_gadget->get_string_value(parm.c_str(), recursive);
-	}
-      } else {
-	return boost::shared_ptr<std::string>(new std::string(it->second));
+    std::string str_val;
+    if (using_properties_) {
+      GadgetPropertyBase* p = find_property(name);
+      if (!p) {
+	throw std::runtime_error("Attempting to access non existent property on Gadget");
+      }
+      str_val = std::string(p->string_value());
+    } else {
+      std::map<std::string,std::string>::iterator it;
+      parameter_mutex_.acquire();
+      it = parameters_.find(std::string(name));
+      parameter_mutex_.release();
+      if (it != parameters_.end()) {
+	str_val = it->second;
       }
     }
+
+    //If string contains an @ sign, we should look for this parameter on another gadget
+    size_t at_pos = str_val.find('@');
+    if (at_pos != std::string::npos) {
+      //There was an add sign, which means look for that parameter on another gadget
+      std::string parm = str_val.substr(0,at_pos);
+      std::string gadget = str_val.substr(at_pos+1);
+	  
+      Gadget* ref_gadget = this->controller_->find_gadget(gadget.c_str());
       
+      if (ref_gadget) {
+	recursive++;
+	return ref_gadget->get_string_value(parm.c_str(), recursive);
+      }
+    } else {
+      return boost::shared_ptr<std::string>(new std::string(str_val));
+    }
+
     return boost::shared_ptr<std::string>(new std::string(""));
   }
 }

--- a/apps/gadgetron/Gadget.h
+++ b/apps/gadgetron/Gadget.h
@@ -30,8 +30,10 @@ namespace Gadgetron{
   class GadgetPropertyBase
   {
   public:
-  GadgetPropertyBase(const char* name)
+  GadgetPropertyBase(const char* name, const char* type_string, const char* description)
     : name_(name)
+    , type_str_(type_string)
+    , description_(description)
     , str_value_("")
     , is_reference_(false)
     , reference_gadget_("") 
@@ -62,8 +64,20 @@ namespace Gadgetron{
       }
     }
 
+    const char* type_string()
+    {
+      return type_str_.c_str();
+    }
+
+    const char* description()
+    {
+      return description_.c_str();
+    }
+
   protected:
     std::string name_;
+    std::string type_str_;
+    std::string description_;
     std::string str_value_;
     bool is_reference_;
     std::string reference_gadget_;
@@ -300,6 +314,19 @@ namespace Gadgetron{
 	    }
 	}
 
+	int get_number_of_properties()
+	{
+	  return properties_.size();
+	}
+
+	GadgetPropertyBase* get_property_by_index(size_t i)
+	{
+	  if (i >= properties_.size()) {
+	    return 0;
+	  }
+	  return properties_[i];
+	}
+
 	GadgetPropertyBase* find_property(const char* name)
 	{
 	  GadgetPropertyBase* p = 0;
@@ -353,8 +380,9 @@ namespace Gadgetron{
       : public GadgetPropertyBase
       {
       public:
-      GadgetProperty(const char* name, Gadget* g, T default_value, bool force_using_properties = true)
-	: GadgetPropertyBase(name)
+      GadgetProperty(const char* name, const char* type_string, const char* description,
+		     Gadget* g, T default_value, bool force_using_properties = true)
+	: GadgetPropertyBase(name,type_string,description)
 	  , g_(g)
 	{
 	  g_->register_property(this, force_using_properties);
@@ -401,20 +429,20 @@ namespace Gadgetron{
 	Gadget* g_;
       };
     
-#define GADGET_PROPERTY(varname, vartype, defaultvalue) GadgetProperty<vartype> varname{#varname,this, defaultvalue}
-#define GADGET_PROPERTY_NO_FORCE(varname, vartype, defaultvalue) GadgetProperty<vartype> varname{#varname,this, defaultvalue,false}
+#define GADGET_PROPERTY(varname, vartype, description, defaultvalue) GadgetProperty<vartype> varname{#varname,#vartype, description, this, defaultvalue}
+#define GADGET_PROPERTY_NO_FORCE(varname, vartype, description, defaultvalue) GadgetProperty<vartype> varname{#varname,#vartype, description, this, defaultvalue,false}
  
     class BasicPropertyGadget : public Gadget
     {
 
     protected:
-      GADGET_PROPERTY_NO_FORCE(using_cloudbus,bool,false);
-      GADGET_PROPERTY_NO_FORCE(pass_on_undesired_data,bool,false);
-      GADGET_PROPERTY_NO_FORCE(threads,int,1);
+      GADGET_PROPERTY_NO_FORCE(using_cloudbus,bool,"Indicates whether the cloudbus is in use and available", false);
+      GADGET_PROPERTY_NO_FORCE(pass_on_undesired_data,bool, "If true, data not matching the process function will be passed to next Gadget", false);
+      GADGET_PROPERTY_NO_FORCE(threads,int, "Number of threads to run in this Gadget", 1);
 #ifdef _WIN32
-      GADGET_PROPERTY_NO_FORCE(workingDirectory, std::string, "c:\\temp\\gadgetron\\");
+      GADGET_PROPERTY_NO_FORCE(workingDirectory, std::string, "Where to store temporary files", "c:\\temp\\gadgetron\\");
 #else
-      GADGET_PROPERTY_NO_FORCE(workingDirectory, std::string, "/tmp/gadgetron/");
+      GADGET_PROPERTY_NO_FORCE(workingDirectory, std::string, "Where to store temporary files", "/tmp/gadgetron/");
 #endif // _WIN32
     }; 
 

--- a/apps/gadgetron/gadgetron_info.cpp
+++ b/apps/gadgetron/gadgetron_info.cpp
@@ -182,6 +182,9 @@ int main(int argc, char** argv)
     GadgetPropertyBase* p = g->get_property_by_index(i);
     if (p) {
       std::cout << "      * " << p->name() << " (" << p->type_string() << "): " << p->description() << std::endl;
+      if (std::string(p->limits_description()) != std::string("")) {
+	std::cout << "        LIMITS: " << p->limits_description() << std::endl;
+      } 
     }
   }
   delete g;

--- a/apps/gadgetron/gadgetron_info.cpp
+++ b/apps/gadgetron/gadgetron_info.cpp
@@ -176,7 +176,14 @@ int main(int argc, char** argv)
   }
 
   std::cout << "  -- Gadget compiled against Gadgetron version " << g->get_gadgetron_version() << std::endl;
-
+  std::cout << "    -- Properties:" << std::endl;
+  int number_of_properties = g->get_number_of_properties();
+  for (int i = 0; i < number_of_properties; i++) {
+    GadgetPropertyBase* p = g->get_property_by_index(i);
+    if (p) {
+      std::cout << "      * " << p->name() << " (" << p->type_string() << "): " << p->description() << std::endl;
+    }
+  }
   delete g;
 
   return 0;

--- a/gadgets/grappa/GrappaGadget.cpp
+++ b/gadgets/grappa/GrappaGadget.cpp
@@ -106,7 +106,7 @@ namespace Gadgetron{
     time_stamps_ = std::vector<ACE_UINT32>(dimensions_[4],0);
 
     //Let's figure out the number of target coils
-    target_coils_ = this->get_int_value("target_coils");
+    target_coils_ = target_coils.value(); //this->get_int_value("target_coils");
     if ((target_coils_ <= 0) || (target_coils_ > dimensions_[3])) {
       target_coils_ = dimensions_[3];
     }
@@ -115,22 +115,21 @@ namespace Gadgetron{
 
     weights_calculator_.set_number_of_target_coils(target_coils_);
 
-    bool use_gpu_ = this->get_bool_value("use_gpu");
+    bool use_gpu_ = use_gpu.value(); //this->get_bool_value("use_gpu");
     GDEBUG_STREAM("use_gpu_ is " << use_gpu_);
 
     weights_calculator_.set_use_gpu(use_gpu_);
 
-    int device_channels = this->get_int_value("device_channels");
-    if (device_channels) {
-      GDEBUG("We got the number of device channels from other gadget: %d\n", device_channels);
-      for (int i = 0; i < device_channels; i++) {
+    if (device_channels.value()) {
+      GDEBUG("We got the number of device channels from other gadget: %d\n", device_channels.value());
+      for (int i = 0; i < device_channels.value(); i++) {
 	weights_calculator_.add_uncombined_channel((unsigned int)i);
       }
     } else {
       //Let's figure out if we have channels that are supposed to be uncombined
-      boost::shared_ptr<std::string> uncomb_str = this->get_string_value("uncombined_channels");
+      std::string uncomb_str = uncombined_channels.value();
       std::vector<std::string> uncomb;
-      boost::split(uncomb, *uncomb_str, boost::is_any_of(","));
+      boost::split(uncomb, uncomb_str, boost::is_any_of(","));
       for (unsigned int i = 0; i < uncomb.size(); i++) {
 	std::string ch = boost::algorithm::trim_copy(uncomb[i]);
 	if (ch.size() > 0) {
@@ -139,10 +138,10 @@ namespace Gadgetron{
 	}
       }
       
-      uncomb_str = this->get_string_value("uncombined_channels_by_name");
-      if (uncomb_str->size()) {
-	GDEBUG("uncomb_str: %s\n",  uncomb_str->c_str());
-	boost::split(uncomb, *uncomb_str, boost::is_any_of(","));
+      uncomb_str = uncombined_channels_by_name.value();
+      if (uncomb_str.size()) {
+	GDEBUG("uncomb_str: %s\n",  uncomb_str.c_str());
+	boost::split(uncomb, uncomb_str, boost::is_any_of(","));
 	for (unsigned int i = 0; i < uncomb.size(); i++) {
 	std::string ch = boost::algorithm::trim_copy(uncomb[i]);
 	map_type_::iterator it = channel_map_.find(ch);
@@ -200,7 +199,7 @@ namespace Gadgetron{
       }
     }
 
-    image_series_ = this->get_int_value("image_series");
+    image_series_ = image_series.value(); //this->get_int_value("image_series");
 
     return GADGET_OK;
   }

--- a/gadgets/grappa/GrappaGadget.h
+++ b/gadgets/grappa/GrappaGadget.h
@@ -43,8 +43,15 @@ public Gadget2< ISMRMRD::AcquisitionHeader, hoNDArray< std::complex<float> > >
   virtual int close(unsigned long flags);
 
   virtual int initial_setup();
-
   bool first_call_;
+
+  GADGET_PROPERTY(target_coils,int,0);
+  GADGET_PROPERTY(use_gpu,bool,true);
+  GADGET_PROPERTY(device_channels,int,0);
+  GADGET_PROPERTY(uncombined_channels,std::string,"");
+  GADGET_PROPERTY(uncombined_channels_by_name,std::string,"");
+  GADGET_PROPERTY(image_series,int,0);
+
  private:
   typedef std::map< std::string, int > map_type_;
 

--- a/gadgets/grappa/GrappaGadget.h
+++ b/gadgets/grappa/GrappaGadget.h
@@ -45,12 +45,12 @@ public Gadget2< ISMRMRD::AcquisitionHeader, hoNDArray< std::complex<float> > >
   virtual int initial_setup();
   bool first_call_;
 
-  GADGET_PROPERTY(target_coils,int,0);
-  GADGET_PROPERTY(use_gpu,bool,true);
-  GADGET_PROPERTY(device_channels,int,0);
-  GADGET_PROPERTY(uncombined_channels,std::string,"");
-  GADGET_PROPERTY(uncombined_channels_by_name,std::string,"");
-  GADGET_PROPERTY(image_series,int,0);
+  GADGET_PROPERTY(target_coils,int, "Number of target coils for GRAPPA recon", 0);
+  GADGET_PROPERTY(use_gpu,bool,"If true, recon will try to use GPU resources (when available)", true);
+  GADGET_PROPERTY(device_channels,int,"Number of device channels", 0);
+  GADGET_PROPERTY(uncombined_channels,std::string,"Uncombined channels (as a comma separated list of channel indices", "");
+  GADGET_PROPERTY(uncombined_channels_by_name,std::string,"Uncombined channels (as a comma separated list of channel names", "");
+  GADGET_PROPERTY(image_series,int,"Image series number for output images", 0);
 
  private:
   typedef std::map< std::string, int > map_type_;

--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.cpp
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.cpp
@@ -19,94 +19,94 @@ namespace Gadgetron{
   ::process_config(ACE_Message_Block* mb)
   {
 
-    std::string trigger_dimension = *this->get_string_value("trigger_dimension");
-    std::string sorting_dimension = *this->get_string_value("sorting_dimension");
+    std::string trigger_dimension_local = trigger_dimension.value();//*this->get_string_value("trigger_dimension");
+    std::string sorting_dimension_local = sorting_dimension.value();//*this->get_string_value("sorting_dimension");
     
-    if (trigger_dimension.size() == 0) {
+    if (trigger_dimension_local.size() == 0) {
       trigger_ = NONE;
-    } else if (trigger_dimension.compare("kspace_encode_step_1") == 0) {
+    } else if (trigger_dimension_local.compare("kspace_encode_step_1") == 0) {
       trigger_ = KSPACE_ENCODE_STEP_1;
-    } else if (trigger_dimension.compare("kspace_encode_step_2") == 0) {
+    } else if (trigger_dimension_local.compare("kspace_encode_step_2") == 0) {
       trigger_ = KSPACE_ENCODE_STEP_2;
-    } else if (trigger_dimension.compare("average") == 0) {
+    } else if (trigger_dimension_local.compare("average") == 0) {
       trigger_ = AVERAGE;
-    } else if (trigger_dimension.compare("slice") == 0) {
+    } else if (trigger_dimension_local.compare("slice") == 0) {
       trigger_ = SLICE;
-    } else if (trigger_dimension.compare("contrast") == 0) {
+    } else if (trigger_dimension_local.compare("contrast") == 0) {
       trigger_ = CONTRAST;
-    } else if (trigger_dimension.compare("phase") == 0) {
+    } else if (trigger_dimension_local.compare("phase") == 0) {
       trigger_ = PHASE;
-    } else if (trigger_dimension.compare("repetition") == 0) {
+    } else if (trigger_dimension_local.compare("repetition") == 0) {
       trigger_ = REPETITION;
-    } else if (trigger_dimension.compare("set") == 0) {
+    } else if (trigger_dimension_local.compare("set") == 0) {
       trigger_ = SET;
-    } else if (trigger_dimension.compare("segment") == 0) {
+    } else if (trigger_dimension_local.compare("segment") == 0) {
       trigger_ = SEGMENT;
-    } else if (trigger_dimension.compare("user_0") == 0) {
+    } else if (trigger_dimension_local.compare("user_0") == 0) {
       trigger_ = USER_0;
-    } else if (trigger_dimension.compare("user_1") == 0) {
+    } else if (trigger_dimension_local.compare("user_1") == 0) {
       trigger_ = USER_1;
-    } else if (trigger_dimension.compare("user_2") == 0) {
+    } else if (trigger_dimension_local.compare("user_2") == 0) {
       trigger_ = USER_2;
-    } else if (trigger_dimension.compare("user_3") == 0) {
+    } else if (trigger_dimension_local.compare("user_3") == 0) {
       trigger_ = USER_3;
-    } else if (trigger_dimension.compare("user_4") == 0) {
+    } else if (trigger_dimension_local.compare("user_4") == 0) {
       trigger_ = USER_4;
-    } else if (trigger_dimension.compare("user_5") == 0) {
+    } else if (trigger_dimension_local.compare("user_5") == 0) {
       trigger_ = USER_5;
-    } else if (trigger_dimension.compare("user_6") == 0) {
+    } else if (trigger_dimension_local.compare("user_6") == 0) {
       trigger_ = USER_6;
-    } else if (trigger_dimension.compare("user_7") == 0) {
+    } else if (trigger_dimension_local.compare("user_7") == 0) {
       trigger_ = USER_7;
     } else {
-      GDEBUG("WARNING: Unknown trigger dimension (%s), trigger condition set to NONE (end of scan)", trigger_dimension.c_str());
+      GDEBUG("WARNING: Unknown trigger dimension (%s), trigger condition set to NONE (end of scan)", trigger_dimension_local.c_str());
       trigger_ = NONE;
     }
   
-    GDEBUG("TRIGGER DIMENSION IS: %s (%d)\n", trigger_dimension.c_str(), trigger_);
+    GDEBUG("TRIGGER DIMENSION IS: %s (%d)\n", trigger_dimension_local.c_str(), trigger_);
 
-    if (sorting_dimension.size() == 0) {
+    if (sorting_dimension_local.size() == 0) {
       sort_ = NONE;
-    } else if (sorting_dimension.compare("kspace_encode_step_1") == 0) {
+    } else if (sorting_dimension_local.compare("kspace_encode_step_1") == 0) {
       sort_ = KSPACE_ENCODE_STEP_1;
-    } else if (sorting_dimension.compare("kspace_encode_step_2") == 0) {
+    } else if (sorting_dimension_local.compare("kspace_encode_step_2") == 0) {
       sort_ = KSPACE_ENCODE_STEP_2;
-    } else if (sorting_dimension.compare("average") == 0) {
+    } else if (sorting_dimension_local.compare("average") == 0) {
       sort_ = AVERAGE;
-    } else if (sorting_dimension.compare("slice") == 0) {
+    } else if (sorting_dimension_local.compare("slice") == 0) {
       sort_ = SLICE;
-    } else if (sorting_dimension.compare("contrast") == 0) {
+    } else if (sorting_dimension_local.compare("contrast") == 0) {
       sort_ = CONTRAST;
-    } else if (sorting_dimension.compare("phase") == 0) {
+    } else if (sorting_dimension_local.compare("phase") == 0) {
       sort_ = PHASE;
-    } else if (sorting_dimension.compare("repetition") == 0) {
+    } else if (sorting_dimension_local.compare("repetition") == 0) {
       sort_ = REPETITION;
-    } else if (sorting_dimension.compare("set") == 0) {
+    } else if (sorting_dimension_local.compare("set") == 0) {
       sort_ = SET;
-    } else if (sorting_dimension.compare("segment") == 0) {
+    } else if (sorting_dimension_local.compare("segment") == 0) {
       sort_ = SEGMENT;
-    } else if (sorting_dimension.compare("user_0") == 0) {
+    } else if (sorting_dimension_local.compare("user_0") == 0) {
       sort_ = USER_0;
-    } else if (sorting_dimension.compare("user_1") == 0) {
+    } else if (sorting_dimension_local.compare("user_1") == 0) {
       sort_ = USER_1;
-    } else if (sorting_dimension.compare("user_2") == 0) {
+    } else if (sorting_dimension_local.compare("user_2") == 0) {
       sort_ = USER_2;
-    } else if (sorting_dimension.compare("user_3") == 0) {
+    } else if (sorting_dimension_local.compare("user_3") == 0) {
       sort_ = USER_3;
-    } else if (sorting_dimension.compare("user_4") == 0) {
+    } else if (sorting_dimension_local.compare("user_4") == 0) {
       sort_ = USER_4;
-    } else if (sorting_dimension.compare("user_5") == 0) {
+    } else if (sorting_dimension_local.compare("user_5") == 0) {
       sort_ = USER_5;
-    } else if (sorting_dimension.compare("user_6") == 0) {
+    } else if (sorting_dimension_local.compare("user_6") == 0) {
       sort_ = USER_6;
-    } else if (sorting_dimension.compare("user_7") == 0) {
+    } else if (sorting_dimension_local.compare("user_7") == 0) {
       sort_ = USER_7;
     } else {
-      GDEBUG("WARNING: Unknown sort dimension (%s), sorting set to NONE\n", sorting_dimension.c_str());
+      GDEBUG("WARNING: Unknown sort dimension (%s), sorting set to NONE\n", sorting_dimension_local.c_str());
       sort_ = NONE;
     }
   
-    GDEBUG("SORTING DIMENSION IS: %s (%d)\n", sorting_dimension.c_str(), sort_);
+    GDEBUG("SORTING DIMENSION IS: %s (%d)\n", sorting_dimension_local.c_str(), sort_);
 
     trigger_events_ = 0;
 

--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
@@ -27,8 +27,47 @@ namespace Gadgetron{
 
 
     protected:
-      GADGET_PROPERTY(trigger_dimension, std::string, "", "");
-      GADGET_PROPERTY(sorting_dimention, std::string, "", "");
+      GADGET_PROPERTY_LIMITS(trigger_dimension, std::string, "Dimension to trigger on", "",
+			     GadgetPropertyLimitsEnumeration, 
+			     "kspace_encode_step_1",
+			     "kspace_encode_step_2",
+			     "average",
+			     "slice",
+			     "contrast",
+			     "phase",
+			     "repetition",
+			     "set",
+			     "segment",
+			     "user_0",
+			     "user_1",
+			     "user_2",
+			     "user_3",
+			     "user_4",
+			     "user_5",
+			     "user_6",
+			     "user_7",
+			     "");
+
+      GADGET_PROPERTY_LIMITS(sorting_dimension, std::string, "Dimension to sort by", "", 
+			     GadgetPropertyLimitsEnumeration, 
+			     "kspace_encode_step_1",
+			     "kspace_encode_step_2",
+			     "average",
+			     "slice",
+			     "contrast",
+			     "phase",
+			     "repetition",
+			     "set",
+			     "segment",
+			     "user_0",
+			     "user_1",
+			     "user_2",
+			     "user_3",
+			     "user_4",
+			     "user_5",
+			     "user_6",
+			     "user_7",
+			     "");
       IsmrmrdCONDITION trigger_;
       IsmrmrdCONDITION sort_;
       map_type_  buckets_;

--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
@@ -27,6 +27,8 @@ namespace Gadgetron{
 
 
     protected:
+      GADGET_PROPERTY(trigger_dimension, std::string, "", "");
+      GADGET_PROPERTY(sorting_dimention, std::string, "", "");
       IsmrmrdCONDITION trigger_;
       IsmrmrdCONDITION sort_;
       map_type_  buckets_;

--- a/gadgets/mri_core/CoilReductionGadget.h
+++ b/gadgets/mri_core/CoilReductionGadget.h
@@ -24,6 +24,9 @@ class EXPORTGADGETSMRICORE CoilReductionGadget :
 			  GadgetContainerMessage< hoNDArray< std::complex<float> > > * m2);
       
     protected:
+      GADGET_PROPERTY(coil_mask, std::string, "String mask of zeros and ones, e.g. 000111000 indicating which coils to keep", "");
+      GADGET_PROPERTY_LIMITS(coils_out, int, "Number of coils to keep, coils with higher indices will be discarded", 128,
+			     GadgetPropertyLimitsRange, 1, 1024);
       std::vector<unsigned short> coil_mask_;
       unsigned int coils_in_;
       unsigned int coils_out_;      


### PR DESCRIPTION
This is a first draft for adding a more formal concept of properties to the Gadgets. For illustration purposes, I have converted one gadget (GrappaGadget) to the new system. Please do don't merge just yet. At this point, I would just like some comments. @inati, @dchansen, @naegelejd, @gtdeveloper5  

The way it works at the moment is that on the Gadget (in the header), you can add properties like:

    GADGET_PROPERTY(target_coils,int,0);
    GADGET_PROPERTY(use_gpu,bool,true);
    GADGET_PROPERTY(device_channels,int,0);
    GADGET_PROPERTY(uncombined_channels,std::string,"");
    GADGET_PROPERTY(uncombined_channels_by_name,std::string,"");
    GADGET_PROPERTY(image_series,int,0);

Once you register properties using this macro, it will force the Gadget into a state where properties have to be declared otherwise, an exception will be thrown when trying to access them. The properties can be access with the "old" interface functions (get_parameter, set_parameter) but the macro also declares them as a member variable with the same name so that they can be access in a safer way:

    bool use_gpu_ = use_gpu.value(); 
 
It is also possible to simply do:

    if (use_gpu == true) { }

And other operators can be implemented later. In any case with this new way of accessing the properties, the check for whether the property exists is done at compile time and there is no risk of misspelling the property name. The value() function also returns the value with proper type, so type checking can be done when within the Gadget.

The intention is to also add some help text to each property. I was thinking of two different things:

1) A short description when declaring the property, i.e. the macro could be expanded:

     GADGET_PROPERTY(use_gpu,bool,true, "Indicates to the Gadget if it should attempt to use the GPU if available");

2) A system of "help files", so that with each property a small (markdown syntax) text file could be created (optionally) and all of these help files could be installed in share/gadgetron/help so that gadgetron_info and other tools can print a more lengthy description of the variable. This could then for a gadget be used to render a complete help document with parameter descriptions for a given Gadget.

There are some things that I have not found super solutions for yet:

* Parameter valid ranges: Should it be possible to say that a parameter is an int between 2 and 7?
* Enumration paramaters, should they simply be strings, but do we need a way to say what the possible valid setting are?
* At the moment, the system is not forced on the Gadgets, the old system still works, but we have to figure out how to handle the transition and ultimately "turn off" the old way of doing parameters
* We have a problems with global variables at the moment, they need to be declared on all Gadgets, and I have macro which does not force the Gadget into property mode that does this, but it is a bit of a hack. Maybe this will all be resolved when we transition completely to the new system. 

I would really like to hear your comments/concerns/suggestions on this. This is important, so please spend a bit of time on it.  