### PR TITLE
changing integration tests to allow no siemens conversion

### DIFF
--- a/test/integration/cases/cpu_grappa_simple.cfg
+++ b/test/integration/cases/cpu_grappa_simple.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/rtgrappa/acc_data_with_device_2.dat
+siemens_dat=rtgrappa/acc_data_with_device_2.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=grappa_rate2.h5
 result_h5=grappa_rate2_cpu_out.h5
-reference_h5= data/rtgrappa/grappa_rate2_cpu_out.h5
+reference_h5=rtgrappa/grappa_rate2_cpu_out.h5
 
 [TEST]
 gadgetron_configuration=grappa_float_cpu.xml

--- a/test/integration/cases/epi_2d.cfg
+++ b/test/integration/cases/epi_2d.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
+siemens_dat=epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens_EPI.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=epi_2d.h5
 result_h5=epi_2d_out.h5
-reference_h5= data/epi/epi_2d_out_20150406_sji.h5 
+reference_h5=epi/epi_2d_out_20150406_sji.h5
 
 [TEST]
 gadgetron_configuration=epi.xml

--- a/test/integration/cases/gpu_fixed_radial_mode1_cg.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_cg.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
+siemens_dat=radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=fixed_radial.h5
 result_h5=fixed_radial_mode1_cg_out.h5
-reference_h5= data/radial_phantom/fixed_radial_mode1.h5
+reference_h5=radial_phantom/fixed_radial_mode1.h5
 
 [TEST]
 gadgetron_configuration=fixed_radial_mode1_gpusense_cg.xml

--- a/test/integration/cases/gpu_fixed_radial_mode1_ktsense.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_ktsense.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
+siemens_dat=radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=fixed_radial.h5
 result_h5=fixed_radial_mode1_ktsense_out.h5
-reference_h5= data/radial_phantom/fixed_radial_mode1.h5
+reference_h5=radial_phantom/fixed_radial_mode1.h5
 
 [TEST]
 gadgetron_configuration=fixed_radial_mode1_gpu_ktsense.xml

--- a/test/integration/cases/gpu_fixed_radial_mode1_realtime.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_realtime.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
+siemens_dat=radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=fixed_radial.h5
 result_h5=fixed_radial_mode1_realtime_out.h5
-reference_h5= data/radial_phantom/fixed_radial_mode1.h5
+reference_h5=radial_phantom/fixed_radial_mode1.h5
 
 [TEST]
 gadgetron_configuration=fixed_radial_mode1_realtime.xml

--- a/test/integration/cases/gpu_golden_radial_mode2_cg.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_cg.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+siemens_dat=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=golden_radial.h5
 result_h5=golden_radial_mode2_cg_out.h5
-reference_h5= data/radial_phantom/golden_radial_mode2.h5
+reference_h5=radial_phantom/golden_radial_mode2.h5
 
 [TEST]
 gadgetron_configuration=golden_radial_mode2_gpusense_cg.xml

--- a/test/integration/cases/gpu_golden_radial_mode2_ktsense.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_ktsense.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+siemens_dat=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=golden_radial.h5
 result_h5=golden_radial_mode2_ktsense_out.h5
-reference_h5= data/radial_phantom/golden_radial_mode2.h5
+reference_h5=radial_phantom/golden_radial_mode2.h5
 
 [TEST]
 gadgetron_configuration=golden_radial_mode2_gpu_ktsense.xml

--- a/test/integration/cases/gpu_golden_radial_mode2_realtime.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_realtime.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+siemens_dat=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=golden_radial.h5
 result_h5=golden_radial_mode2_realtime_out.h5
-reference_h5= data/radial_phantom/golden_radial_mode2.h5
+reference_h5=radial_phantom/golden_radial_mode2.h5
 
 [TEST]
 gadgetron_configuration=golden_radial_mode2_realtime.xml

--- a/test/integration/cases/gpu_golden_radial_mode2_sb.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_sb.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+siemens_dat=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=golden_radial.h5
 result_h5=golden_radial_mode2_sb_out.h5
