### PR TITLE
Create a single PythonGadget

### DIFF
--- a/gadgets/python/GadgetronPythonMRI.cpp
+++ b/gadgets/python/GadgetronPythonMRI.cpp
@@ -33,21 +33,5 @@ BOOST_PYTHON_MODULE(GadgetronPythonMRI)
       .def("close", &Gadgetron::GadgetInstrumentationStreamControllerWrapper::close)
       .def("set_python_gadget", &Gadgetron::GadgetInstrumentationStreamControllerWrapper::set_python_gadget)
       .def("set_parameter", &Gadgetron::GadgetInstrumentationStreamControllerWrapper::set_parameter)
-      ;
-    
-    enum_<Gadgetron::GadgetMessageID>("GadgetMessageID")
-      .value("GADGET_MESSAGE_EXT_ID_MIN",Gadgetron::GADGET_MESSAGE_EXT_ID_MIN)
-      .value("GADGET_MESSAGE_ACQUISITION",Gadgetron::GADGET_MESSAGE_ACQUISITION)
-      .value("GADGET_MESSAGE_NEW_MEASUREMENT",Gadgetron::GADGET_MESSAGE_NEW_MEASUREMENT)
-      .value("GADGET_MESSAGE_END_OF_SCAN",Gadgetron::GADGET_MESSAGE_END_OF_SCAN)
-      .value("GADGET_MESSAGE_IMAGE_CPLX_FLOAT",Gadgetron::GADGET_MESSAGE_IMAGE_CPLX_FLOAT)
-      .value("GADGET_MESSAGE_IMAGE_REAL_FLOAT",Gadgetron::GADGET_MESSAGE_IMAGE_REAL_FLOAT)
-      .value("GADGET_MESSAGE_IMAGE_REAL_USHORT",Gadgetron::GADGET_MESSAGE_IMAGE_REAL_USHORT)
-      .value("GADGET_MESSAGE_ISMRMRD_ACQUISITION", Gadgetron::GADGET_MESSAGE_ISMRMRD_ACQUISITION)
-      .value("GADGET_MESSAGE_ISMRMRD_IMAGE_CPLX_FLOAT", Gadgetron::GADGET_MESSAGE_ISMRMRD_IMAGE_CPLX_FLOAT)
-      .value("GADGET_MESSAGE_ISMRMRD_IMAGE_REAL_FLOAT", Gadgetron::GADGET_MESSAGE_ISMRMRD_IMAGE_REAL_FLOAT)
-      .value("GADGET_MESSAGE_ISMRMRD_IMAGE_REAL_USHORT", Gadgetron::GADGET_MESSAGE_ISMRMRD_IMAGE_REAL_USHORT)
-      .value("GADGET_MESSAGE_EMPTY",Gadgetron::GADGET_MESSAGE_EMPTY)
-      .value("GADGET_MESSAGE_EXT_ID_MAX",Gadgetron::GADGET_MESSAGE_EXT_ID_MAX)
-      ;
+      ;    
 }

--- a/gadgets/python/PythonGadget.cpp
+++ b/gadgets/python/PythonGadget.cpp
@@ -57,6 +57,9 @@ namespace Gadgetron{
       case (ISMRMRD::ISMRMRD_CXDOUBLE):
 	return this->process(hmi, AsContainerMessage< hoNDArray< std::complex<double> > >(hmi->cont()), mmb);
 	break;
+      default:
+	GERROR("Unknown image data_type %d received\n", h->data_type);
+	break;
       }
     }
   }

