### PR TITLE
New Cloudbus with Relay

### DIFF
--- a/apps/gadgetron/gadgetron.xml.example
+++ b/apps/gadgetron/gadgetron.xml.example
@@ -6,8 +6,8 @@
   <port>9002</port>
 
   <cloudBus>
-    <multiCastAddress>224.2.2.9</multiCastAddress>
-    <port>4148</port>
+    <relayAddress>localhost</relayAddress>
+    <port>8002</port>
   </cloudBus>
   
 </gadgetronConfiguration>

--- a/apps/gadgetron/gadgetron_xml.cpp
+++ b/apps/gadgetron/gadgetron_xml.cpp
@@ -35,7 +35,7 @@ namespace GadgetronXML
     pugi::xml_node b = root.child("cloudBus");
     if (b) {
       CloudBus cb;
-      cb.multiCastAddress = b.child_value("multiCastAddress");
+      cb.relayAddress = b.child_value("relayAddress");
       cb.port = static_cast<unsigned int>(std::atoi(b.child_value("port")));
       h.cloudBus = cb;
     }

--- a/apps/gadgetron/gadgetron_xml.h
+++ b/apps/gadgetron/gadgetron_xml.h
@@ -75,7 +75,7 @@ namespace GadgetronXML
 
   struct CloudBus
   {
-    std::string multiCastAddress;
+    std::string relayAddress;
     unsigned int port;
   };
 

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -158,9 +158,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   if (c.cloudBus) {
     GINFO("Starting cloudBus: %s:%d\n", 
-	  c.cloudBus->multiCastAddress.c_str(), c.cloudBus->port);
-    Gadgetron::CloudBus::set_mcast_address(c.cloudBus->multiCastAddress.c_str());
-    Gadgetron::CloudBus::set_mcast_port(c.cloudBus->port);
+	  c.cloudBus->relayAddress.c_str(), c.cloudBus->port);
+    Gadgetron::CloudBus::set_relay_address(c.cloudBus->relayAddress.c_str());
+    Gadgetron::CloudBus::set_relay_port(c.cloudBus->port);
     Gadgetron::CloudBus::set_gadgetron_port(std::atoi(port_no));
     Gadgetron::CloudBus* cb = Gadgetron::CloudBus::instance();//This actually starts the bus.
     gadget_parameters["using_cloudbus"] = std::string("true"); //This is our message to the Gadgets that we have activated the bus

--- a/apps/gadgetron/schema/gadgetron.xsd
+++ b/apps/gadgetron/schema/gadgetron.xsd
@@ -27,7 +27,7 @@
 		<xs:element maxOccurs="1" minOccurs="0" name="cloudBus">
 		  <xs:complexType>
 		    <xs:sequence>
-		      <xs:element maxOccurs="1" minOccurs="1" name="multiCastAddress" type="xs:string"/>
+		      <xs:element maxOccurs="1" minOccurs="1" name="relayAddress" type="xs:string"/>
 		      <xs:element maxOccurs="1" minOccurs="1" name="port" type="xs:unsignedInt"/>
 		    </xs:sequence>
 		  </xs:complexType>