-reference_h5= data/radial_phantom/golden_radial_mode2.h5
+reference_h5=radial_phantom/golden_radial_mode2.h5
 
 [TEST]
 gadgetron_configuration=golden_radial_mode2_gpusense_sb.xml

--- a/test/integration/cases/gpu_grappa_simple.cfg
+++ b/test/integration/cases/gpu_grappa_simple.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/rtgrappa/acc_data_with_device_2.dat
+siemens_dat=rtgrappa/acc_data_with_device_2.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=grappa_rate2.h5
 result_h5=grappa_rate2_out.h5
-reference_h5= data/rtgrappa/grappa_rate2_cpu_out.h5
+reference_h5=rtgrappa/grappa_rate2_cpu_out.h5
 
 [TEST]
 gadgetron_configuration=grappa_float.xml

--- a/test/integration/cases/gpu_spiral.cfg
+++ b/test/integration/cases/gpu_spiral.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
+siemens_dat=spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=simple_spiral.h5
 result_h5=simple_spiral_out.h5
-reference_h5= data/spiral/simple_spiral_out.h5
+reference_h5=spiral/simple_spiral_out.h5
 
 [TEST]
 gadgetron_configuration=spiral_flow_gpusense_cg.xml

--- a/test/integration/cases/gpu_spiral_sb.cfg
+++ b/test/integration/cases/gpu_spiral_sb.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
+siemens_dat=spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=simple_spiral.h5
 result_h5=simple_spiral_out.h5
-reference_h5= data/spiral/simple_spiral_out.h5
+reference_h5=spiral/simple_spiral_out.h5
 
 [TEST]
 gadgetron_configuration=spiral_flow_gpusense_sb.xml

--- a/test/integration/cases/gtplus_3D_head.cfg
+++ b/test/integration/cases/gtplus_3D_head.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/3D_head/meas_MID00156_FID05944_GRE_128iso_p2x2.dat
+siemens_dat=gtplus/3D_head/meas_MID00156_FID05944_GRE_128iso_p2x2.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_3D_head.h5
 result_h5=gtplus_3D_head_out.h5
-reference_h5= data/gtplus/3D_head/gtplus_3D_ref_20140924.h5
+reference_h5=gtplus/3D_head/gtplus_3D_ref_20140924.h5
 
 [TEST]
 gadgetron_configuration=GT_3DT_Cartesian.xml

--- a/test/integration/cases/gtplus_FatWater.cfg
+++ b/test/integration/cases/gtplus_FatWater.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/FatWater/meas_MID00342_3e2i_R4.dat
+siemens_dat=gtplus/FatWater/meas_MID00342_3e2i_R4.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_FatWater.h5
 result_h5=gtplus_FatWater_out.h5
-reference_h5= data/gtplus/FatWater/gtplus_FatWater_ref.h5
+reference_h5=gtplus/FatWater/gtplus_FatWater_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_FatWater.xml

--- a/test/integration/cases/gtplus_FetalHASTE.cfg
+++ b/test/integration/cases/gtplus_FetalHASTE.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/FetalHASTE/raw30488.dat
+siemens_dat=gtplus/FetalHASTE/raw30488.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_FetalHASTE.h5
 result_h5=gtplus_FetalHASTE_out.h5
-reference_h5= data/gtplus/FetalHASTE/gtplus_FetalHASTE_ref_20140826.h5
+reference_h5=gtplus/FetalHASTE/gtplus_FetalHASTE_ref_20140826.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_HASTE.xml

--- a/test/integration/cases/gtplus_LGE.cfg
+++ b/test/integration/cases/gtplus_LGE.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/LGE/meas_MID00083_9_slice.dat
+siemens_dat=gtplus/LGE/meas_MID00083_9_slice.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_LGE.h5
 result_h5=gtplus_LGE_out.h5
-reference_h5= data/gtplus/LGE/gtplus_LGE_ref_20140826.h5
+reference_h5=gtplus/LGE/gtplus_LGE_ref_20140826.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_LGE.xml

