### PR TITLE
further fix 3D recon for image orientation

### DIFF
--- a/gadgets/gtPlus/GtPlusReconGadget.cpp
+++ b/gadgets/gtPlus/GtPlusReconGadget.cpp
@@ -1114,7 +1114,7 @@ namespace Gadgetron
         // find the center partition
         if ( E2 > 1 )
         {
-            size_t midE2 = E2/2;
+            long long midE2 = E2/2;
             size_t offset = images->get_offset(slc, midE2, con, phs, rep, set, 0, ave);
 
             while ( std::abs(imageHeader.slice_dir[0])<1e-6 && std::abs(imageHeader.slice_dir[1])<1e-6 && std::abs(imageHeader.slice_dir[2])<1e-6 )
@@ -1140,9 +1140,10 @@ namespace Gadgetron
 
             // comput slice postion vector for this partition
             float posVecCurr[3];
-            posVecCurr[0] = (float)(posVec[0] + aSpacing_[2]*sliceVec[0]*(e2-midE2+0.5f));
-            posVecCurr[1] = (float)(posVec[1] + aSpacing_[2]*sliceVec[1]*(e2-midE2+0.5f));
-            posVecCurr[2] = (float)(posVec[2] + aSpacing_[2]*sliceVec[2]*(e2-midE2+0.5f));
+            float e2_offset = (float)e2 - (float)midE2 + 0.5f;
+            posVecCurr[0] = (float)(posVec[0] + aSpacing_[2] * sliceVec[0] * e2_offset);
+            posVecCurr[1] = (float)(posVec[1] + aSpacing_[2] * sliceVec[1] * e2_offset);
+            posVecCurr[2] = (float)(posVec[2] + aSpacing_[2] * sliceVec[2] * e2_offset);
 
             imageHeader.position[0] = posVecCurr[0];
             imageHeader.position[1] = posVecCurr[1];

--- a/gadgets/gtPlus/config/GT_3DT_Cartesian.xml
+++ b/gadgets/gtPlus/config/GT_3DT_Cartesian.xml
@@ -272,7 +272,7 @@
         -->
         <property>
             <name>coil_map_algorithm</name>
-            <value>ISMRMRD_SOUHEIL_ITER</value>
+            <value>ISMRMRD_SOUHEIL</value>
         </property>
         <property>
             <name>csm_kSize</name>
@@ -286,7 +286,7 @@
 
         <property>
             <name>csm_true_3D</name>
-            <value>false</value>
+            <value>true</value>
         </property>
 
         <property>

--- a/gadgets/gtPlus/config/GT_3DT_Cartesian_GFactor.xml
+++ b/gadgets/gtPlus/config/GT_3DT_Cartesian_GFactor.xml
@@ -284,7 +284,7 @@
         -->
         <property>
             <name>coil_map_algorithm</name>
-            <value>ISMRMRD_SOUHEIL_ITER</value>
+            <value>ISMRMRD_SOUHEIL</value>
         </property>
         <property>
             <name>csm_kSize</name>
@@ -298,7 +298,7 @@
 
         <property>
             <name>csm_true_3D</name>
-            <value>false</value>
+            <value>true</value>
         </property>
 
         <property>


### PR DESCRIPTION
Fix a bug in computing 3D slice orientation.

Since there are still problems with iterative coil map estimation, switch back to non-iterative version for now.

3D recon uses true 3D coil map estimation.