### PR TITLE
Support for properties passed to pure python gadgets etc,

### DIFF
--- a/apps/gadgetron/Gadget.cpp
+++ b/apps/gadgetron/Gadget.cpp
@@ -11,8 +11,8 @@ namespace Gadgetron
     }
 
     std::string str_val;
+    GadgetPropertyBase* p = find_property(name);
     if (using_properties_) {
-      GadgetPropertyBase* p = find_property(name);
       if (!p) {
 	GERROR("Property %s\n", name);
 	throw std::runtime_error("Attempting to access non existent property on Gadget");

--- a/apps/gadgetron/Gadget.h
+++ b/apps/gadgetron/Gadget.h
@@ -268,20 +268,22 @@ namespace Gadgetron{
             return 0;
         }
 
-        int set_parameter(const char* name, const char* val, bool trigger = true) {
+        virtual int set_parameter(const char* name, const char* val, bool trigger = true) {
 	  boost::shared_ptr<std::string> old_value = get_string_value(name);
+	  GadgetPropertyBase* p = this->find_property(name);
 
-	  if (using_properties_) {
-	    GadgetPropertyBase* p = this->find_property(name);
-	    if (!p) {
-	      throw std::runtime_error("Attempting to set non-registered property while operaying in forced using_properties mode");
-	    }
+	  if (p) {
 	    p->string_value(val);
 	  } else {
-	    parameter_mutex_.acquire();
-            parameters_[std::string(name)] = std::string(val);
-	    parameter_mutex_.release();
+	    if (using_properties_) {
+	      throw std::runtime_error("Attempting to set non-registered property while operaying in forced using_properties mode");
+	    }
 	  }
+
+	  parameter_mutex_.acquire();
+	  parameters_[std::string(name)] = std::string(val);
+	  parameter_mutex_.release();
+
 	  if (trigger) {
 	    return parameter_changed(std::string(name), std::string(val), *old_value);
 	  }
@@ -289,15 +291,15 @@ namespace Gadgetron{
 	  return 0;
         }
 
-        int get_bool_value(const char* name) {
+        virtual int get_bool_value(const char* name) {
             return (0 == ACE_OS::strcmp(get_string_value(name)->c_str(), "true"));
         }
 
-        int get_int_value(const char* name) {
+        virtual int get_int_value(const char* name) {
             return ACE_OS::atoi(get_string_value(name)->c_str());
         }
 
-        double get_double_value(const char* name) {
+        virtual double get_double_value(const char* name) {
             return ACE_OS::atof(get_string_value(name)->c_str());
         }
 

--- a/gadgets/python/config/python_tpat_snr_scale.xml
+++ b/gadgets/python/config/python_tpat_snr_scale.xml
@@ -52,7 +52,8 @@
       <dll>gadgetron_python</dll>
       <classname>PythonGadget</classname>
       <property><name>python_module</name>                <value>tpat_snr_scale</value></property>
-      <property><name>python_class</name>                <value>Recon</value></property>
+      <property><name>python_class</name>                 <value>Recon</value></property>
+      <property><name>pmri_method</name>                   <value>grappa</value></property>
     </gadget>
 
      <gadget>

--- a/gadgets/python/gadgets/gadgetron.py
+++ b/gadgets/python/gadgets/gadgetron.py
@@ -79,7 +79,15 @@ class Gadget(object):
         results = self.results
         self.results = []
         return results
-        
+
+
+class WrappedGadget(object):
+    def __init__(self, dllname, classname, gadgetname):
+        self.gadgetname = gadgetname
+        self.classname = classname
+        self.dllname = dllname
+        self.parameters = dict()
+    
 class WrapperGadget(Gadget):
     
     def __init__(self, dllname, classname, gadgetname=None, next_gadget=None):
@@ -89,9 +97,12 @@ class WrapperGadget(Gadget):
         self.controller_ = GadgetronPythonMRI.GadgetInstrumentationStreamController()
         self.controller_.prepend_gadget(gadgetname,dllname,classname)
         self.controller_.set_python_gadget(self)
-    
+        self.wrapped_gadgets = list()
+        self.wrapped_gadgets.append(WrappedGadget(dllname,classname,gadgetname))
+
     def prepend_gadget(self,dllname, classname, gadgetname=None):
         self.controller_.prepend_gadget(gadgetname,dllname,classname)
+        self.wrapped_gadgets.insert(0,WrappedGadget(dllname,classname,gadgetname))
 
     def wait(self):
        self.controller_.close()
@@ -126,6 +137,11 @@ class WrapperGadget(Gadget):
         return 0
 
     def set_parameter(self,gadgetname,parameter,value):
+        for g in self.wrapped_gadgets:
+            if g.gadgetname == gadgetname:
+                g.parameters[parameter] = value
+                break
+
         self.controller_.set_parameter(gadgetname,parameter,value)
 
 class FunctionGadget(Gadget):

--- a/gadgets/python/gadgets/remove_2x_oversampling.py
+++ b/gadgets/python/gadgets/remove_2x_oversampling.py
@@ -1,6 +1,5 @@
 import numpy as np
 from ismrmrdtools import transform
-import libxml2
 from gadgetron import Gadget
 
 class Remove2xOversampling(Gadget):

--- a/gadgets/python/utils/CMakeLists.txt
+++ b/gadgets/python/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
 install(FILES
-  gadgetron_run_python_chain.py  gadgetron_xml_to_python.py
+  gadgetron_run_python_chain.py  gadgetron_xml_to_python.py gadgetron_python_to_xml.py
   DESTINATION ${GADGETRON_INSTALL_PYTHON_MODULE_PATH} COMPONENT main)

--- a/gadgets/python/utils/gadgetron_python_to_xml.py
+++ b/gadgets/python/utils/gadgetron_python_to_xml.py
@@ -1,0 +1,83 @@
+import sys
+import os
+import inspect
+import gadgetron
+
+sys.path.append(os.environ['GADGETRON_HOME'] + '/share/gadgetron/python')
+
+def convert_to_xml(first_gadget):
+    g = first_gadget
+
+    xml_string  = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    xml_string += "<gadgetronStreamConfiguration xsi:schemaLocation=\"http://gadgetron.sf.net/gadgetron gadgetron.xsd\" xmlns=\"http://gadgetron.sf.net/gadgetron\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n"
+
+    #Add standard readers and writers
+    xml_string += "<reader>\n"
+    xml_string += "  <slot>1008</slot>\n"
+    xml_string += "  <dll>gadgetron_mricore</dll>\n"
+    xml_string += "  <classname>GadgetIsmrmrdAcquisitionMessageReader</classname>\n"
+    xml_string += "</reader>\n"
+    xml_string += "\n"
+    xml_string += "<writer>\n"
+    xml_string += "  <slot>1022</slot>\n"
+    xml_string += "  <dll>gadgetron_mricore</dll>\n"
+    xml_string += "  <classname>MRIImageWriter</classname>\n"
+    xml_string += "</writer>\n"
+    xml_string += "\n"
+
+    while (g):
+        if isinstance(g,gadgetron.WrapperGadget):
+            for wg in g.wrapped_gadgets:
+                xml_string += "<gadget>\n"
+                xml_string += "  <name>" + wg.gadgetname +"</name>\n"
+                xml_string += "  <dll>" + wg.dllname + "</dll>\n"
+                xml_string += "  <classname>" + wg.classname + "</classname>\n"
+                for p in wg.parameters:
+                    xml_string += "    <property>\n"
+                    xml_string += "      <name>" + str(p) + "</name>\n"
+                    xml_string += "      <value>" + str(wg.parameters[p]) + "</value>\n"
+                    xml_string += "    </property>\n"
+                xml_string += "</gadget>\n\n"
+        else:
+            xml_string += "<gadget>\n"
+            xml_string += "  <name>" + str(g.__class__.__name__) +"</name>\n"
+            xml_string += "  <dll>gadgetron_python</dll>\n"
+            xml_string += "  <classname>PythonGadget</classname>\n"
+            xml_string += "  <property>\n"
+            xml_string += "    <name>python_module</name>\n"
+            xml_string += "    <value>" + g.__module__ + "</value>\n"
+            xml_string += "  </property>\n"            
+            xml_string += "  <property>\n"
+            xml_string += "    <name>python_class</name>\n"
+            xml_string += "    <value>" + g.__class__.__name__ + "</value>\n"
+            xml_string += "  </property>\n"
+            for p in g.params:
+                xml_string += "  <property>\n"
+                xml_string += "    <name>" + str(p) + "</name>\n"
+                xml_string += "    <value>" + str(g.params[p]) + "</value>\n"
+                xml_string += "  </property>\n"
+            xml_string += "</gadget>\n\n"
+
+        g = g.next_gadget
+
+    xml_string += "</gadgetronStreamConfiguration>\n"
+    return xml_string
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print "Usage: " + sys.argv[0] + "<gadgetron_python_chain.py>"
+        raise Exception("Invalid number of arguments")
+
+    python_function_file = sys.argv[1]
+    if not os.path.isfile(python_function_file):
+        print("%s is not a valid file" % python_function_file)
+        raise SystemExit
+    
+    namespace = {}
+    execfile(python_function_file, namespace)
+    globals().update(namespace)
+
+    g0 = define_gadget_chain() #Call function from imported file
+
+    xml_string = convert_to_xml(g0)
+    print xml_string

--- a/gadgets/python/utils/gadgetron_run_python_chain.py
+++ b/gadgets/python/utils/gadgetron_run_python_chain.py
@@ -30,7 +30,7 @@ def get_last_gadget(first_gadget):
 if __name__ == "__main__":
     if len(sys.argv) != 4:
         print "Usage: " + sys.argv[0] + " <gadgetron_python_chain.py> <ismrmrd_out.h5> <ismrmrd_out.h5>"
-        raise "Invalid number of arguments."
+        raise Exception("Invalid number of arguments.")
 
     python_function_file = sys.argv[1]
     filename = sys.argv[2]

--- a/gadgets/python/utils/gadgetron_xml_to_python.py
+++ b/gadgets/python/utils/gadgetron_xml_to_python.py
@@ -24,6 +24,7 @@ def convert_xml(xmlfilename):
             object_name = 'g' + str(counter)
             python_module = None
             python_class = None
+            prop_set_string = ''
             for p in gadget.findall(add_ns('property')):
                 pname = p.findall(add_ns('name'))[0].text
                 pvalue = p.findall(add_ns('value'))[0].text
@@ -32,11 +33,12 @@ def convert_xml(xmlfilename):
                     python_module = pvalue
                 elif (pname == 'python_class'):
                     python_class = pvalue
+                else:
+                    prop_set_string += '    ' + object_name + '.set_parameter(\"' + pname + '\", \"' + pvalue + '\")\n'
 
-                if (python_module and python_class):
-                    break
             header_string += 'from ' + python_module + ' import ' + python_class + '\n'
             function_string += '    ' + object_name + ' = ' + python_class + '(next_gadget=' + next_gadget + ')\n'
+            function_string += prop_set_string
             last_gadget_was_wrapper = False
         else:
             if not last_gadget_was_wrapper:

--- a/gadgets/python/utils/gadgetron_xml_to_python.py
+++ b/gadgets/python/utils/gadgetron_xml_to_python.py
@@ -61,10 +61,10 @@ def convert_xml(xmlfilename):
     function_code = header_string
     function_code += '\n'
     function_code += function_string
-    print function_code
+    return function_code
  
 if __name__ == "__main__":
     if len(argv) != 2:
         print "Usage: " + argv[0] + " <configuration.xml>"
         raise "Invalid number of arguments. Please provide the name of a gadgetron configuration file"
-    convert_xml(argv[1])
+    print convert_xml(argv[1])


### PR DESCRIPTION
This PR adds support for properties passed from C++ to Python Gadgets. This is done without violating the requirement that properties usually have to be defined and without using the current exception for Gadgets that don't define properties. It is achieved by overloading the set_parameter function on the PythonGadget and storing the properties that are not defined as such and this list of parameters are then passed on to the Python gadget.  

It also provides a script to convert a Python chain to it's equivalent XML representation. There are some various utilities to support this on the basic Gadget Python class and the GadgetWrapper class. 

It also fixes a bug that caused properties to not be set in the old style map on the gadgets that define properties but don't enforce it strictly. 