--- a/test/integration/cases/gtplus_Perfusion.cfg
+++ b/test/integration/cases/gtplus_Perfusion.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/Perfusion/meas_MID00045_R3_AIF_ON.dat
+siemens_dat=gtplus/Perfusion/meas_MID00045_R3_AIF_ON.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_Perfusion.h5
 result_h5=gtplus_Perfusion_out.h5
-reference_h5= data/gtplus/Perfusion/gtplus_Perfusion_ref_20140826.h5
+reference_h5=gtplus/Perfusion/gtplus_Perfusion_ref_20140826.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Perfusion.xml

--- a/test/integration/cases/gtplus_T2W.cfg
+++ b/test/integration/cases/gtplus_T2W.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/T2W/meas_MID00057_T2w.dat
+siemens_dat=gtplus/T2W/meas_MID00057_T2w.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_T2W.h5
 result_h5=gtplus_T2W_out.h5
-reference_h5= data/gtplus/T2W/gtplus_T2W_ref.h5
+reference_h5=gtplus/T2W/gtplus_T2W_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_T2W.xml

--- a/test/integration/cases/gtplus_localizer.cfg
+++ b/test/integration/cases/gtplus_localizer.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/localizer/meas_MID00026.dat
+siemens_dat=gtplus/localizer/meas_MID00026.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_localizer.h5
 result_h5=gtplus_localizer_out.h5
-reference_h5= data/gtplus/localizer/gtplus_localizer_ref.h5
+reference_h5=gtplus/localizer/gtplus_localizer_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian.xml

--- a/test/integration/cases/gtplus_molli.cfg
+++ b/test/integration/cases/gtplus_molli.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/MOLLI/20100330_10h33m11s_5562.dat
+siemens_dat=gtplus/MOLLI/20100330_10h33m11s_5562.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens_VB17.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=-1
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=gtplus_molli.h5
 result_h5=gtplus_molli_out.h5
-reference_h5= data/gtplus/MOLLI/gtplus_molli_ref_20141105.h5
+reference_h5=gtplus/MOLLI/gtplus_molli_ref_20141105.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_MOLLI.xml

--- a/test/integration/cases/gtplus_real_time_cine.cfg
+++ b/test/integration/cases/gtplus_real_time_cine.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/RealTimeCine/meas_MID21_CINE_R4.dat
+siemens_dat=gtplus/RealTimeCine/meas_MID21_CINE_R4.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_real_time_cine.h5
 result_h5=gtplus_real_time_cine_out.h5
-reference_h5= data/gtplus/RealTimeCine/gtplus_real_time_cine_ref_20150328.h5
+reference_h5=gtplus/RealTimeCine/gtplus_real_time_cine_ref_20150328.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_RealTimeCine.xml

--- a/test/integration/cases/gtplus_real_time_cine_9slices.cfg
+++ b/test/integration/cases/gtplus_real_time_cine_9slices.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/RealTimeCine_9slices/meas_MID00832.dat
+siemens_dat=gtplus/RealTimeCine_9slices/meas_MID00832.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_real_time_cine_9slices.h5
 result_h5=gtplus_real_time_cine_9slices_out.h5
-reference_h5= data/gtplus/RealTimeCine_9slices/gtplus_real_time_cine_ref_20150328.h5
+reference_h5=gtplus/RealTimeCine_9slices/gtplus_real_time_cine_ref_20150328.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_RealTimeCine.xml

--- a/test/integration/cases/gtplus_sasha.cfg
+++ b/test/integration/cases/gtplus_sasha.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/sasha/20140325_15h59m29s_7720.dat
+siemens_dat=gtplus/sasha/20140325_15h59m29s_7720.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_sasha.h5
 result_h5=gtplus_sasha_out.h5
-reference_h5= data/gtplus/sasha/gtplus_sasha_ref.h5
+reference_h5=gtplus/sasha/gtplus_sasha_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian_GFactor.xml

--- a/test/integration/cases/gtplus_snr_unit_recon_builtin_noise.cfg
+++ b/test/integration/cases/gtplus_snr_unit_recon_builtin_noise.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/snr_unit_recon_builtin_noise/meas_MID00127_FID02864_GRE_reps=150__WIP724_sPAT=4.dat
+siemens_dat=gtplus/snr_unit_recon_builtin_noise/meas_MID00127_FID02864_GRE_reps=150__WIP724_sPAT=4.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=-1
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=gtplus_snr_unit_recon_builtin_noise.h5
 result_h5=gtplus_snr_unit_recon_builtin_noise_out.h5