--- a/gadgets/gtPlus/GtPlusReconGadget.cpp
+++ b/gadgets/gtPlus/GtPlusReconGadget.cpp
@@ -496,7 +496,7 @@ namespace Gadgetron
 
         if (this->using_cloudbus.value() && has_cloud_node_xml_configuration) {
             std::vector<GadgetronNodeInfo> nodes;
-            CloudBus::instance()->get_node_info(nodes);
+            //CloudBus::instance()->get_node_info(nodes);
 
             if (nodes.size()>0)
             {

--- a/gadgets/gtPlus/GtPlusReconGadget.cpp
+++ b/gadgets/gtPlus/GtPlusReconGadget.cpp
@@ -496,7 +496,7 @@ namespace Gadgetron
 
         if (this->using_cloudbus.value() && has_cloud_node_xml_configuration) {
             std::vector<GadgetronNodeInfo> nodes;
-            //CloudBus::instance()->get_node_info(nodes);
+            CloudBus::instance()->get_node_info(nodes);
 
             if (nodes.size()>0)
             {

--- a/toolboxes/cloudbus/CMakeLists.txt
+++ b/toolboxes/cloudbus/CMakeLists.txt
@@ -24,8 +24,17 @@ target_link_libraries(gadgetron_cloudbus
 		     gadgetron_toolbox_log
                      optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} )
 
+add_executable(gadgetron_cloudbus_relay cloudbus_relay.cpp)
+
+target_link_libraries(gadgetron_cloudbus_relay 
+                     gadgetron_toolbox_cloudbus 
+		     gadgetron_toolbox_log
+                     optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} )
+
+
 install(TARGETS gadgetron_toolbox_cloudbus DESTINATION lib COMPONENT main)
 install(TARGETS gadgetron_cloudbus DESTINATION bin COMPONENT main)
+install(TARGETS gadgetron_cloudbus_relay DESTINATION bin COMPONENT main)
 
 install(FILES 
   CloudBus.h

--- a/toolboxes/cloudbus/CloudBus.cpp
+++ b/toolboxes/cloudbus/CloudBus.cpp
@@ -40,32 +40,169 @@ namespace Gadgetron
     gadgetron_port_ = port;
   }
 
-  /*
-  void CloudBus::get_node_info(std::vector<GadgetronNodeInfo>& nodes)
+  void CloudBus::set_compute_capability(uint32_t c)
+  {
+    node_info_.compute_capability = c;
+  }
+
+
+  int CloudBus::open(void*)
+  {
+    if (!this->reactor()) {
+      this->reactor(ACE_Reactor::instance());
+    }
+    return this->activate( THR_NEW_LWP | THR_JOINABLE,1); //single thread
+  }
+
+  
+
+  int CloudBus::handle_close (ACE_HANDLE handle, ACE_Reactor_Mask close_mask)
+  {
+    GDEBUG("Cloud bus connection closed\n");
+    this->peer().close();
+    connected_ = false;
+    return 0;
+  }
+
+  int CloudBus::handle_input (ACE_HANDLE fd)
+  {
+    size_t recv_cnt;
+    uint32_t msg_size;
+    if ((recv_cnt = peer().recv_n (&msg_size, sizeof(uint32_t))) <= 0) {
+      GDEBUG("Failed to get msg_size from relay. Relay must have disconnected\n");
+      return -1;
+    }
+    char* buffer = new char[msg_size];
+    nodes_.clear();
+    if ((recv_cnt = peer().recv_n (buffer, msg_size)) <= 0) {
+      GDEBUG("Failed to read message from relay. Relay must have disconnected\n");
+      delete [] buffer;
+      return -1;
+    }
+      
+    uint32_t msg_id = *((uint32_t*)buffer);
+    if (msg_id != GADGETRON_CLOUDBUS_NODE_LIST_REPLY) {
+      GERROR("Unexpected message id = %d\n", msg_id);
+      return -1;
+    }
+    deserialize(nodes_, buffer+4, msg_size-4);
+    delete [] buffer;
+    node_list_condition_.signal();
+    return 0;
+  }
+
+  
+  int CloudBus::svc(void)
+  {
+    
+    while (true) {
+      if (connected_) {
+	//
+      } else {
+	std::string connect_addr(relay_inet_addr_);
+	if (connect_addr == "localhost") {
+	  connect_addr = node_info_.address;
+	}
+	ACE_INET_Addr server(relay_port_,connect_addr.c_str());
+	ACE_SOCK_Connector connector;
+
+	if (connector.connect(this->peer(),server) == 0) {
+	  ACE_TCHAR peer_name[MAXHOSTNAMELENGTH];
+	  ACE_INET_Addr peer_addr;
+	  if ((this->peer().get_remote_addr (peer_addr) == 0) && 
+	      (peer_addr.addr_to_string (peer_name, MAXHOSTNAMELENGTH) == 0)) {
+
+	    GDEBUG("CloudBus connected to relay at  %s\n", peer_name);
+	    if (this->reactor ()->register_handler(this, ACE_Event_Handler::READ_MASK) != 0) {
+	      GERROR("Failed to register read handler\n");
+	      return -1;
+	    }
+
+	    mtx_.acquire();
+	    connected_ = true;
+	    mtx_.release();
+	    if (!query_mode_) {
+	      send_node_info();
+	    }
+	  } 
+	}
+      }
+      //Sleep for 5 seconds
+      ACE_Time_Value tv (5);
+      ACE_OS::sleep (tv);	  	
+    }
+    return 0;
+  }
+
+  void CloudBus::send_node_info()
+  {
+    size_t buf_len = calculate_node_info_length(node_info_);
+    try {
+      char* buffer = new char[4+4+buf_len];
+      *((uint32_t*)buffer) = buf_len+4;
+      *((uint32_t*)(buffer + 4)) = GADGETRON_CLOUDBUS_NODE_INFO;
+      if (connected_) {
+	serialize(node_info_,buffer + 8,buf_len);
+	this->peer().send_n(buffer,buf_len+8);
+      }
+      delete [] buffer;
+    } catch (...) {
+      GERROR("Failed to send gadgetron node info\n");
+      throw;
+    }
+    print_nodes();
+  }
+
+  void CloudBus::update_node_info()
   {
     mtx_.acquire();
-    nodes.clear();
-    for (map_type_::iterator it = nodes_.begin(); it != nodes_.end(); ++it) {
-      GadgetronNodeInfo n = it->second.first;
-      nodes.push_back(n);
+    if (connected_) {
+      uint32_t req[2];
+      req[0] = 4;
+      req[1] = GADGETRON_CLOUDBUS_NODE_LIST_QUERY;
+
+      this->peer().send_n((char*)(&req),8);
+      node_list_condition_.wait();
     }
+    mtx_.release();
+  }
+  
+  void CloudBus::print_nodes()
+  {
+    std::vector<GadgetronNodeInfo> nl;
+    get_node_info(nl);
+    GDEBUG("Number of available nodes: %d\n", nl.size());
+    for (std::vector<GadgetronNodeInfo>::iterator it = nl.begin();
+	 it != nl.end(); it++)
+      {
+	GDEBUG("  %s, %s, %d\n", it->uuid.c_str(), it->address.c_str(), it->port);
+      }
+  }
+  
+  void CloudBus::get_node_info(std::vector<GadgetronNodeInfo>& nodes)
+  {
+    update_node_info();
+    mtx_.acquire();
+    nodes = nodes_;
     mtx_.release();
   }
   
   size_t CloudBus::get_number_of_nodes()
   {
-    size_t n = 0;
+    update_node_info();
+    size_t nodes;
     mtx_.acquire();
-    n = nodes_.size();
+    nodes = nodes_.size();
     mtx_.release();
-    return n;
+    return nodes;
   }
-  */
 
   CloudBus::CloudBus(int port, const char* addr)
     : mtx_("CLOUDBUSMTX")
+    , mtx_node_list_("CLOUDBUSMTXNODELIST")
+    , node_list_condition_(mtx_node_list_)
     , uuid_(boost::uuids::random_generator()())
-    , connected_(false)
+    , connected_(false)      
   {
     node_info_.port = gadgetron_port_;
     set_compute_capability(1);

--- a/toolboxes/cloudbus/CloudBus.cpp
+++ b/toolboxes/cloudbus/CloudBus.cpp
@@ -4,155 +4,30 @@
 namespace Gadgetron
 {
   CloudBus* CloudBus::instance_ = 0;
-  const char* CloudBus::mcast_inet_addr_ = GADGETRON_DEFAULT_MULTICAST_ADDR;
-  int CloudBus::mcast_port_ = GADGETRON_DEFAULT_MULTICAST_PORT;
+  const char* CloudBus::relay_inet_addr_ = GADGETRON_DEFAULT_RELAY_ADDR;
+  int CloudBus::relay_port_ = GADGETRON_DEFAULT_RELAY_PORT;
   bool CloudBus::query_mode_ = false; //Listen only is disabled default
   int CloudBus::gadgetron_port_ = 9002; //Default port
-
-  CloudBusTask::CloudBusTask(int port, const char* addr)
-    : inherited()
-    , mcast_addr_(port, addr)
-    , mcast_dgram_(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO)
-  {
-  }
-
-  CloudBusTask::CloudBusTask()
-    : inherited()
-    , mcast_addr_(GADGETRON_DEFAULT_MULTICAST_PORT, GADGETRON_DEFAULT_MULTICAST_ADDR)
-    , mcast_dgram_(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO)
-  {
-  }
-    
-  int CloudBusTask::open(void*)
-  {
-    return this->activate( THR_NEW_LWP | THR_JOINABLE,1); //single thread
-  }
-
-  CloudBusReceiverTask::CloudBusReceiverTask(int port, const char* addr)
-    : CloudBusTask(port, addr)
-  {
-    
-  }
-
-  int CloudBusReceiverTask::open(void*)
-  {
-
-#if defined(__linux) || defined(__linux__) || defined(linux)
-    //On linux we will loop through all names interfaces and join as many as we can
-    struct if_nameindex *intf;
-    intf = if_nameindex ();
-    if (intf == 0) {
-      GERROR("Unable to get names of network interfaces\n");
-      return -1;
-    }
-    
-    int ifs_joined = 0;
-    int index = 0;
-    while (intf[index].if_index != 0 || intf[index].if_name != 0) {
-      if (mcast_dgram_.join(mcast_addr_,1,intf[index].if_name) != -1) {
-	++ifs_joined;
-      }
-      ++index;
-    }      
-    if_freenameindex (intf);
-
-    if (!ifs_joined) {
-      GERROR_STREAM("Error doing dgram join");
-      return -1;
-    }
-#else
-    if (mcast_dgram_.join(mcast_addr_) == -1) {
-      GERROR_STREAM("Error doing dgram join");
-      return -1;
-    }
-#endif
-
-    return CloudBusTask::open();      
-  }
-
-  int CloudBusReceiverTask::close(u_long flags)
-  {
-    mcast_dgram_.leave(mcast_addr_);
-    return CloudBusTask::close(flags);
-  }
-
-  int CloudBusReceiverTask::svc(void)
-  {
-    char buffer[GADGETRON_NODE_INFO_MESSAGE_LENGTH]; //Size of message
-    GadgetronNodeInfo info;
-    ACE_INET_Addr peer_address;
-    while (mcast_dgram_.recv(buffer, GADGETRON_NODE_INFO_MESSAGE_LENGTH, peer_address) != -1)
-      {
-	info.uuid = boost::uuids::to_string(*((boost::uuids::uuid*)buffer));
-	info.address = std::string(peer_address.get_host_addr());
-	memcpy(&info.port              , buffer + 16,                    sizeof(uint32_t));
-	memcpy(&info.compute_capability, buffer + 16 + sizeof(uint32_t), sizeof(uint32_t));
-	CloudBus::instance()->update_node(info.uuid.c_str(), info);
-      }
-
-    return 0;
-  }
-
-  CloudBusSenderTask::CloudBusSenderTask(int port, const char* addr)
-    : CloudBusTask(port, addr)
-  {
-    
-  }
-
-  int CloudBusSenderTask::open(void*)
-  {
-    if (mcast_dgram_.open(mcast_addr_) == -1) {
-      GDEBUG_STREAM("Error doing dgram open");
-      return -1;
-    }
-    return CloudBusTask::open();      
-  }
-
-  int CloudBusSenderTask::svc(void)
-  {
-    char buffer[GADGETRON_NODE_INFO_MESSAGE_LENGTH]; //Size of message
-    if (CloudBus::instance()->uuid_.size() != 16) {
-      GDEBUG_STREAM("Severe problem, UUID is != 16");
-      GDEBUG_STREAM("uuid: " << CloudBus::instance()->uuid_ << "(" << CloudBus::instance()->uuid_.size() << ")");
-    }
-    
-    memcpy(buffer                        ,  CloudBus::instance()->uuid_.begin(), 16);
-    memcpy(buffer + 16,                    &CloudBus::instance()->node_info_.port, sizeof(uint32_t));
-    memcpy(buffer + 16 + sizeof(uint32_t), &CloudBus::instance()->node_info_.compute_capability, sizeof(uint32_t));
-    
-    while (true) {
-      if (!CloudBus::instance()->query_mode_) {
-	if (mcast_dgram_.send(buffer, GADGETRON_NODE_INFO_MESSAGE_LENGTH) == -1) {
-	  GDEBUG_STREAM("Failed to send dgram data");
-	}
-      }
-      CloudBus::instance()->remove_stale_nodes();
-      ACE_OS::sleep(5);//Sleep for 5 seconds
-    }
-
-    return 0;
-  }
 
   CloudBus* CloudBus::instance()
   {
     if (!instance_)
       {
-	instance_ = new CloudBus(mcast_port_, mcast_inet_addr_);
-	instance_->receiver_.open();
-	instance_->sender_.open();
+	instance_ = new CloudBus(relay_port_, relay_inet_addr_);
+	instance_->open();
       }
     return instance_;
   }
 
   
-  void CloudBus::set_mcast_address(const char* addr)
+  void CloudBus::set_relay_address(const char* addr)
   {
-    mcast_inet_addr_ = addr;
+    relay_inet_addr_ = addr;
   }
 
-  void CloudBus::set_mcast_port(int port)
+  void CloudBus::set_relay_port(int port)
   {
-    mcast_port_ = port;
+    relay_port_ = port;
   }
 
   void CloudBus::set_query_only(bool m)
@@ -165,13 +40,7 @@ namespace Gadgetron
     gadgetron_port_ = port;
   }
 
-  void CloudBus::wait()
-  {
-    sender_.wait();
-    receiver_.wait();
-    receiver_.close();
-  }
-
+  /*
   void CloudBus::get_node_info(std::vector<GadgetronNodeInfo>& nodes)
   {
     mtx_.acquire();
@@ -191,12 +60,12 @@ namespace Gadgetron
     mtx_.release();
     return n;
   }
+  */
 
   CloudBus::CloudBus(int port, const char* addr)
-    : receiver_(port, addr)
-    , sender_(port, addr)
-    , mtx_("CLOUDBUSMTX")
+    : mtx_("CLOUDBUSMTX")
     , uuid_(boost::uuids::random_generator()())
+    , connected_(false)
   {
     node_info_.port = gadgetron_port_;
     set_compute_capability(1);
@@ -207,42 +76,4 @@ namespace Gadgetron
     node_info_.address = std::string(local_addr.get_host_name());
   }
 
-  void CloudBus::update_node(const char* a, GadgetronNodeInfo& info)
-  {
-    mtx_.acquire();
-    std::string key(a);
-    map_type_::iterator it = nodes_.find(key);
-    if (it == nodes_.end()) {
-      if (info.uuid != node_info_.uuid) { //Reject stuff coming from myself
-	GDEBUG_STREAM("---->>>> New Cloud Node <<<<< ----- " << info.uuid << " (" << info.address << ":" << info.port << ", " << info.compute_capability << ")");
-      } 
-    } 
-
-    if (info.uuid != node_info_.uuid) {
-      nodes_[key] = std::pair<GadgetronNodeInfo,time_t>(info,time(NULL));
-    }
-    mtx_.release();
-  }
-
-  void CloudBus::remove_stale_nodes()
-  {
-    mtx_.acquire();
-    map_type_ new_nodes_;
-    time_t now = time(NULL);
-    for (map_type_::iterator it = nodes_.begin(); it != nodes_.end(); ++it) {
-      if (fabs(difftime(it->second.second,now)) > 30) {
-        GadgetronNodeInfo n = it->second.first;
-        GDEBUG_STREAM("---->>>> DELETING STALE CLOUD NODE <<<<< ----- " << n.uuid << " (" << n.address << ":" << n.port  << ", " << n.compute_capability << ")");
-      }
-      else
-      {
-        new_nodes_[it->first] = it->second;
-      }
-    }
-
-    nodes_.clear();
-    nodes_ = new_nodes_;
-
-    mtx_.release();
-  }
 }

--- a/toolboxes/cloudbus/CloudBus.h
+++ b/toolboxes/cloudbus/CloudBus.h
@@ -4,9 +4,13 @@
 #include "cloudbus_export.h"
 #include <ace/Task.h>
 #include <ace/INET_Addr.h>
-#include <ace/SOCK_Dgram_Mcast.h>
 #include <ace/OS_NS_unistd.h>
+#include <ace/SOCK_Connector.h>
+#include <ace/SOCK_Stream.h>
 #include <ace/SOCK_Acceptor.h>
+#include <ace/Svc_Handler.h>
+
+#include "log.h"
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -18,9 +22,11 @@
 #include <time.h>
 #include <vector>
 
-#define GADGETRON_DEFAULT_MULTICAST_ADDR "224.9.9.2"
-#define GADGETRON_DEFAULT_MULTICAST_PORT 4148
+#define GADGETRON_DEFAULT_RELAY_ADDR "localhost"
+#define GADGETRON_DEFAULT_RELAY_PORT 8002
 #define GADGETRON_NODE_INFO_MESSAGE_LENGTH 16+sizeof(uint32_t)*2 //16 bytes for uuid + 2 ints
+
+#define MAXHOSTNAMELENGTH 1024
 
 namespace Gadgetron
 {
@@ -33,48 +39,66 @@ namespace Gadgetron
     uint32_t compute_capability;
   };
   
-  class CloudBusTask : public ACE_Task<ACE_MT_SYNCH>
+
+  class EXPORTCLOUDBUS CloudBus : public ACE_Svc_Handler<ACE_SOCK_STREAM, ACE_MT_SYNCH>
   {
   public:
     typedef ACE_Task<ACE_MT_SYNCH> inherited;    
-    CloudBusTask(int port, const char* addr);
-    CloudBusTask();
-    virtual int open(void* = 0);
+    virtual int open(void* = 0)
+    {
+      if (!this->reactor()) {
+	this->reactor(ACE_Reactor::instance());
+      }
+      return this->activate( THR_NEW_LWP | THR_JOINABLE,1); //single thread
+    }
 
-  protected:
-    ACE_SOCK_Dgram_Mcast mcast_dgram_;
-    ACE_INET_Addr mcast_addr_;
-  };
+    virtual int handle_close (ACE_HANDLE handle, ACE_Reactor_Mask close_mask)
+    {
+      GDEBUG("Cloud bus connection closed\n");
+      this->peer().close();
+      connected_ = false;
+      return 0;
+    }
 
-  class CloudBusReceiverTask : public CloudBusTask
-  {
-  public:
-    CloudBusReceiverTask(int port, const char* addr);
-    virtual int open(void* = 0);
-    virtual int close(u_long flags = 0);
-    virtual int svc(void);
-  };
+    virtual int svc(void)
+    {
+      
+      while (true) {
+	if (connected_) {
+	  //
+	} else {
+	  std::string connect_addr(relay_inet_addr_);
+	  if (connect_addr == "localhost") {
+	    connect_addr = node_info_.address;
+	  }
+	  ACE_INET_Addr server(relay_port_,connect_addr.c_str());
+	  ACE_SOCK_Connector connector;
 
+	  if (connector.connect(this->peer(),server) == 0) {
+	    ACE_TCHAR peer_name[MAXHOSTNAMELENGTH];
+	    ACE_INET_Addr peer_addr;
+	    if ((this->peer().get_remote_addr (peer_addr) == 0) && 
+		(peer_addr.addr_to_string (peer_name, MAXHOSTNAMELENGTH) == 0)) {
 
-  class CloudBusSenderTask : public CloudBusTask
-  {
-  public:
-    CloudBusSenderTask(int port, const char* addr);
-    virtual int open(void* = 0);
-    virtual int svc(void);
-  };
+	      GDEBUG("Connected to %s\n", peer_name);
+	      if (this->reactor ()->register_handler(this, ACE_Event_Handler::READ_MASK) != 0) {
+		GERROR("Failed to register read handler\n");
+		return -1;
+	      }
+	      connected_ = true;
+	    } 
+	  }
+	}
+	//Sleep for 5 seconds
+	ACE_Time_Value tv (5);
+	ACE_OS::sleep (tv);	  	
+      }
+      return 0;
+    }
 
-  class EXPORTCLOUDBUS CloudBus
-  {
-    friend class CloudBusReceiverTask;
-    friend class CloudBusSenderTask;
-
-    typedef std::map<std::string, std::pair<GadgetronNodeInfo, time_t> > map_type_;
-
-  public:
     static CloudBus* instance();
-    static void set_mcast_address(const char* addr);
-    static void set_mcast_port(int port);
+    static void set_relay_address(const char* addr);
+    static void set_relay_port(int port);
     static void set_query_only(bool m = true);
     static void set_gadgetron_port(uint32_t port);
 
@@ -83,32 +107,28 @@ namespace Gadgetron
       node_info_.compute_capability = c;
     }
 
-    void wait();
 
-    void get_node_info(std::vector<GadgetronNodeInfo>& nodes);
-    size_t get_number_of_nodes();
+    //void get_node_info(std::vector<GadgetronNodeInfo>& nodes);
+    //size_t get_number_of_nodes();
 
   protected:
     ///Protected constructor. 
     CloudBus(int port, const char* addr);
+    CloudBus(); 
 
-    void update_node(const char* a, GadgetronNodeInfo& info);
-    void remove_stale_nodes();
-    
     static CloudBus* instance_;
-    static const char* mcast_inet_addr_;
-    static int mcast_port_;
+    static const char* relay_inet_addr_;
+    static int relay_port_;
     static bool query_mode_; //Listen only
     static int gadgetron_port_;
 
     GadgetronNodeInfo node_info_;
-    map_type_ nodes_;
     
-    CloudBusReceiverTask receiver_;
-    CloudBusSenderTask   sender_;
     ACE_Thread_Mutex mtx_;
 
     boost::uuids::uuid uuid_;
+    bool connected_;
+    ACE_SOCK_Stream socket_;
   };
 
 

--- a/toolboxes/cloudbus/CloudBus.h
+++ b/toolboxes/cloudbus/CloudBus.h
@@ -24,7 +24,6 @@
 
 #define GADGETRON_DEFAULT_RELAY_ADDR "localhost"
 #define GADGETRON_DEFAULT_RELAY_PORT 8002
-#define GADGETRON_NODE_INFO_MESSAGE_LENGTH 16+sizeof(uint32_t)*2 //16 bytes for uuid + 2 ints
 #define MAXHOSTNAMELENGTH 1024
 
 #include "cloudbus_io.h"
@@ -35,92 +34,27 @@ namespace Gadgetron
   class EXPORTCLOUDBUS CloudBus : public ACE_Svc_Handler<ACE_SOCK_STREAM, ACE_MT_SYNCH>
   {
   public:
-    typedef ACE_Task<ACE_MT_SYNCH> inherited;    
-    virtual int open(void* = 0)
-    {
-      if (!this->reactor()) {
-	this->reactor(ACE_Reactor::instance());
-      }
-      return this->activate( THR_NEW_LWP | THR_JOINABLE,1); //single thread
-    }
+    typedef ACE_Task<ACE_MT_SYNCH> inherited;
 
-    virtual int handle_close (ACE_HANDLE handle, ACE_Reactor_Mask close_mask)
-    {
-      GDEBUG("Cloud bus connection closed\n");
-      this->peer().close();
-      connected_ = false;
-      return 0;
-    }
+    virtual int open(void* = 0);
+    virtual int handle_close (ACE_HANDLE handle, ACE_Reactor_Mask close_mask);
 
-    virtual int svc(void)
-    {
-      
-      while (true) {
-	if (connected_) {
-	  //
-	} else {
-	  std::string connect_addr(relay_inet_addr_);
-	  if (connect_addr == "localhost") {
-	    connect_addr = node_info_.address;
-	  }
-	  ACE_INET_Addr server(relay_port_,connect_addr.c_str());
-	  ACE_SOCK_Connector connector;
-
-	  if (connector.connect(this->peer(),server) == 0) {
-	    ACE_TCHAR peer_name[MAXHOSTNAMELENGTH];
-	    ACE_INET_Addr peer_addr;
-	    if ((this->peer().get_remote_addr (peer_addr) == 0) && 
-		(peer_addr.addr_to_string (peer_name, MAXHOSTNAMELENGTH) == 0)) {
-
-	      GDEBUG("Connected to %s\n", peer_name);
-	      if (this->reactor ()->register_handler(this, ACE_Event_Handler::READ_MASK) != 0) {
-		GERROR("Failed to register read handler\n");
-		return -1;
-	      }
-	      connected_ = true;
-	      send_node_info();
-	    } 
-	  }
-	}
-	//Sleep for 5 seconds
-	ACE_Time_Value tv (5);
-	ACE_OS::sleep (tv);	  	
-      }
-      return 0;
-    }
+    virtual int handle_input (ACE_HANDLE fd = ACE_INVALID_HANDLE);
+    virtual int svc(void);
 
     static CloudBus* instance();
     static void set_relay_address(const char* addr);
     static void set_relay_port(int port);
     static void set_query_only(bool m = true);
     static void set_gadgetron_port(uint32_t port);
+    void set_compute_capability(uint32_t c);
 
-    void set_compute_capability(uint32_t c)
-    {
-      node_info_.compute_capability = c;
-    }
-
-    void send_node_info()
-    {
-      size_t buf_len = calculate_node_info_length(node_info_);
-      try {
-	char* buffer = new char[4+4+buf_len];
-	*((uint32_t*)buffer) = buf_len+4;
-	*((uint32_t*)buffer + 4) = GADGETRON_CLOUDBUS_NODE_INFO;
-	if (connected_) {
-	  serialize(node_info_,buffer + 8,buf_len);
-	  this->peer().send_n(buffer,buf_len+8);
-	}
-	delete [] buffer;
-      } catch (...) {
-	GERROR("Failed to send gadgetron node info\n");
-	throw;
-      }
-    }
-
-    //void get_node_info(std::vector<GadgetronNodeInfo>& nodes);
-    //size_t get_number_of_nodes();
-
+    void send_node_info();    
+    void update_node_info();
+    void get_node_info(std::vector<GadgetronNodeInfo>& nodes);
+    void print_nodes();
+    size_t get_number_of_nodes();
+    
   protected:
     ///Protected constructor. 
     CloudBus(int port, const char* addr);
@@ -133,15 +67,16 @@ namespace Gadgetron
     static int gadgetron_port_;
 
     GadgetronNodeInfo node_info_;
+    std::vector<GadgetronNodeInfo> nodes_;
     
     ACE_Thread_Mutex mtx_;
-
+    ACE_Thread_Mutex mtx_node_list_;
+    ACE_Condition<ACE_Thread_Mutex> node_list_condition_;
+    
     boost::uuids::uuid uuid_;
     bool connected_;
     ACE_SOCK_Stream socket_;
   };
-
-
 }
 
 #endif

