### PR TITLE
bug fix  and new features

### DIFF
--- a/apps/gadgetron/GadgetStreamController.cpp
+++ b/apps/gadgetron/GadgetStreamController.cpp
@@ -297,9 +297,9 @@ int GadgetStreamController::configure(std::string config_xml_string)
       classname = i->classname;
 
       GINFO("--Found writer declaration\n");
-      GINFO("  Reader dll: %s\n", dllname.c_str());
-      GINFO("  Reader class: %s\n", classname.c_str());
-      GINFO("  Reader slot: %d\n", slot);
+      GINFO("  Writer dll: %s\n", dllname.c_str());
+      GINFO("  Writer class: %s\n", classname.c_str());
+      GINFO("  Writer slot: %d\n", slot);
       
       GadgetMessageWriter* w =
 	load_dll_component<GadgetMessageWriter>(dllname.c_str(),

--- a/apps/gadgetron/GadgetStreamInterface.h
+++ b/apps/gadgetron/GadgetStreamInterface.h
@@ -110,7 +110,7 @@ namespace Gadgetron {
       ComponentCreator cc = reinterpret_cast<ComponentCreator> (tmp);
       
       if (cc == 0) {
-	GERROR("Failed to load factory (%s) from DLL (%s)\n", dllname, factoryname);
+	GERROR("Failed to load factory (%s) from DLL (%s)\n", factoryname, dllname);
 	return 0;
       }
       

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -41,7 +41,7 @@ namespace Gadgetron {
     if ( !boost::filesystem::exists(workingdirectory) )
       {
         boost::filesystem::path workingPath(workingdirectory);
-        if ( !boost::filesystem::create_directory(workingPath) )
+        if ( !boost::filesystem::create_directories(workingPath) )
 	  {
 	    GERROR("Error creating the working directory.\n");
 	    return false;

--- a/gadgets/dicom/DicomFinishGadget.h
+++ b/gadgets/dicom/DicomFinishGadget.h
@@ -70,6 +70,10 @@ namespace Gadgetron
 
         virtual int process_config(ACE_Message_Block * mb);
         virtual int process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1);
+        virtual int send_message(ACE_Message_Block *mb)
+        {
+            return this->controller_->output_ready(mb);
+        }
 
         template <typename T>
         int write_data_attrib(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1, GadgetContainerMessage< hoNDArray< T > >* m2)
@@ -398,7 +402,7 @@ namespace Gadgetron
                 mfilename->cont(m3);
             }
 
-            int ret = this->controller_->output_ready(mb);
+            int ret = this->send_message(mb);
 
             if ((ret < 0))
             {

--- a/toolboxes/log/log.cpp
+++ b/toolboxes/log/log.cpp
@@ -70,7 +70,6 @@ namespace Gadgetron
        if (newStdOut == NULL) {
          printf("Unable to redirect stdout to %s\n", log_file);
          fflush(stdout);
-         exit(EXIT_FAILURE);
        }
     }
   }

--- a/toolboxes/log/log.cpp
+++ b/toolboxes/log/log.cpp
@@ -61,6 +61,18 @@ namespace Gadgetron
       enableOutputOption(GADGETRON_LOG_PRINT_LEVEL);
       enableOutputOption(GADGETRON_LOG_PRINT_DATETIME);
     }
+
+    // Redirect stdout to a log file
+    char *log_file = getenv(GADGETRON_LOG_FILE_ENVIRONMENT);
+    if (log_file != NULL) {
+       fflush(stdout);
+       FILE *newStdOut = freopen(log_file, "a", stdout);
+       if (newStdOut == NULL) {
+         printf("Unable to redirect stdout to %s\n", log_file);
+         fflush(stdout);
+         exit(EXIT_FAILURE);
+       }
+    }
   }
 
 

--- a/toolboxes/log/log.h
+++ b/toolboxes/log/log.h
@@ -8,6 +8,7 @@
 #include <sstream> //For deprecated macros
 
 #define GADGETRON_LOG_MASK_ENVIRONMENT "GADGETRON_LOG_MASK"
+#define GADGETRON_LOG_FILE_ENVIRONMENT "GADGETRON_LOG_FILE"
 
 namespace Gadgetron
 {


### PR DESCRIPTION
PR includes four distinct commits:
1. Fixed incorrect log output messages.
2. Added ability to redirect stdout to file specified in environment variable GADGETRON_LOG_FILE. Redirection is done in construction of singleton GadgetronLogger, and no changes are made if GADGETRON_LOG_FILE does not exist in the calling environment. This features is particularly useful in daemonizing a gadgetron instance.
3. Switched to recursive directory creation for Gadgetron workingDirectory, in case the parent of a specified workingDirectory does not exist. Uses BOOST's recursive creating function instead of non-recursive function.
4. Modified DicomFinishGadget to separate message creation from message sending. This allows subclasses with customized sending functionality, e.g. direct storage to a C-STORE SCP.