### PR TITLE
made dcmFile protected

### DIFF
--- a/gadgets/dicom/DicomFinishGadget.h
+++ b/gadgets/dicom/DicomFinishGadget.h
@@ -67,6 +67,7 @@ namespace Gadgetron
         { }
 
     protected:
+        DcmFileFormat dcmFile;
 
         virtual int process_config(ACE_Message_Block * mb);
         virtual int process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1);
@@ -414,7 +415,6 @@ namespace Gadgetron
         }
 
     private:
-        DcmFileFormat dcmFile;
         std::string seriesIUIDRoot;
         long initialSeriesNumber;
         std::map <unsigned int, std::string> seriesIUIDs;


### PR DESCRIPTION
When attempting to inherit from `DicomFinishGadget` and adding new Dicom parameters to dcmFile from information from the `ImageHeader` dcmFile needs to be protected to adds these parameters.