-reference_h5= data/gtplus/snr_unit_recon_builtin_noise/gtplus_snr_unit_recon_ref.h5
+reference_h5=gtplus/snr_unit_recon_builtin_noise/gtplus_snr_unit_recon_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian_GFactor.xml

--- a/test/integration/cases/gtplus_snr_unit_recon_ipat4.cfg
+++ b/test/integration/cases/gtplus_snr_unit_recon_ipat4.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/snr_unit_recon_ipat4/meas_MID00175_FID02912_GRE_reps=150_iPAT=4.dat
+siemens_dat=gtplus/snr_unit_recon_ipat4/meas_MID00175_FID02912_GRE_reps=150_iPAT=4.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_snr_unit_recon_ipat4.h5
 result_h5=gtplus_snr_unit_recon_ipat4_out.h5
-reference_h5= data/gtplus/snr_unit_recon_ipat4/gtplus_snr_unit_recon_ref.h5
+reference_h5=gtplus/snr_unit_recon_ipat4/gtplus_snr_unit_recon_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian_GFactor.xml

--- a/test/integration/cases/gtplus_snr_unit_recon_prospective_cine.cfg
+++ b/test/integration/cases/gtplus_snr_unit_recon_prospective_cine.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/ProspectiveCine/meas_MID00209_FID07469_CV_gtPlus_2D_epat4.dat
+siemens_dat=gtplus/ProspectiveCine/meas_MID00209_FID07469_CV_gtPlus_2D_epat4.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_snr_unit_recon_ProspectiveCine.h5
 result_h5=gtplus_snr_unit_recon_ProspectiveCine_out.h5
-reference_h5= data/gtplus/ProspectiveCine/gtplus_snr_unit_recon_ref_20140826.h5
+reference_h5=gtplus/ProspectiveCine/gtplus_snr_unit_recon_ref_20140826.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian_GFactor.xml

--- a/test/integration/cases/gtplus_snr_unit_recon_spat2_asym_pf.cfg
+++ b/test/integration/cases/gtplus_snr_unit_recon_spat2_asym_pf.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/snr_unit_recon_spat2_asym_pf/meas_MID00156_FID03210_GRE_reps=50_sPAT2_xRes256_dummy1_FOV240_strong_asym_7_8pf.dat
+siemens_dat=gtplus/snr_unit_recon_spat2_asym_pf/meas_MID00156_FID03210_GRE_reps=50_sPAT2_xRes256_dummy1_FOV240_strong_asym_7_8pf.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_snr_unit_recon_spat2_asym_pf.h5
 result_h5=gtplus_snr_unit_recon_spat2_asym_pf_out.h5
-reference_h5= data/gtplus/snr_unit_recon_spat2_asym_pf/gtplus_snr_unit_recon_ref.h5
+reference_h5=gtplus/snr_unit_recon_spat2_asym_pf/gtplus_snr_unit_recon_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian_GFactor.xml

--- a/test/integration/cases/gtplus_snr_unit_recon_spat3.cfg
+++ b/test/integration/cases/gtplus_snr_unit_recon_spat3.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/snr_unit_recon_spat3/meas_MID00152_FID03206_GRE_reps=20_sPAT3_xRes256_dummy1_FOV240.dat
+siemens_dat=gtplus/snr_unit_recon_spat3/meas_MID00152_FID03206_GRE_reps=20_sPAT3_xRes256_dummy1_FOV240.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_snr_unit_recon_spat3.h5
 result_h5=gtplus_snr_unit_recon_spat3_out.h5
-reference_h5= data/gtplus/snr_unit_recon_spat3/gtplus_snr_unit_recon_ref.h5
+reference_h5=gtplus/snr_unit_recon_spat3/gtplus_snr_unit_recon_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian_GFactor.xml