--- a/toolboxes/cloudbus/cloudbus_io.h
+++ b/toolboxes/cloudbus/cloudbus_io.h
@@ -1,0 +1,124 @@
+#ifndef CLOUDBUS_IO_H
+#define CLOUDBUS_IO_H
+
+#include <exception>
+#include <cstring>
+#include <vector>
+
+namespace Gadgetron
+{
+  enum CLOUDBUS_MESSAGE_TYPE
+  {
+    GADGETRON_CLOUDBUS_MESSAGE_MIN = 0,
+    GADGETRON_CLOUDBUS_NODE_INFO = 1,
+    GADGETRON_CLOUDBUS_NODE_LIST_QUERY = 2,
+    GADGETRON_CLOUDBUS_NODE_LIST_REPLY = 3,
+    GADGETRON_CLOUDBUS_MESSAGE_MAX
+  };
+  
+  struct GadgetronNodeInfo
+  {
+    std::string uuid;
+    std::string address;
+    uint32_t port;
+    uint32_t compute_capability;
+  };
+
+  size_t calculate_node_info_length(GadgetronNodeInfo& n)
+  {
+    size_t len = 0;
+    len += 4 + n.uuid.size();
+    len += 4 + n.address.size();
+    len += 8;
+    return len;
+  }
+  
+  size_t serialize(GadgetronNodeInfo& n, char* buffer, size_t buf_len)
+  {
+    size_t pos = 0;
+    
+    if (buf_len < calculate_node_info_length(n)) {
+      throw std::runtime_error("Provided buffer is too short for serialization");
+    }
+    
+    *((uint32_t*)(buffer + pos)) = n.uuid.size(); pos += 4;
+    memcpy ((buffer+pos), n.uuid.c_str(), n.uuid.size() ); pos += n.uuid.size();
+
+    *((uint32_t*)(buffer + pos)) = n.address.size(); pos += 4;
+    memcpy ((buffer+pos), n.address.c_str(), n.address.size() ); pos += n.address.size();
+
+    *((uint32_t*)(buffer + pos)) = n.port; pos += 4;
+    *((uint32_t*)(buffer + pos)) = n.compute_capability; pos += 4;
+    
+    return pos;
+  }
+
+  size_t deserialize(GadgetronNodeInfo& n, char* buffer, size_t buf_len)
+  {
+    size_t pos = 0;
+    
+    if (buf_len < 16) throw std::runtime_error("Provided buffer is too small to hold node info");
+
+    size_t uuid_size = *((uint32_t*)(buffer+pos)); pos += 4;
+    n.uuid = std::string(buffer+pos,uuid_size); pos += uuid_size;
+
+    size_t address_size = *((uint32_t*)(buffer+pos)); pos += 4;
+    n.address = std::string(buffer+pos,address_size); pos += address_size;
+
+    n.port = *((uint32_t*)(buffer+pos)); pos += 4;
+    n.compute_capability = *((uint32_t*)(buffer+pos)); pos += 4;
+
+    return pos;
+  }
+
+
+  size_t calculate_node_info_list_length(std::vector<GadgetronNodeInfo>& nl)
+  {
+    size_t length = 0;
+    for (std::vector<GadgetronNodeInfo>::iterator it = nl.begin();
+	 it != nl.end(); it++)
+      {
+	length += calculate_node_info_length(*it);
+      }
+    return length;
+  }
+  
+  size_t serialize(std::vector<GadgetronNodeInfo>& nl, char* buffer, size_t buf_len)
+  {
+    size_t serialized_length = calculate_node_info_list_length(nl);
+    if ((serialized_length+4) > buf_len) throw std::runtime_error("Buffer too short for serializing node info list");
+
+    *((uint32_t*)buffer) = nl.size();
+
+    size_t pos = 4;
+
+    for (std::vector<GadgetronNodeInfo>::iterator it = nl.begin();
+	 it != nl.end(); it++)
+      {
+	pos += serialize(*it,buffer+pos,buf_len-pos);
+      }
+
+    return pos;
+  }
+
+
+  size_t deserialize(std::vector<GadgetronNodeInfo>& nl, char* buffer, size_t buf_len)
+  {
+    nl.clear();
+    size_t pos = 0;
+
+    uint32_t num_nodes = *((uint32_t*)buffer);
+    pos += 4;
+    
+    for (unsigned int i = 0; i < num_nodes; i++) {
+      GadgetronNodeInfo n;
+      pos += deserialize(n,buffer+pos,buf_len-pos);
+      nl.push_back(n);
+    }
+    
+    return pos;
+  }
+
+}
+
+#endif

