### PR TITLE
revert the set_num_threads(1) in posv

### DIFF
--- a/toolboxes/core/cpu/math/hoNDArray_linalg.cpp
+++ b/toolboxes/core/cpu/math/hoNDArray_linalg.cpp
@@ -1296,11 +1296,7 @@ void posv(hoNDArray<T>& A, hoNDArray<T>& b)
 
 #ifdef USE_OMP
         int num_threads = omp_get_num_threads();
-#pragma omp single
-        {
-            if (!omp_in_parallel() && num_threads>1) omp_set_num_threads(1);
-        }
-
+        if (!omp_in_parallel() && num_threads>1) omp_set_num_threads(1);
 #endif //USE_OMP
 
         if ( typeid(T)==typeid(float) )

--- a/toolboxes/core/cpu/math/hoNDArray_linalg.cpp
+++ b/toolboxes/core/cpu/math/hoNDArray_linalg.cpp
@@ -3,10 +3,6 @@
 #include "hoNDArray_elemwise.h"
 #include "hoNDArray_reductions.h"
 
-#ifdef USE_OMP
-    #include "omp.h"
-#endif // USE_OMP
-
 #ifndef lapack_complex_float
     #define lapack_complex_float  std::complex<float> 
 #endif // lapack_complex_float
@@ -1294,11 +1290,6 @@ void posv(hoNDArray<T>& A, hoNDArray<T>& b)
         This is a temporary fix that we should keep an eye on.
         */
 
-#ifdef USE_OMP
-        int num_threads = omp_get_num_threads();
-        omp_set_num_threads(1);
-#endif //USE_OMP
-
         if ( typeid(T)==typeid(float) )
         {
             sposv_(&uplo, &n, &nrhs, reinterpret_cast<float*>(pA), &lda, reinterpret_cast<float*>(pB), &ldb, &info);
@@ -1317,15 +1308,8 @@ void posv(hoNDArray<T>& A, hoNDArray<T>& b)
         }
         else
         {
-#ifdef USE_OMP
-            omp_set_num_threads(num_threads);
-#endif //USE_OM
             GADGET_THROW("posv : unsupported type ... ");
         }
-
-#ifdef USE_OMP
-        omp_set_num_threads(num_threads);
-#endif //USE_OMP
 
         GADGET_CHECK_THROW(info==0);
     }

--- a/toolboxes/mri/pmri/gpu/htgrappa.cpp
+++ b/toolboxes/mri/pmri/gpu/htgrappa.cpp
@@ -34,11 +34,6 @@ namespace Gadgetron
     hoNDArray<T> A_ori;
     A_ori = *A;
 
-#ifdef USE_OMP
-    int num_threads = omp_get_num_threads();
-    omp_set_num_threads(1);
-#endif //USE_OMP
-
     try
     {
         posv(*A, *B);
@@ -53,11 +48,6 @@ namespace Gadgetron
         hesv(*A, *B);
         GERROR_STREAM("ht_grappa_solve_spd_system : hesv(*A, *B) is called ");
     }
-
-#ifdef USE_OMP
-    omp_set_num_threads(num_threads);
-#endif //USE_OMP
-
   }
 
   template void ht_grappa_solve_spd_system< float_complext >(hoNDArray< float_complext > *A, hoNDArray< float_complext > *B);


### PR DESCRIPTION
Actually it is a bad idea to set number of threads to be 1 in the posv call itself. The reason is that posv call can be inside openmp loop. Depending the outloop openmp thread scheduling, some posv call will find num_threads to be 1 and after leaving the posv call, the number of threads will not be properly restored. This problem is found because after this change, some iterative code actually started to run with only one thread and becomes much slower.

It seems still better to handle the gpu/openblas posv threading problem at  where it happens, instead of changing basic linalg implementation.