### PR TITLE
fix the framework to be consistently support ROE1E2CHA

### DIFF
--- a/apps/clients/gadgetron_ismrmrd_client/gadgetron_ismrmrd_client.cpp
+++ b/apps/clients/gadgetron_ismrmrd_client/gadgetron_ismrmrd_client.cpp
@@ -161,7 +161,7 @@ public:
 
   virtual void read(tcp::socket* stream)
   {
-    ssize_t recv_count = 0;
+    size_t recv_count = 0;
     
     typedef unsigned long long size_t_type;
     uint32_t len(0);
@@ -206,7 +206,7 @@ public:
 
   virtual void read(tcp::socket* stream)
   {
-    ssize_t recv_count = 0;
+    size_t recv_count = 0;
     
     typedef unsigned long long size_t_type;
     size_t_type len(0);
@@ -625,19 +625,19 @@ public:
 
             // since the NDArray does not carry the pixel spacing
             header.dime.pixdim[0] = 0;
-            if ( pixelSize.size() > 1 )
+            if ( pixelSize.size() > 0 )
                 header.dime.pixdim[1] = pixelSize[0];
-            if ( pixelSize.size() > 2 )
+            if ( pixelSize.size() > 1 )
                 header.dime.pixdim[2] = pixelSize[1];
-            if ( pixelSize.size() > 3 )
+            if ( pixelSize.size() > 2 )
                 header.dime.pixdim[3] = pixelSize[2];
-            if ( pixelSize.size() > 4 )
+            if ( pixelSize.size() > 3 )
                 header.dime.pixdim[4] = pixelSize[3];
-            if ( pixelSize.size() > 5 )
+            if ( pixelSize.size() > 4 )
                 header.dime.pixdim[5] = pixelSize[4];
-            if ( pixelSize.size() > 6 )
+            if ( pixelSize.size() > 5 )
                 header.dime.pixdim[6] = pixelSize[5];
-            if ( pixelSize.size() > 7 )
+            if ( pixelSize.size() > 6 )
                 header.dime.pixdim[7] = pixelSize[6];
 
             header.dime.vox_offset = 0;
@@ -749,12 +749,13 @@ public:
         st1 << filename << ".hdr";
         std::string head_varname = st1.str();
 
-        std::vector<size_t> dim(3);
+        std::vector<size_t> dim(4, 1);
         dim[0] = h.matrix_size[0];
         dim[1] = h.matrix_size[1];
         dim[2] = h.matrix_size[2];
+        dim[3] = h.channels;
 
-        std::vector<float> pixelSize(3);
+        std::vector<float> pixelSize(4, 1);
         pixelSize[0] = h.field_of_view[0] / h.matrix_size[0];
         pixelSize[1] = h.field_of_view[1] / h.matrix_size[1];
         pixelSize[2] = h.field_of_view[2] / h.matrix_size[2];
@@ -775,7 +776,7 @@ public:
 
         std::ofstream outfileData;
         outfileData.open(img_varname.c_str(), std::ios::out | std::ios::binary);
-        outfileData.write(reinterpret_cast<const char*>(im.getDataPtr()), sizeof(T)*dim[0] * dim[1] * dim[2]);
+        outfileData.write(reinterpret_cast<const char*>(im.getDataPtr()), sizeof(T)*dim[0] * dim[1] * dim[2] * dim[3]);
         outfileData.close();
     }
 

--- a/gadgets/mri_core/MRIImageWriter.h
+++ b/gadgets/mri_core/MRIImageWriter.h
@@ -29,13 +29,14 @@ namespace Gadgetron{
             uint16_t RO = header->getObjectPtr()->matrix_size[0];
             uint16_t E1 = header->getObjectPtr()->matrix_size[1];
             uint16_t E2 = header->getObjectPtr()->matrix_size[2];
+            uint16_t CHA = header->getObjectPtr()->channels;
 
-            unsigned long expected_elements = RO*E1*E2;
+            unsigned long expected_elements = RO*E1*E2*CHA;
 
             if (expected_elements != data->getObjectPtr()->get_number_of_elements())
             {
                 GDEBUG("Number of header elements %d is inconsistent with number of elements in NDArray %d\n", expected_elements, data->getObjectPtr()->get_number_of_elements());
-                GDEBUG("Header dimensions: %d, %d, %d\n", RO, E1, E2);
+                GDEBUG("Header dimensions: %d, %d, %d, %d\n", RO, E1, E2, CHA);
                 GDEBUG("Number of array dimensions: %d:\n", data->getObjectPtr()->get_number_of_dimensions());
                 for (size_t i = 0; i < data->getObjectPtr()->get_number_of_dimensions(); i++)
                 {


### PR DESCRIPTION
After reviewing related compoments, it is found that since MRIImageReader and ISMRMRD utilities support RO/E1/E2/CHA image, the gadgetron image writer and client are updated to support image with [RO E1 E2 CHA]. So now a gadget can send multi-channel images back to client.

I will make another PR to make IceGadgetron support multi-channel incoming images and run scanner  test on it.