### PR TITLE
Fixing usage of boost::filesystem::create_directories

### DIFF
--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -41,7 +41,11 @@ namespace Gadgetron {
     if ( !boost::filesystem::exists(workingdirectory) )
       {
         boost::filesystem::path workingPath(workingdirectory);
-        if ( !boost::filesystem::create_directories(workingPath) )
+        try
+          {
+            boost::filesystem::create_directories(workingPath);
+          }
+        catch (...)
 	  {
 	    GERROR("Error creating the working directory.\n");
 	    return false;


### PR DESCRIPTION
The usage of `boost::filesystem::create_directories` is incorrect in Gadgetron's
`main.cpp`. This function returns `true` if the directory was created and `false`
otherwise. Not creating the directory is not an error, however, e.g. if it already
exists. In the case of an actual error this function throws a `boost::filesystem_error`.

Without this fix, it doesn't appear to be possible to run successive instances
of the Gadgetron since the temporary directory is not "cleaned up".