--- a/toolboxes/cloudbus/cloudbus_main.cpp
+++ b/toolboxes/cloudbus/cloudbus_main.cpp
@@ -7,8 +7,8 @@ int main(int argc, char** argv)
 {
   GDEBUG_STREAM("CloudBus Main Program" << std::endl);
 
-  int port = GADGETRON_DEFAULT_MULTICAST_PORT;
-  const char* addr = GADGETRON_DEFAULT_MULTICAST_ADDR;
+  int port = GADGETRON_DEFAULT_RELAY_PORT;
+  const char* addr = GADGETRON_DEFAULT_RELAY_ADDR;
   bool query_only_mode = true;
 
   if (argc > 1) {
@@ -27,8 +27,8 @@ int main(int argc, char** argv)
   }
 
   //Port and address must be set before grabbing the instance for the first time. 
-  Gadgetron::CloudBus::set_mcast_address(addr);
-  Gadgetron::CloudBus::set_mcast_port(port);
+  Gadgetron::CloudBus::set_relay_address(addr);
+  Gadgetron::CloudBus::set_relay_port(port);
   Gadgetron::CloudBus::set_query_only(query_only_mode);
   Gadgetron::CloudBus* cb = Gadgetron::CloudBus::instance();
   cb->wait();

--- a/toolboxes/cloudbus/cloudbus_relay.cpp
+++ b/toolboxes/cloudbus/cloudbus_relay.cpp
@@ -6,6 +6,7 @@
 #include "ace/Stream.h"
 
 #include "log.h"
+#include "cloudbus_io.h"
 
 namespace Gadgetron{
 
@@ -55,6 +56,17 @@ namespace Gadgetron{
 	delete [] buffer;
 	return -1;
       }
+
+      uint32_t msg_id = *((uint32_t*)buffer);
+      GadgetronNodeInfo n;
+      switch (msg_id) {
+      case (GADGETRON_CLOUDBUS_NODE_INFO):
+	deserialize(n,buffer+4,msg_size-4);
+	GDEBUG("Received node information from: %s,%s,%d\n", n.uuid.c_str(), n.address.c_str(), n.port);
+	break;
+      default:
+	GERROR("Unknow message ID = %d\n", msg_id);
+      }
       
       GDEBUG("Received message of size: %d\n", msg_size);
       delete [] buffer;
@@ -76,6 +88,8 @@ namespace Gadgetron{
 	ACE_Event_Handler::DONT_CALL;
   
       this->reactor ()->remove_handler (this, mask);
+
+      return 0;
     }
     
     virtual int output_ready(ACE_Message_Block* mb) 

--- a/toolboxes/cloudbus/cloudbus_relay.cpp
+++ b/toolboxes/cloudbus/cloudbus_relay.cpp
@@ -1,0 +1,175 @@
+#include "ace/Reactor.h"
+#include "ace/SOCK_Acceptor.h"
+#include "ace/Svc_Handler.h"
+#include "ace/SOCK_Stream.h"
+#include "ace/Reactor_Notification_Strategy.h"
+#include "ace/Stream.h"
+
+#include "log.h"
+
+namespace Gadgetron{
+
+  class CloudBusNodeController 
+    : public ACE_Svc_Handler<ACE_SOCK_STREAM, ACE_MT_SYNCH>
+  {
+  public:
+    CloudBusNodeController()
+      : notifier_ (0, this, ACE_Event_Handler::WRITE_MASK)
+    {
+    }
+    
+    virtual ~CloudBusNodeController()
+    { 
+    }
+    
+    virtual int open (void) {
+      this->notifier_.reactor (this->reactor ());
+      this->msg_queue ()->notification_strategy (&this->notifier_);
+
+      ACE_TCHAR peer_name[MAXHOSTNAMELEN];
+      ACE_INET_Addr peer_addr;
+      if (peer().get_remote_addr (peer_addr) == 0 &&
+	  peer_addr.addr_to_string (peer_name, MAXHOSTNAMELEN) == 0) {
+	GINFO("Connection from %s\n", peer_name);
+      }
+
+
+      return this->reactor ()->register_handler(this,
+						ACE_Event_Handler::READ_MASK);// | ACE_Event_Handler::WRITE_MASK);
+
+    }
+
+    virtual int handle_input (ACE_HANDLE fd = ACE_INVALID_HANDLE)
+    {
+      uint32_t msg_size;
+      size_t recv_cnt;
+      if ((recv_cnt = peer().recv_n (&msg_size, sizeof(uint32_t))) <= 0) {
+	GERROR("Unable to read message message size\n");
+	return -1;
+      }
+
+      char* buffer = new char[msg_size];
+      
+      if ((recv_cnt = peer().recv_n (buffer, msg_size)) <= 0) {
+	GERROR("Unable to read message\n");
+	delete [] buffer;
+	return -1;
+      }
+      
+      GDEBUG("Received message of size: %d\n", msg_size);
+      delete [] buffer;
+
+      return 0;
+    }
+
+    virtual int handle_close (ACE_HANDLE handle,
+			      ACE_Reactor_Mask mask)
+    {
+      GDEBUG("Cloud bus connection closed\n");
+      
+      if (mask == ACE_Event_Handler::WRITE_MASK)
+	return 0;
+      
+      this->stream_.close();
+      
+      mask = ACE_Event_Handler::ALL_EVENTS_MASK |
+	ACE_Event_Handler::DONT_CALL;
+  
+      this->reactor ()->remove_handler (this, mask);
+    }
+    
+    virtual int output_ready(ACE_Message_Block* mb) 
+    {
+      return 0;
+    }
+
+  private:
+    ACE_Reactor_Notification_Strategy notifier_;
+    ACE_Stream<ACE_MT_SYNCH> stream_;
+    
+  };
+
+
+
+  class CloudBusRelayAcceptor : public ACE_Event_Handler
+  {
+  public:
+    virtual ~CloudBusRelayAcceptor () 
+    {
+      this->handle_close (ACE_INVALID_HANDLE, 0);
+    } 
+    
+    int open (const ACE_INET_Addr &listen_addr)
+    {
+      if (this->acceptor_.open (listen_addr, 1) == -1) {
+	GERROR("error opening acceptor\n");
+	return -1;
+      }
+      return this->reactor ()->register_handler(this, ACE_Event_Handler::ACCEPT_MASK);
+    }
+    
+    virtual ACE_HANDLE get_handle (void) const
+    { 
+      return this->acceptor_.get_handle (); 
+    }
+    
+    virtual int handle_input (ACE_HANDLE fd = ACE_INVALID_HANDLE)
+    {
+      CloudBusNodeController *controller;
+
+      ACE_NEW_RETURN (controller, CloudBusNodeController, -1);
+      
+      auto_ptr<CloudBusNodeController> p (controller);
+      
+      if (this->acceptor_.accept (controller->peer ()) == -1) {
+	GERROR("Failed to accept controller connection\n"); 
+	return -1;
+      }
+      
+      p.release ();
+      controller->reactor (this->reactor ());
+      if (controller->open () == -1)
+	controller->handle_close (ACE_INVALID_HANDLE, 0);
+      return 0;
+
+    }
+    
+    virtual int handle_close (ACE_HANDLE handle,
+			      ACE_Reactor_Mask close_mask)
+    {
+      GDEBUG("Close CloudBus Relay Acceptor\n");
+      
+      if (this->acceptor_.get_handle () != ACE_INVALID_HANDLE) {
+	ACE_Reactor_Mask m = 
+	  ACE_Event_Handler::ACCEPT_MASK | ACE_Event_Handler::DONT_CALL;
+	this->reactor ()->remove_handler (this, m);
+	this->acceptor_.close ();
+      }
+      return 0;
+
+    }
+    
+  protected:
+    ACE_SOCK_Acceptor acceptor_;
+  };
+}
+
+
+int main(int argc, char** argv)
+{
+  GDEBUG("CloudBus Relay Staring\n");
+
+  const int port_no = 8002;
+
+  ACE_INET_Addr port_to_listen (port_no);
+
+  Gadgetron::CloudBusRelayAcceptor acceptor;
+
+  acceptor.reactor (ACE_Reactor::instance ());
+  if (acceptor.open (port_to_listen) == -1)
+    return 1;
+
+  ACE_Reactor::instance()->run_reactor_event_loop ();
+
+  return 0;
+}


### PR DESCRIPTION
This is a reworked version of the cloudbus that now uses a relay to overcome the problems with multi-casting on many common cloud platforms. 

Basically, you would start the "gadgetron_cloudbus_relay" on some server and then set the relay address in the config file (gadgetron.xml):

    <cloudBus>
       <relayAddress>127.0.0.1</relayAddress>
       <port>8002</port>
    </cloudBus>

If the relay shuts down, the nodes will reconnect if and when the relay comes back up. The available nodes can be queried with the same interface function as the previous relay. 

@xueh2, I need you to check if this is compatible with the cloud stuff in gtplus. If so, I say we merge this and then we can add more bells and whistles as we go. 

Another question is if we need a script (or two) to start this from the chroot image, and maybe an upstart script to keep it running. 

@xueh2, @naegelejd, @inati, comments?
 