--- a/gadgets/python/PythonGadget.cpp
+++ b/gadgets/python/PythonGadget.cpp
@@ -1,6 +1,65 @@
 #include "PythonGadget.h"
 
 namespace Gadgetron{
-  GADGET_FACTORY_DECLARE(AcquisitionPythonGadget)
-  GADGET_FACTORY_DECLARE(ImagePythonGadget)
+  int PythonGadget::process(ACE_Message_Block* mb)
+  {
+    GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* hma = AsContainerMessage<ISMRMRD::AcquisitionHeader>(mb);
+    if (hma) {
+      GadgetContainerMessage< hoNDArray< std::complex<float> > >* dmb = AsContainerMessage< hoNDArray< std::complex<float> > >(hma->cont());
+      if (!dmb) {
+	GERROR("Error converting data array from message block for Acquisition\n");
+	hma->release();
+	return GADGET_FAIL;;
+      }
+      GadgetContainerMessage< ISMRMRD::MetaContainer>* mmb = AsContainerMessage< ISMRMRD::MetaContainer >(dmb->cont());
+      this->process(hma,dmb,mmb);
+    } else {
+      GadgetContainerMessage<ISMRMRD::ImageHeader>* hmi = AsContainerMessage<ISMRMRD::ImageHeader>(mb);
+      if (!hmi) {
+	if (pass_on_undesired_data.value()) {
+	  return this->next()->putq(mb);
+	} else {
+	  GERROR("This is neither an acquisition or an image. Something is wrong here");
+	  mb->release();
+	  return GADGET_FAIL;
+	}
+      }
+      
+      ISMRMRD::ImageHeader* h = hmi->getObjectPtr();
+      GadgetContainerMessage< ISMRMRD::MetaContainer>* mmb = 0;
+
+      if (hmi->cont()) {
+	mmb = AsContainerMessage< ISMRMRD::MetaContainer >(hmi->cont()->cont());
+      }
+
+      switch (h->data_type) {	
+      case (ISMRMRD::ISMRMRD_USHORT):
+	return this->process(hmi, AsContainerMessage< hoNDArray< uint16_t > >(hmi->cont()), mmb);
+	break;
+      case (ISMRMRD::ISMRMRD_SHORT):
+	return this->process(hmi, AsContainerMessage< hoNDArray< int16_t > >(hmi->cont()), mmb);
+	break;
+      case (ISMRMRD::ISMRMRD_UINT):
+	return this->process(hmi, AsContainerMessage< hoNDArray< uint32_t > >(hmi->cont()), mmb);
+	break;
+      case (ISMRMRD::ISMRMRD_INT):
+	return this->process(hmi, AsContainerMessage< hoNDArray< int32_t > >(hmi->cont()), mmb);
+	break;
+      case (ISMRMRD::ISMRMRD_FLOAT):
+	return this->process(hmi, AsContainerMessage< hoNDArray< float > >(hmi->cont()), mmb);
+	break;
+      case (ISMRMRD::ISMRMRD_DOUBLE):
+	return this->process(hmi, AsContainerMessage< hoNDArray< double > >(hmi->cont()), mmb);
+	break;
+      case (ISMRMRD::ISMRMRD_CXFLOAT):
+	return this->process(hmi, AsContainerMessage< hoNDArray< std::complex<float> > >(hmi->cont()), mmb);
+	break;
+      case (ISMRMRD::ISMRMRD_CXDOUBLE):
+	return this->process(hmi, AsContainerMessage< hoNDArray< std::complex<double> > >(hmi->cont()), mmb);
+	break;
+      }
+    }
+  }
+  
+  GADGET_FACTORY_DECLARE(PythonGadget)
 }

--- a/gadgets/python/config/python.xml
+++ b/gadgets/python/config/python.xml
@@ -18,7 +18,7 @@
     <gadget>
       <name>RemoveOversamplingPython</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
       <property><name>python_module</name>                <value>remove_2x_oversampling</value></property>
       <property><name>python_class</name>                <value>Remove2xOversampling</value></property>
@@ -27,7 +27,7 @@
     <gadget>
       <name>AccReconPython</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
       <property><name>python_module</name>                <value>accumulate_and_recon</value></property>
       <property><name>python_class</name>                <value>AccumulateAndRecon</value></property>
@@ -36,7 +36,7 @@
     <gadget>
       <name>CoilCombinePython</name>
       <dll>gadgetron_python</dll>
-      <classname>ImagePythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
       <property><name>python_module</name>                <value>rms_coil_combine</value></property>
       <property><name>python_class</name>                <value>RMSCoilCombine</value></property>
@@ -45,7 +45,7 @@
     <gadget>
       <name>ImageViewPython</name>
       <dll>gadgetron_python</dll>
-      <classname>ImagePythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
       <property><name>python_module</name>                <value>image_viewer</value></property>
       <property><name>python_class</name>                <value>ImageViewer</value></property>

--- a/gadgets/python/config/python_short.xml
+++ b/gadgets/python/config/python_short.xml
@@ -18,7 +18,7 @@
     <gadget>
       <name>RemoveOversamplingPython</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
       <property><name>python_module</name>                <value>remove_2x_oversampling</value></property>
       <property><name>python_class</name>                <value>Remove2xOversampling</value></property>
@@ -27,7 +27,7 @@
     <gadget>
       <name>AccReconPython</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
       <property><name>python_module</name>                <value>accumulate_and_recon</value></property>
       <property><name>python_class</name>                <value>AccumulateAndRecon</value></property>
@@ -36,7 +36,7 @@
     <gadget>
       <name>CoilCombinePython</name>
       <dll>gadgetron_python</dll>
