### PR TITLE
Fixed bug where empty echo Train length set Magnetic Field Strength to 1

### DIFF
--- a/gadgets/dicom/DicomFinishGadget.cpp
+++ b/gadgets/dicom/DicomFinishGadget.cpp
@@ -459,10 +459,9 @@ namespace Gadgetron {
             WRITE_DCM_STRING(key, "3.0");
         }
 
-
+		key.set(0x0018, 0x0091);
         // Echo Train Length
         if (h.encoding[0].echoTrainLength) {
-            key.set(0x0018, 0x0091);
             ACE_OS::snprintf(buf, BUFSIZE, "%ld", (long)*h.encoding[0].echoTrainLength);
             WRITE_DCM_STRING(key, buf);
         }


### PR DESCRIPTION
moved *key.set(0x0018, 0x0091)* outside of if statement so the else will effect echoTrainLength key instead of magnetic field strength key.