--- a/test/integration/cases/gtplus_snr_unit_recon_tpat3.cfg
+++ b/test/integration/cases/gtplus_snr_unit_recon_tpat3.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gtplus/snr_unit_recon_tpat3/meas_MID00171_FID02908_GRE_reps=150_TPAT=3.dat
+siemens_dat=gtplus/snr_unit_recon_tpat3/meas_MID00171_FID02908_GRE_reps=150_TPAT=3.dat
 siemens_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=-1
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
-out_folder=test
 ismrmrd=gtplus_snr_unit_recon_tpat3.h5
 result_h5=gtplus_snr_unit_recon_tpat3_out.h5
-reference_h5= data/gtplus/snr_unit_recon_tpat3/gtplus_snr_unit_recon_ref.h5
+reference_h5=gtplus/snr_unit_recon_tpat3/gtplus_snr_unit_recon_ref.h5
 
 [TEST]
 gadgetron_configuration=GT_2DT_Cartesian_GFactor.xml

--- a/test/integration/cases/simple_gre.cfg
+++ b/test/integration/cases/simple_gre.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/simple_gre/meas_MiniGadgetron_GRE.dat
+siemens_dat=simple_gre/meas_MiniGadgetron_GRE.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=simple_gre.h5
 result_h5=simple_gre_out.h5
-reference_h5= data/simple_gre/simple_gre_out_20150110_msh.h5 
+reference_h5=simple_gre/simple_gre_out_20150110_msh.h5
 
 [TEST]
 gadgetron_configuration=default.xml

--- a/test/integration/cases/simple_gre_3d.cfg
+++ b/test/integration/cases/simple_gre_3d.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/gre_3d/meas_MID248_gre_FID30644.dat
+siemens_dat=gre_3d/meas_MID248_gre_FID30644.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=simple_gre_3d.h5
 result_h5=simple_gre_out_3d.h5
-reference_h5= data/gre_3d/simple_gre_out_3d_20150110_msh.h5
+reference_h5=gre_3d/simple_gre_out_3d_20150110_msh.h5
 
 [TEST]
 gadgetron_configuration=default_optimized.xml

--- a/test/integration/cases/simple_gre_python.cfg
+++ b/test/integration/cases/simple_gre_python.cfg
@@ -1,5 +1,5 @@
 [FILES]
-siemens_dat=data/simple_gre/meas_MiniGadgetron_GRE.dat
+siemens_dat=simple_gre/meas_MiniGadgetron_GRE.dat
 siemens_parameter_xml=IsmrmrdParameterMap.xml
 siemens_parameter_xsl=IsmrmrdParameterMap.xsl
 siemens_dependency_measurement1=0
@@ -8,10 +8,9 @@ siemens_dependency_measurement3=0
 siemens_dependency_parameter_xml=IsmrmrdParameterMap_Siemens.xml
 siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=0
-out_folder=test
 ismrmrd=simple_gre.h5
 result_h5=simple_gre_out.h5
-reference_h5= data/simple_gre/simple_gre_out.h5
+reference_h5=simple_gre/simple_gre_out.h5
 
 [TEST]
 gadgetron_configuration=python_short.xml

--- a/test/integration/run_all_tests.py
+++ b/test/integration/run_all_tests.py
@@ -1,4 +1,3 @@
-import ConfigParser
 import os
 import sys
 import glob
@@ -30,10 +29,8 @@ def main():
     for t in content:
         print("Grabbing test case: " + t)
 
-        # We need to figure out where this test dumps log files
-        config = ConfigParser.RawConfigParser()
-        config.read(t)
-        out_folder = config.get('FILES', 'out_folder')
+        # save this test's log files
+        out_folder = 'test'
         gadgetron_log_filename = os.path.join(pwd, out_folder, "gadgetron.log")
         client_log_filename = os.path.join(pwd, out_folder, "client.log")
 


### PR DESCRIPTION
Simply ensure `siemens_dat` is empty in the testcase config or just omit the `siemens_*` parameters from the config entirely.
The `ismrmrd` parameter will be used to find an ISMRMRD dataset in the `data/` directory, which will then be reconstructed as part of your test.