### PR TITLE
Fix rt grappa cpu test

### DIFF
--- a/gadgets/grappa/GrappaCalibrationBuffer.cpp
+++ b/gadgets/grappa/GrappaCalibrationBuffer.cpp
@@ -117,6 +117,8 @@ namespace Gadgetron{
 
         std::vector<unsigned int> uncombined_channel_weights;
 
+        //GDEBUG_STREAM("==========================================================================");
+        //GDEBUG_STREAM("compute weights on scan : " << m1->scan_counter);
         //GDEBUG("sampled_region[0] = %d,%d\n", sampled_region[0].first, sampled_region[0].second);
         //GDEBUG("sampled_region[1] = %d,%d\n", sampled_region[1].first, sampled_region[1].second);
 

--- a/gadgets/interventional_mri/grappa_device.xml
+++ b/gadgets/interventional_mri/grappa_device.xml
@@ -55,6 +55,7 @@
       <property><name>uncombined_channels</name><value>0</value></property>
       -->
       <property><name>device_channels</name><value>present_uncombined_channels@PCA</value></property>
+      <property><name>use_gpu</name><value>true</value></property>
     </gadget>
 
     <gadget>

--- a/toolboxes/mri/pmri/gpu/htgrappa.cpp
+++ b/toolboxes/mri/pmri/gpu/htgrappa.cpp
@@ -10,12 +10,12 @@
 
 
 /*
-  This file is used to hide certain Armadillo calls from the nvcc compiler. If Armadillo functions need to 
-  be called in a *.cu file, it is preferably to wrap the calls in a function and place that function in 
+  This file is used to hide certain Armadillo calls from the nvcc compiler. If Armadillo functions need to
+  be called in a *.cu file, it is preferably to wrap the calls in a function and place that function in
   a *.cpp file so that Armadillo code will not be compiled by nvcc.
 
   Some error handling may be needed in these functions, but eventually SymmetricHermitianPositiveDefiniteLinearSystem_posv
-  will be renamed and made to throw exceptions and then it should be handled. 
+  will be renamed and made to throw exceptions and then it should be handled.
 
  */
 
@@ -25,17 +25,19 @@ namespace Gadgetron
 {
   template <class T> void ht_grappa_solve_spd_system(hoNDArray<T> *A, hoNDArray<T> *B) {
     /*
-      We are swithcing off OpenMP threading before this call to posv. There seems to be a bad interaction between openmp, cuda, and BLAS. 
-      So far this problem has only been observed from *.cu files (or in functions called from *.cu files) but the problem may be more general. 
+      We are swithcing off OpenMP threading before this call to posv. There seems to be a bad interaction between openmp, cuda, and BLAS.
+      So far this problem has only been observed from *.cu files (or in functions called from *.cu files) but the problem may be more general.
 
-      This is a temporary fix that we should keep an eye on. 
+      This is a temporary fix that we should keep an eye on.
      */
 #ifdef USE_OMP
     int num_threads = omp_get_num_threads();
     omp_set_num_threads(1);
 #endif //USE_OMP
 
-    posv(*A, *B);
+    // it is found that if signal is very very high, the posv can throw exceptions due to ill-conditioned matrix of A
+    // hesv does not require A to be a positive-definite matrix, but an n-by-n symmetric matrix
+    hesv(*A, *B);
 
 #ifdef USE_OMP
     omp_set_num_threads(num_threads);
@@ -44,5 +46,5 @@ namespace Gadgetron
   }
 
   template void ht_grappa_solve_spd_system< float_complext >(hoNDArray< float_complext > *A, hoNDArray< float_complext > *B);
-  
+
 }

--- a/toolboxes/mri/pmri/gpu/htgrappa.cpp
+++ b/toolboxes/mri/pmri/gpu/htgrappa.cpp
@@ -30,14 +30,29 @@ namespace Gadgetron
 
       This is a temporary fix that we should keep an eye on.
      */
+
+    hoNDArray<T> A_ori;
+    A_ori = *A;
+
 #ifdef USE_OMP
     int num_threads = omp_get_num_threads();
     omp_set_num_threads(1);
 #endif //USE_OMP
 
-    // it is found that if signal is very very high, the posv can throw exceptions due to ill-conditioned matrix of A
-    // hesv does not require A to be a positive-definite matrix, but an n-by-n symmetric matrix
-    hesv(*A, *B);
+    try
+    {
+        posv(*A, *B);
+    }
+    catch(...)
+    {
+        // it is found that if signal is very very high, the posv can throw exceptions due to ill-conditioned matrix of A
+        // hesv does not require A to be a positive-definite matrix, but an n-by-n symmetric matrix
+
+        GERROR_STREAM("ht_grappa_solve_spd_system : posv(*A, *B) throws exceptions ... ");
+        *A = A_ori;
+        hesv(*A, *B);
+        GERROR_STREAM("ht_grappa_solve_spd_system : hesv(*A, *B) is called ");
+    }
 
 #ifdef USE_OMP
     omp_set_num_threads(num_threads);


### PR DESCRIPTION
Make posv single threaded, since it is found to be not thread-safe when using with openblas and cuda.
Speed up the rt grappa by allowing AHA to be computed with multi-threading. 
If no uncombined channel, the cpu kernel is computed from first target_coil_ channel. The reason is other channels are zeros after coil compression.
