### PR TITLE
Add gadgetron start on cpus

### DIFF
--- a/apps/gadgetron/webapp/gadgetron_web.conf.in
+++ b/apps/gadgetron/webapp/gadgetron_web.conf.in
@@ -9,7 +9,15 @@ stop on starting shutdown
 console output
 kill signal INT
 
-exec su -c "python @CMAKE_INSTALL_PREFIX@/bin/gadgetron_web_app.py @CMAKE_INSTALL_PREFIX@/config/gadgetron_web_app.cfg" gadgetron
+pre-start script
+    for cpunum in $(
+        cat /sys/devices/system/cpu/cpu*/topology/thread_siblings_list | 
+        cut -s -d, -f2- | tr ',' '\n' | sort -un); do
+            echo 0 > /sys/devices/system/cpu/cpu$cpunum/online
+    done
+end script
+
+exec su -c "python @CMAKE_INSTALL_PREFIX@/bin/gadgetron_web_app.py @CMAKE_INSTALL_PREFIX@/share/gadgetron/config/gadgetron_web_app.cfg" gadgetron
 
 respawn
 

--- a/apps/gadgetron/webapp/gadgetron_web_app.cfg
+++ b/apps/gadgetron/webapp/gadgetron_web_app.cfg
@@ -7,5 +7,3 @@ GADGETRON_HOME=/usr/local/gadgetron
 ISMRMRD_HOME=/usr/local
 logfile=/tmp/gadgetron.log
 
-[RUNTIME]
-cpulist=0-31

--- a/apps/gadgetron/webapp/gadgetron_web_app.cfg
+++ b/apps/gadgetron/webapp/gadgetron_web_app.cfg
@@ -6,3 +6,6 @@ port=9002
 GADGETRON_HOME=/usr/local/gadgetron
 ISMRMRD_HOME=/usr/local
 logfile=/tmp/gadgetron.log
+
+[RUNTIME]
+cpulist=0-31

--- a/apps/gadgetron/webapp/gadgetron_web_app.in
+++ b/apps/gadgetron/webapp/gadgetron_web_app.in
@@ -6,3 +6,6 @@ port=9002
 GADGETRON_HOME=@CMAKE_INSTALL_PREFIX@
 ISMRMRD_HOME=@ISMRMRD_INCLUDE_DIR@/..
 logfile=/tmp/gadgetron.log
+
+[RUNTIME]
+cpulist=0-31

--- a/apps/gadgetron/webapp/gadgetron_web_app.in
+++ b/apps/gadgetron/webapp/gadgetron_web_app.in
@@ -7,5 +7,3 @@ GADGETRON_HOME=@CMAKE_INSTALL_PREFIX@
 ISMRMRD_HOME=@ISMRMRD_INCLUDE_DIR@/..
 logfile=/tmp/gadgetron.log
 
-[RUNTIME]
-cpulist=0-31

--- a/apps/gadgetron/webapp/gadgetron_web_app.py
+++ b/apps/gadgetron/webapp/gadgetron_web_app.py
@@ -73,7 +73,7 @@ class GadgetronResource(resource.Resource):
         
         self.environment = dict()
         self.environment["GADGETRON_HOME"]=gadgetron_home
-        self.environment["PATH"]=self.environment["GADGETRON_HOME"] + "/bin"
+        self.environment["PATH"]="/usr/bin:/usr/local/bin:" + self.environment["GADGETRON_HOME"] + "/bin"
 
         if (platform.system() == 'Linux'):
             self.environment["LD_LIBRARY_PATH"]="/usr/local/cuda/lib64:/usr/local/cula/lib64:" +  self.environment["GADGETRON_HOME"] + "/lib:" + ismrmrd_home + "/lib"  

--- a/apps/gadgetron/webapp/gadgetron_web_app.py
+++ b/apps/gadgetron/webapp/gadgetron_web_app.py
@@ -68,7 +68,11 @@ class GadgetronResource(resource.Resource):
         ismrmrd_home = config.get('GADGETRON', 'ISMRMRD_HOME')
         self.gadgetron_log_filename = config.get('GADGETRON','logfile')
         self.gadgetron_port = config.get('GADGETRON','port')