-      <classname>ImagePythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
       <property><name>python_module</name>                <value>rms_coil_combine</value></property>
       <property><name>python_class</name>                <value>RMSCoilCombine</value></property>

--- a/gadgets/python/config/python_tpat_snr_scale.xml
+++ b/gadgets/python/config/python_tpat_snr_scale.xml
@@ -18,7 +18,7 @@
     <gadget>
       <name>NoiseAdj</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_module</name>                <value>tpat_snr_scale</value></property>
       <property><name>python_class</name>                <value>NoiseAdj</value></property>
     </gadget>
@@ -26,7 +26,7 @@
     <gadget>
       <name>RemOS</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_module</name>                <value>tpat_snr_scale</value></property>
       <property><name>python_class</name>                <value>RemOS</value></property>
     </gadget>
@@ -34,7 +34,7 @@
     <gadget>
       <name>PCA</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_module</name>                <value>tpat_snr_scale</value></property>
       <property><name>python_class</name>                <value>PCA</value></property>
     </gadget>
@@ -42,7 +42,7 @@
     <gadget>
       <name>CoilReduce</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_module</name>                <value>tpat_snr_scale</value></property>
       <property><name>python_class</name>                <value>CoilReduce</value></property>
     </gadget>
@@ -50,7 +50,7 @@
     <gadget>
       <name>Recon</name>
       <dll>gadgetron_python</dll>
-      <classname>AcquisitionPythonGadget</classname>
+      <classname>PythonGadget</classname>
       <property><name>python_module</name>                <value>tpat_snr_scale</value></property>
       <property><name>python_class</name>                <value>Recon</value></property>
     </gadget>

--- a/gadgets/python/gadgets/accumulate_and_recon.py
+++ b/gadgets/python/gadgets/accumulate_and_recon.py
@@ -18,7 +18,6 @@ class AccumulateAndRecon(Gadget):
         self.enc = self.header.encoding[0]
 
     def process(self, acq, data,*args):
-
         if self.myBuffer is None:
             channels = acq.active_channels
             if self.enc.encodingLimits.slice != None:
@@ -50,16 +49,16 @@ class AccumulateAndRecon(Gadget):
             img_head.slice_dir = acq.slice_dir
             img_head.patient_table_position = acq.patient_table_position
             img_head.acquisition_time_stamp = acq.acquisition_time_stamp
-            img_head.image_index = self.myCounter;
-            img_head.image_series_index = self.mySeries;
-
+            img_head.image_index = self.myCounter
+            img_head.image_series_index = self.mySeries
+            img_head.data_type = ismrmrd.DATATYPE_CXFLOAT
             self.myCounter += 1
             if self.myCounter > 5:
                     self.mySeries += 1
                     self.myCounter = 1
 
             #Return image to Gadgetron
-            self.put_next(img_head,image,*args)
+            self.put_next(img_head,image.astype('complex64'),*args)
             
         #print "Returning to Gadgetron"
         return 0 #Everything OK

--- a/gadgets/python/gadgets/rms_coil_combine.py
+++ b/gadgets/python/gadgets/rms_coil_combine.py
@@ -7,6 +7,7 @@ class RMSCoilCombine(Gadget):
         print "RMS Coil Combine, Config ignored"
 
     def process(self, h, im):
+        print "process called in coil combine"
         combined_image = np.sqrt(np.sum(np.square(np.abs(im)),axis=0))
         h.channels = 1
         self.put_next(h,combined_image.astype('complex64'))

--- a/gadgets/python/gadgets/rms_coil_combine.py
+++ b/gadgets/python/gadgets/rms_coil_combine.py
@@ -7,7 +7,6 @@ class RMSCoilCombine(Gadget):
         print "RMS Coil Combine, Config ignored"
 
     def process(self, h, im):
-        print "process called in coil combine"
         combined_image = np.sqrt(np.sum(np.square(np.abs(im)),axis=0))
         h.channels = 1
         self.put_next(h,combined_image.astype('complex64'))


### PR DESCRIPTION
Create a single PythonGadget type and removed the need for Acquisition and Image Gadgets in Python. The PythonGadget supports all Acquisition and Image types.

Instead of having an ImagePythonGadget (which we would now need multiple versions of to support different data types) and AcquisitionGadget, there is now a single PythonGadget, which supports both all types of ISMRMRD data. 

This is also a precursor for creating a gadgetron_python_to_xml.py script that will take a chain in Python and return it's equivalent xml chain. I ran into difficulties writing that script, since in Python we don't distinguish those types of Gadgets so when converting, it is hard to write the right XML. This PR should make that easy. 

Thoughts? Comments?