-        self.gadgetron_cpulist = config.get('RUNTIME','cpulist')
+
+        self.gadgetron_cpulist = 0
+        if (config.has_option('RUNTIME','cpulist')):
+            self.gadgetron_cpulist = config.get('RUNTIME','cpulist')
+
         gf = open(self.gadgetron_log_filename,"w")
         
         self.environment = dict()
@@ -81,10 +85,14 @@ class GadgetronResource(resource.Resource):
             self.environment["DYLD_LIBRARY_PATH"]="/usr/local/cuda/lib64:/usr/local/cula/lib64:" +  self.environment["GADGETRON_HOME"] + "/lib:" + ismrmrd_home + "/lib:/opt/local/lib"  
 
         #self.process_lock.acquire()
-        if (platform.system() == 'Windows'):
-            self.gadgetron_process = subprocess.Popen(["start", "/AFFINITY", self.gadgetron_cpulist, "gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
+        if(self.gadgetron_cpulist != 0):
+            if (platform.system() == 'Windows'):
+                self.gadgetron_process = subprocess.Popen(["start", "/AFFINITY", self.gadgetron_cpulist, "gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
+            else:
+                self.gadgetron_process = subprocess.Popen(["taskset","-c",self.gadgetron_cpulist,"gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
         else:
-            self.gadgetron_process = subprocess.Popen(["taskset","-c",self.gadgetron_cpulist,"gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
+            self.gadgetron_process = subprocess.Popen(["gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
+
         #self.process_lock.release()
         resource.Resource.__init__(self)
         
@@ -103,10 +111,13 @@ class GadgetronResource(resource.Resource):
             self.gadgetron_process.kill()
             time.sleep(2)
         gf = open(self.gadgetron_log_filename,"w")
-        if (platform.system() == 'Windows'):
-            self.gadgetron_process = subprocess.Popen(["start", "/AFFINITY", self.gadgetron_cpulist, "gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
+        if(self.gadgetron_cpulist != 0):
+            if (platform.system() == 'Windows'):
+                self.gadgetron_process = subprocess.Popen(["start", "/AFFINITY", self.gadgetron_cpulist, "gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
+            else:
+                self.gadgetron_process = subprocess.Popen(["taskset","-c",self.gadgetron_cpulist,"gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
         else:
-            self.gadgetron_process = subprocess.Popen(["taskset","-c",self.gadgetron_cpulist,"gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
+            self.gadgetron_process = subprocess.Popen(["gadgetron","-p",self.gadgetron_port], env=self.environment,stdout=gf,stderr=gf)
         time.sleep(2)
         self.process_lock.release()
 

--- a/chroot/gadgetron_chroot.conf
+++ b/chroot/gadgetron_chroot.conf
@@ -12,6 +12,15 @@ console log
 
 kill signal INT
 
+# turn off hyper-threading if any
+pre-start script
+    for cpunum in $(
+        cat /sys/devices/system/cpu/cpu*/topology/thread_siblings_list | 
+        cut -s -d, -f2- | tr ',' '\n' | sort -un); do
+            echo 0 > /sys/devices/system/cpu/cpu$cpunum/online
+    done
+end script
+
 # Call a script that will mount the proc and start the webapp inside the chroot env
 script
     exec su -c "/home/gadgetron_chroot/current/chroot-root/gadgetron/usr/local/share/gadgetron/chroot/start-webapp.sh /home/gadgetron_chroot/current/chroot-root/gadgetron" root &


### PR DESCRIPTION
The motivation for this PR is that hyper-threading in general slows down the computational intensive gadgetron chain. The 4th generation amazon instance can have up to 18 physicial cores and 36 logic cores. I observed hyper-threading on 36 logic cores slowed down the iterative recon substantially. 

An optional cpulist control is added to start the python gadgetron web app. User can specify this option to control which cores gadgetron is started on, e.g. 0-15 means gadgetron is started on core 0 to core 15. Other syntax includes: e.g. 0,5,7,9-11

In windows, the cpu affinity is controlled using "start /AFFINITY 0xffff gadgetron -p port". In this example, gadgetron is started on core 0 to core 15 (0xffff indicates this).

To start gadgetron on specific cores, linux command taskset is used.

If this option is not set, as default, gadgetron will be started on all cores, as current behavior.
