### PR TITLE
add more functions into mri_core; for generic chain

### DIFF
--- a/gadgets/grappa/GrappaWeightsCalculator.cpp
+++ b/gadgets/grappa/GrappaWeightsCalculator.cpp
@@ -187,6 +187,10 @@ template <class T> int GrappaWeightsCalculator<T>::svc(void)  {
             size_t kRO = 5;
             size_t kNE1 = 4;
 
+            Gadgetron::coilMapMakerInati< std::complex<float> > csm;
+            csm.ks_ = ks;
+            csm.power_ = power;
+
             if (numUnCombined==0)
             {
                 hoNDArray< std::complex<float> > acs(RO, E1, target_coils_, reinterpret_cast< std::complex<float>* >(host_data->begin()));
@@ -199,7 +203,13 @@ template <class T> int GrappaWeightsCalculator<T>::svc(void)  {
                 }
 
                 hoNDFFT<float>::instance()->ifft2c(target_acs, complex_im_);
-                Gadgetron::coil_map_2d_Inati(complex_im_, coil_map_, ks, power);
+                // Gadgetron::coil_map_2d_Inati(complex_im_, coil_map_, ks, power);
+
+                coil_map_.create(RO, E1, target_coils_);
+
+                hoNDArray< std::complex<float> > complexImBuf(RO, E1, 1, target_coils_, complex_im_.begin());
+                hoNDArray< std::complex<float> > coilMapBuf(RO, E1, 1, target_coils_, coil_map_.begin());
+                csm.make_coil_map(complexImBuf, coilMapBuf);
 
                 // compute unmixing coefficients
                 if (mb1->getObjectPtr()->acceleration_factor == 1)
@@ -286,7 +296,14 @@ template <class T> int GrappaWeightsCalculator<T>::svc(void)  {
 
                 hoNDFFT<float>::instance()->ifft2c(target_acs_, complex_im_);
 
-                Gadgetron::coil_map_2d_Inati(complex_im_, coil_map_, ks, power);
+                coil_map_.create(RO, E1, complex_im_.get_size(2));
+
+                hoNDArray< std::complex<float> > complexImBuf(RO, E1, 1, complex_im_.get_size(2), complex_im_.begin());
+                hoNDArray< std::complex<float> > coilMapBuf(RO, E1, 1, coil_map_.get_size(2), coil_map_.begin());
+                csm.make_coil_map(complexImBuf, coilMapBuf);
+
+                // Gadgetron::coil_map_2d_Inati(complex_im_, coil_map_, ks, power);
+                // csm.make_coil_map_2d(complex_im_, coil_map_);
 
                 // compute unmixing coefficients
                 if (mb1->getObjectPtr()->acceleration_factor == 1)

--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
@@ -8,7 +8,7 @@
 #include <ismrmrd/ismrmrd.h>
 #include <complex>
 #include <map>
-#include "mri_core_data.h"
+#include "mri_core_acquisition_bucket.h"
 
 namespace Gadgetron{
 

--- a/gadgets/mri_core/BucketToBufferGadget.h
+++ b/gadgets/mri_core/BucketToBufferGadget.h
@@ -9,7 +9,7 @@
 #include <ismrmrd/xml.h>
 #include <complex>
 #include <map>
-#include "mri_core_data.h"
+#include "mri_core_acquisition_bucket.h"
 
 namespace Gadgetron{
 

--- a/toolboxes/mri_core/CMakeLists.txt
+++ b/toolboxes/mri_core/CMakeLists.txt
@@ -5,7 +5,7 @@ endif (WIN32)
 include_directories(
     ${Boost_INCLUDE_DIR} 
     ${ARMADILLO_INCLUDE_DIRS} 
-    ${ACE_INCLUDE_DIR} 
+    # ${ACE_INCLUDE_DIR} 
     ${ISMRMRD_INCLUDE_DIR}
     ${FFTW3_INCLUDE_DIR}
     ${MKL_INCLUDE_DIR}
@@ -25,25 +25,30 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/math 
     ${CMAKE_SOURCE_DIR}/toolboxes/gtplus
     ${CMAKE_SOURCE_DIR}/toolboxes/gtplus/util
-    ${CMAKE_SOURCE_DIR}/toolboxes/gtplus/workflow
-    ${CMAKE_SOURCE_DIR}/toolboxes/gtplus/algorithm
-    ${CMAKE_SOURCE_DIR}/toolboxes/gtplus/solver
+    ${CMAKE_SOURCE_DIR}/apps/gadgetron 
 )
 
 set( mri_core_header_files
         mri_core_export.h
         mri_core_def.h
+        mri_core_acquisition_bucket.h
         mri_core_data.h
         mri_core_utility.h
         mri_core_kspace_filter.h
         mri_core_grappa.h 
-        mri_core_coil_map_estimation.h )
+        mri_core_recon_para.h 
+        mri_core_partial_fourier.h 
+        mri_core_coil_map_estimation.h 
+        mri_core_reference_preparation.h )
 
 set( mri_core_source_files
         mri_core_utility.cpp 
         mri_core_grappa.cpp 
         mri_core_kspace_filter.cpp
-        mri_core_coil_map_estimation.cpp )
+        mri_core_coil_map_estimation.cpp 
+        mri_core_partial_fourier.cpp 
+        mri_core_recon_para.cpp 
+        mri_core_reference_preparation.cpp )
 
 add_library(gadgetron_toolbox_mri_core SHARED 
      ${mri_core_header_files} ${mri_core_source_files} )
@@ -51,7 +56,14 @@ add_library(gadgetron_toolbox_mri_core SHARED
 set_target_properties(gadgetron_toolbox_mri_core PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
 set_target_properties(gadgetron_toolbox_mri_core PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(gadgetron_toolbox_mri_core gadgetron_toolbox_cpucore gadgetron_toolbox_cpucore_math ${ARMADILLO_LIBRARIES} gadgetron_toolbox_cpufft )
+target_link_libraries(gadgetron_toolbox_mri_core 
+                    gadgetron_toolbox_cpucore 
+                    gadgetron_toolbox_cpucore_math 
+                    ${ARMADILLO_LIBRARIES} 
+                    gadgetron_toolbox_cpufft 
+                    gadgetron_toolbox_cpuklt 
+                    # gadgetron_toolbox_gtplus_io 
+                    )
 
 install(TARGETS gadgetron_toolbox_mri_core DESTINATION lib COMPONENT main)
 

--- a/toolboxes/mri_core/mri_core_acquisition_bucket.h
+++ b/toolboxes/mri_core/mri_core_acquisition_bucket.h
@@ -1,0 +1,168 @@
+#ifndef MRI_CORE_ACQUISITION_BUCKET_H
+#define MRI_CORE_ACQUISITION_BUCKET_H
+
+#include "GadgetContainerMessage.h"
+#include "mri_core_data.h"
+
+namespace Gadgetron 
+{
+
+  /** 
+      This class functions as a storage unit for statistics related to
+      the @IsmrmrdAcquisitionData objects.
+
+   */
+  class IsmrmrdAcquisitionBucketStats
+  {
+    public:
+      // Set of labels found in the data or ref part of a bucket
+      //11D, fixed order [RO, E1, E2, CHA, SLC, PHS, CON, REP, SET, SEG, AVE]
+      std::set<uint16_t> kspace_encode_step_1;
+      std::set<uint16_t> kspace_encode_step_2;
+      std::set<uint16_t> slice;
+      std::set<uint16_t> phase;
+      std::set<uint16_t> contrast;
+      std::set<uint16_t> repetition;
+      std::set<uint16_t> set;
+      std::set<uint16_t> segment;
+      std::set<uint16_t> average;
+  };
+
+  /** 
+      This class functions as a storage unit for GadgetContainerMessage pointers
+      that point to acquisiton headers, data and trajectories.
+
+      It is the storage used in the @IsmrmrdAcquisitionBucket structure. 
+
+   */
+  class IsmrmrdAcquisitionData
+  {
+  public:
+    /**
+       Default Constructor
+    */
+    IsmrmrdAcquisitionData()
+      : head_(0)
+      , data_(0)
+      , traj_(0)
+      {
+
+      }
+    
+    /**
+       Constructor
+    */
+    IsmrmrdAcquisitionData(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head,
+                           GadgetContainerMessage< hoNDArray< std::complex<float> > >* data,
+                           GadgetContainerMessage< hoNDArray< float > >* traj = 0)
+    {
+      if (head) {
+	head_ = head->duplicate();
+      } else {
+	head_ = 0;
+      }
+
+      if (data) {
+	data_ = data->duplicate();
+      } else {
+	data_ = 0;
+      }
+
+      if (traj) {
+	traj_ = traj->duplicate();
+      } else {
+	traj_ = 0;
+      }
+    }
+
+    /** 
+	Assignment operator
+     */
+    IsmrmrdAcquisitionData& operator=(const IsmrmrdAcquisitionData& d)
+      {
+	if (this != &d) { 
+	  if (d.head_) {
+	    if (head_) head_->release();
+	    head_ = d.head_->duplicate();
+	  } else {
+	    head_ = 0;
+	  }
+	  
+	  if (d.data_) {
+	    if (data_) data_->release();
+	    data_ = d.data_->duplicate();
+	  } else {
+	    data_ = 0;
+	  }
+	  
+	  if (d.traj_) {
+	    if (traj_) traj_->release();
+	    traj_ = d.traj_->duplicate();
+	  } else {
+	    traj_ = 0;
+	  }
+	}
+	return *this;
+      }
+
+    /**
+       Copy constructor
+     */
+    IsmrmrdAcquisitionData(const IsmrmrdAcquisitionData& d)
+      : head_(0)
+      , data_(0)
+      , traj_(0)
+      {
+	*this = d;
+      }
+
+
+    /**
+       Destructor. The memory in the GadgetContainer Messages will be deleted
+       when the object is destroyed. 
+     */
+    ~IsmrmrdAcquisitionData() {
+      if (head_) {
+	head_->release();
+	head_ = 0;
+      }
+
+      if (data_) {
+	data_->release();
+	data_ = 0;
+      }
+
+      if (traj_) {
+	traj_->release();
+	traj_ = 0;
+      }
+    }
+
+
+    GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head_;
+    GadgetContainerMessage< hoNDArray< std::complex<float> > >* data_;
+    GadgetContainerMessage< hoNDArray< float > > * traj_;
+  };
+
+
+  /**
+
+     This class serves as the storage unit for buffered data. 
+     The @IsmrmrdAcquisitionData structure contains pointers 
+     to the GadgetContainerMessages with the data. 
+
+     Data stored in these buckets will automatically get deleted when the object is
+     destroyed. 
+
+   */ 
+  class IsmrmrdAcquisitionBucket
+  {
+  public:
+    std::vector< IsmrmrdAcquisitionData > data_;
+    std::vector< IsmrmrdAcquisitionData > ref_;
+    std::vector< IsmrmrdAcquisitionBucketStats > datastats_;
+    std::vector< IsmrmrdAcquisitionBucketStats > refstats_;
+  };
+  
+}
+#endif //MRI_CORE_ACQUISITION_BUCKET_H

--- a/toolboxes/mri_core/mri_core_data.h
+++ b/toolboxes/mri_core/mri_core_data.h
@@ -1,7 +1,6 @@
 #ifndef MRI_CORE_DATA_H
 #define MRI_CORE_DATA_H
 
-#include "GadgetContainerMessage.h"
 #include "ismrmrd/ismrmrd.h"
 #include "ismrmrd/meta.h"
 #include <vector>
@@ -38,171 +37,22 @@ namespace Gadgetron
 	USER_7,
 	NONE
       };
-    
-  /** 
-      This class functions as a storage unit for statistics related to
-      the @IsmrmrdAcquisitionData objects.
 
-   */
-  class IsmrmrdAcquisitionBucketStats
-  {
-    public:
-      // Set of labels found in the data or ref part of a bucket
-      //11D, fixed order [RO, E1, E2, CHA, SLC, PHS, CON, REP, SET, SEG, AVE]
-      std::set<uint16_t> kspace_encode_step_1;
-      std::set<uint16_t> kspace_encode_step_2;
-      std::set<uint16_t> slice;
-      std::set<uint16_t> phase;
-      std::set<uint16_t> contrast;
-      std::set<uint16_t> repetition;
-      std::set<uint16_t> set;
-      std::set<uint16_t> segment;
-      std::set<uint16_t> average;
-  };
-
-  /** 
-      This class functions as a storage unit for GadgetContainerMessage pointers
-      that point to acquisiton headers, data and trajectories.
-
-      It is the storage used in the @IsmrmrdAcquisitionBucket structure. 
-
-   */
-  class IsmrmrdAcquisitionData
-  {
-  public:
-    /**
-       Default Constructor
-    */
-    IsmrmrdAcquisitionData()
-      : head_(0)
-      , data_(0)
-      , traj_(0)
-      {
-
-      }
-    
-    /**
-       Constructor
-    */
-    IsmrmrdAcquisitionData(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head,
-                           GadgetContainerMessage< hoNDArray< std::complex<float> > >* data,
-                           GadgetContainerMessage< hoNDArray< float > >* traj = 0)
-    {
-      if (head) {
-	head_ = head->duplicate();
-      } else {
-	head_ = 0;
-      }
-
-      if (data) {
-	data_ = data->duplicate();
-      } else {
-	data_ = 0;
-      }
-
-      if (traj) {
-	traj_ = traj->duplicate();
-      } else {
-	traj_ = 0;
-      }
-    }
-
-    /** 
-	Assignment operator
-     */
-    IsmrmrdAcquisitionData& operator=(const IsmrmrdAcquisitionData& d)
-      {
-	if (this != &d) { 
-	  if (d.head_) {
-	    if (head_) head_->release();
-	    head_ = d.head_->duplicate();
-	  } else {
-	    head_ = 0;
-	  }
-	  
-	  if (d.data_) {
-	    if (data_) data_->release();
-	    data_ = d.data_->duplicate();
-	  } else {
-	    data_ = 0;
-	  }
-	  
-	  if (d.traj_) {
-	    if (traj_) traj_->release();
-	    traj_ = d.traj_->duplicate();
-	  } else {
-	    traj_ = 0;
-	  }
-	}
-	return *this;
-      }
-
-    /**
-       Copy constructor
-     */
-    IsmrmrdAcquisitionData(const IsmrmrdAcquisitionData& d)
-      : head_(0)
-      , data_(0)
-      , traj_(0)
-      {
-	*this = d;
-      }
-
-
-    /**
-       Destructor. The memory in the GadgetContainer Messages will be deleted
-       when the object is destroyed. 
-     */
-    ~IsmrmrdAcquisitionData() {
-      if (head_) {
-	head_->release();
-	head_ = 0;
-      }
-
-      if (data_) {
-	data_->release();
-	data_ = 0;
-      }
-
-      if (traj_) {
-	traj_->release();
-	traj_ = 0;
-      }
-    }
-
-
-    GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head_;
-    GadgetContainerMessage< hoNDArray< std::complex<float> > >* data_;
-    GadgetContainerMessage< hoNDArray< float > > * traj_;
-  };
-
-
-  /**
-
-     This class serves as the storage unit for buffered data. 
-     The @IsmrmrdAcquisitionData structure contains pointers 
-     to the GadgetContainerMessages with the data. 
-
-     Data stored in these buckets will automatically get deleted when the object is
-     destroyed. 
-
-   */ 
-  class IsmrmrdAcquisitionBucket
-  {
-  public:
-    std::vector< IsmrmrdAcquisitionData > data_;
-    std::vector< IsmrmrdAcquisitionData > ref_;
-    std::vector< IsmrmrdAcquisitionBucketStats > datastats_;
-    std::vector< IsmrmrdAcquisitionBucketStats > refstats_;
-  };
-  
-  
   class SamplingLimit
   {
   public:
     uint16_t min_;
     uint16_t center_;
     uint16_t max_;
+
+    SamplingLimit()
+    {
+        min_ = 0;
+        center_ = 0;
+        max_ = 0;
+    }
+
+    ~SamplingLimit() {}
   };
   
   class SamplingDescription
@@ -219,6 +69,27 @@ namespace Gadgetron
     // sampled range along RO, E1, E2 (for asymmetric echo and partial fourier)
     // min, max and center
     SamplingLimit sampling_limits_[3];
+
+    SamplingDescription()
+    {
+        encoded_FOV_[0] = 0;
+        encoded_FOV_[1] = 0;
+        encoded_FOV_[2] = 0;
+
+        recon_FOV_[0] = 0;
+        recon_FOV_[1] = 0;
+        recon_FOV_[2] = 0;
+
+        encoded_matrix_[0] = 0;
+        encoded_matrix_[1] = 0;
+        encoded_matrix_[2] = 0;
+
+        recon_matrix_[0] = 0;
+        recon_matrix_[1] = 0;
+        recon_matrix_[2] = 0;
+    }
+
+    ~SamplingDescription() {}
   };
   
   class IsmrmrdDataBuffered

--- a/toolboxes/mri_core/mri_core_grappa.h
+++ b/toolboxes/mri_core/mri_core_grappa.h
@@ -41,6 +41,10 @@ namespace Gadgetron {
     /// gFactor: [RO E1], gfactor
     template <typename T> EXPORTMRICORE void grappa2d_unmixing_coeff(const hoNDArray<T>& kerIm, const hoNDArray<T>& coilMap, size_t acceFactorE1, hoNDArray<T>& unmixCoeff, hoNDArray< typename realType<T>::Type >& gFactor);
 
+    /// compute per channel gfactor from image domain kernel
+    /// gFactor: [RO E1 dstCHA], gfactor
+    template <typename T> EXPORTMRICORE void grappa2d_per_channel_gfactor(const hoNDArray<T>& kerIm, size_t acceFactorE1, hoNDArray< typename realType<T>::Type >& gFactor);
+
     /// apply unmixing coefficient on undersampled kspace
     /// kspace: [RO E1 srcCHA ...]
     /// unmixCoeff : [RO E1 srcCHA]
@@ -129,6 +133,10 @@ namespace Gadgetron {
                                                                 size_t acceFactorE1, size_t acceFactorE2, 
                                                                 hoNDArray<T>& unmixCoeff, 
                                                                 hoNDArray< typename realType<T>::Type >& gFactor);
+
+    /// compute gfactor for every dst channel
+    /// gfactor: [RO E1 E2 dstCHA]
+    template <typename T> EXPORTMRICORE void grappa3d_per_channel_gfactor(const hoNDArray<T>& convKer, size_t RO, size_t E1, size_t E2, size_t acceFactorE1, size_t acceFactorE2, hoNDArray< typename realType<T>::Type >& gFactor);
 
     /// apply grappa convolution kernel to perform per-channel unwrapping
     /// convKer: 3D kspace grappa convolution kernel [convKRO convKE1 convKE2 srcCHA dstCHA]

--- a/toolboxes/mri_core/mri_core_partial_fourier.cpp
+++ b/toolboxes/mri_core/mri_core_partial_fourier.cpp
@@ -1,0 +1,1897 @@
+﻿
+/** \file   mri_core_partial_fourier.cpp
+    \brief  Implementation partial fourier handling functionalities for 2D and 3D MRI
+    \author Hui Xue
+*/
+
+#include "mri_core_partial_fourier.h"
+#include "mri_core_kspace_filter.h"
+#include "hoNDFFT.h"
+#include "hoNDArray_elemwise.h"
+#include "hoNDArray_linalg.h"
+#include "hoNDArray_reductions.h"
+#include "ho2DArray.h"
+#include "ho3DArray.h"
+#include "hoMatrix.h"
+#include "hoNDArray_utils.h"
+
+namespace Gadgetron
+{
+    // ------------------------------------------------------------------------
+
+    std::string get_ismrmrd_partial_fourier_handling_algo_name(ismrmrdPARTIALFOURIERHANDLINGALGO v)
+    {
+        std::string name;
+
+        switch (v)
+        {
+        case ISMRMRD_PF_None:
+            name = "None";
+            break;
+
+        case ISMRMRD_PF_Zerofilling_filter:
+            name = "ZeroFillingFilter";
+            break;
+
+        case ISMRMRD_PF_Pocs:
+            name = "POCS";
+            break;
+
+        case ISMRMRD_PF_FengHuang:
+            name = "FengHuang";
+            break;
+
+        default:
+            GERROR_STREAM("Unrecognized ISMRMRD partial fourier handling algorithm type : " << v);
+        }
+
+        return name;
+    }
+
+    ismrmrdPARTIALFOURIERHANDLINGALGO get_ismrmrd_partial_fourier_handling_algo(const std::string& name)
+    {
+        ismrmrdPARTIALFOURIERHANDLINGALGO v;
+
+        if (name == "None")
+        {
+            v = ISMRMRD_PF_None;
+        }
+        else if (name == "ZeroFillingFilter")
+        {
+            v = ISMRMRD_PF_Zerofilling_filter;
+        }
+        else if (name == "POCS")
+        {
+            v = ISMRMRD_PF_Pocs;
+        }
+        else if (name == "FengHuang")
+        {
+            v = ISMRMRD_PF_FengHuang;
+        }
+        else
+        {
+            GERROR_STREAM("Unrecognized ISMRMRD partial fourier handling algorithm name : " << name);
+        }
+
+        return v;
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_reset_kspace_2d(const hoNDArray<T>& src, hoNDArray<T>& dst, size_t startRO, size_t endRO, size_t startE1, size_t endE1)
+    {
+        try
+        {
+            size_t NDim = src.get_number_of_dimensions();
+            GADGET_CHECK_THROW(NDim >= 2);
+
+            size_t RO = dst.get_size(0);
+            size_t E1 = dst.get_size(1);
+
+            size_t RO_src = src.get_size(0);
+            size_t E1_src = src.get_size(1);
+
+            GADGET_CHECK_THROW(RO == RO_src);
+            GADGET_CHECK_THROW(E1 == E1_src);
+            GADGET_CHECK_THROW(src.get_number_of_elements() == dst.get_number_of_elements());
+
+            if ((startRO >= RO) || (endRO >= RO) || (startRO>endRO))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_reset_kspace_2d(...) : (startRO>=RO) || (endRO>=RO) || (startRO>endRO) ... ");
+                return;
+            }
+
+            if ((startE1 >= E1) || (endE1 >= E1) || (startE1>endE1))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_reset_kspace_2d(...) : (startE1>=E1) || (endE1>=E1) || (startE1>endE1) ... ");
+                return;
+            }
+
+            size_t N = dst.get_number_of_elements() / (RO*E1);
+            const T* pSrc = src.begin();
+            T* pDst = dst.begin();
+
+            long long n;
+
+#pragma omp parallel for default(none) private(n) shared(N, pSrc, pDst, RO, E1, startRO, endRO, startE1, endE1)
+            for (n = 0; n<(long long)N; n++)
+            {
+                for (size_t e1 = startE1; e1 <= endE1; e1++)
+                {
+                    size_t offset = n*RO*E1 + e1*RO + startRO;
+                    memcpy(pDst + offset, pSrc + offset, sizeof(T)*(endRO - startRO + 1));
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partial_fourier_reset_kspace_2d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_reset_kspace_3d(const hoNDArray<T>& src, hoNDArray<T>& dst, size_t startRO, size_t endRO, size_t startE1, size_t endE1, size_t startE2, size_t endE2)
+    {
+        try
+        {
+            size_t NDim = src.get_number_of_dimensions();
+            GADGET_CHECK_THROW(NDim >= 2);
+
+            size_t RO = dst.get_size(0);
+            size_t E1 = dst.get_size(1);
+            size_t E2 = dst.get_size(2);
+
+            size_t RO_src = src.get_size(0);
+            size_t E1_src = src.get_size(1);
+            size_t E2_src = src.get_size(2);
+
+            GADGET_CHECK_THROW(RO == RO_src);
+            GADGET_CHECK_THROW(E1 == E1_src);
+            GADGET_CHECK_THROW(E2 == E2_src);
+            GADGET_CHECK_THROW(src.get_number_of_elements() == dst.get_number_of_elements());
+
+            if ((startRO >= RO) || (endRO >= RO) || (startRO>endRO))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_reset_kspace_3d(...) : (startRO>=RO) || (endRO>=RO) || (startRO>endRO) ... ");
+                return;
+            }
+
+            if ((startE1 >= E1) || (endE1 >= E1) || (startE1>endE1))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_reset_kspace_3d(...) : (startE1>=E1) || (endE1>=E1) || (startE1>endE1) ... ");
+                return;
+            }
+
+            if ((startE2 >= E2) || (endE2 >= E2) || (startE2>endE2))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_reset_kspace_3d(...) : (startE2>=E2) || (endE2>=E2) || (startE2>endE2) ... ");
+                return;
+            }
+
+            size_t N = dst.get_number_of_elements() / (RO*E1*E2);
+            const T* pSrc = src.begin();
+            T* pDst = dst.begin();
+
+            long long n;
+
+#pragma omp parallel for default(none) private(n) shared(N, pSrc, pDst, RO, E1, E2, startRO, endRO, startE1, endE1, startE2, endE2)
+            for (n = 0; n<(long long)N; n++)
+            {
+                for (size_t e2 = startE2; e2 <= endE2; e2++)
+                {
+                    for (size_t e1 = startE1; e1 <= endE1; e1++)
+                    {
+                        size_t offset = n*RO*E1*E2 + e2*E1*RO + e1*RO + startRO;
+                        memcpy(pDst + offset, pSrc + offset, sizeof(T)*(endRO - startRO + 1));
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partial_fourier_reset_kspace_3d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_transition_band_2d(const hoNDArray<T>& src, hoNDArray<T>& dst, size_t startRO, size_t endRO, size_t startE1, size_t endE1, size_t transBandRO, size_t transBandE1)
+    {
+        try
+        {
+            size_t NDim = src.get_number_of_dimensions();
+            GADGET_CHECK_THROW(NDim >= 2);
+
+            size_t RO = dst.get_size(0);
+            size_t E1 = dst.get_size(1);
+
+            size_t RO_src = src.get_size(0);
+            size_t E1_src = src.get_size(1);
+
+            GADGET_CHECK_THROW(RO == RO_src);
+            GADGET_CHECK_THROW(E1 == E1_src);
+            GADGET_CHECK_THROW(src.get_number_of_elements() == dst.get_number_of_elements());
+
+            if ((startRO >= RO) || (endRO >= RO) || (startRO>endRO))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_transition_band_2d(...) : (startRO>=RO) || (endRO>=RO) || (startRO>endRO) ... ");
+                return;
+            }
+
+            if ((startE1 >= E1) || (endE1 >= E1) || (startE1>endE1))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_transition_band_2d(...) : (startE1>=E1) || (endE1>=E1) || (startE1>endE1) ... ");
+                return;
+            }
+
+            while (transBandRO>1 && startRO + transBandRO > RO / 2)
+            {
+                transBandRO--;
+            }
+
+            while (transBandRO>1 && endRO - transBandRO < RO / 2)
+            {
+                transBandRO--;
+            }
+
+            while (transBandE1>1 && startE1 + transBandE1 > E1 / 2)
+            {
+                transBandE1--;
+            }
+
+            while (transBandE1>1 && endE1 - transBandE1 < E1 / 2)
+            {
+                transBandE1--;
+            }
+
+            ISMRMRDKSPACEFILTER filterType = ISMRMRD_FILTER_TAPERED_HANNING;
+            bool densityComp = false;
+
+            hoNDArray<T> filter_src_RO, filter_src_E1;
+
+            if (startRO == 0 && endRO == RO - 1)
+            {
+                Gadgetron::generate_asymmetric_filter(RO, startRO, endRO, filter_src_RO, ISMRMRD_FILTER_NONE, transBandRO, densityComp);
+            }
+            else
+            {
+                Gadgetron::generate_asymmetric_filter(RO, startRO, endRO, filter_src_RO, ISMRMRD_FILTER_TAPERED_HANNING, transBandRO, densityComp);
+            }
+
+            if (startE1 == 0 && endE1 == E1 - 1)
+            {
+                Gadgetron::generate_asymmetric_filter(E1, startE1, endE1, filter_src_E1, ISMRMRD_FILTER_NONE, transBandE1, densityComp);
+            }
+            else
+            {
+                Gadgetron::generate_asymmetric_filter(E1, startE1, endE1, filter_src_E1, ISMRMRD_FILTER_TAPERED_HANNING, transBandE1, densityComp);
+            }
+
+            // in this way, the SNR unit scale property is perserved
+            T midValue = filter_src_RO(RO / 2);
+            T scalFactor = T(1.0) / midValue;
+            Gadgetron::scal(scalFactor, filter_src_RO);
+
+            midValue = filter_src_E1(E1 / 2);
+            scalFactor = T(1.0) / midValue;
+            Gadgetron::scal(scalFactor, filter_src_E1);
+
+            hoNDArray<T> filter_dst_RO(RO), filter_dst_E1(E1);
+
+            size_t ii;
+            for (ii = 0; ii<RO; ii++)
+            {
+                filter_dst_RO(ii) = T(1.0) - filter_src_RO(ii);
+            }
+
+            for (ii = 0; ii<E1; ii++)
+            {
+                filter_dst_E1(ii) = T(1.0) - filter_src_E1(ii);
+            }
+
+            hoNDArray<T> srcFiltered(src), dstFiltered(dst);
+            if (startRO == 0 && endRO == RO - 1)
+            {
+                Gadgetron::apply_kspace_filter_E1(src, filter_src_E1, srcFiltered);
+                Gadgetron::apply_kspace_filter_E1(dst, filter_dst_E1, dstFiltered);
+            }
+            else if (startE1 == 0 && endE1 == E1 - 1)
+            {
+                Gadgetron::apply_kspace_filter_RO(src, filter_src_RO, srcFiltered);
+                Gadgetron::apply_kspace_filter_RO(dst, filter_dst_RO, dstFiltered);
+            }
+            else
+            {
+                Gadgetron::apply_kspace_filter_ROE1(src, filter_src_RO, filter_src_E1, srcFiltered);
+
+                hoNDArray<T> fxy;
+                Gadgetron::compute_2d_filter(filter_src_RO, filter_src_E1, fxy);
+
+                size_t Nxy = RO*E1;
+                for (ii = 0; ii<Nxy; ii++)
+                {
+                    fxy(ii) = T(1.0) - fxy(ii);
+                }
+
+                Gadgetron::apply_kspace_filter_ROE1(dst, fxy, dstFiltered);
+            }
+
+            Gadgetron::add(srcFiltered, dstFiltered, dst);
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partial_fourier_transition_band_2d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_transition_band_3d(const hoNDArray<T>& src, hoNDArray<T>& dst, size_t startRO, size_t endRO, size_t startE1, size_t endE1, size_t startE2, size_t endE2, size_t transBandRO, size_t transBandE1, size_t transBandE2)
+    {
+        try
+        {
+            size_t NDim = src.get_number_of_dimensions();
+            GADGET_CHECK_THROW(NDim >= 3);
+
+            size_t RO = dst.get_size(0);
+            size_t E1 = dst.get_size(1);
+            size_t E2 = dst.get_size(2);
+
+            size_t RO_src = src.get_size(0);
+            size_t E1_src = src.get_size(1);
+            size_t E2_src = src.get_size(2);
+
+            GADGET_CHECK_THROW(RO == RO_src);
+            GADGET_CHECK_THROW(E1 == E1_src);
+            GADGET_CHECK_THROW(E2 == E2_src);
+            GADGET_CHECK_THROW(src.get_number_of_elements() == dst.get_number_of_elements());
+
+            if ((startRO >= RO) || (endRO >= RO) || (startRO>endRO))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_transition_band_3d(...) : (startRO>=RO) || (endRO>=RO) || (startRO>endRO) ... ");
+                return;
+            }
+
+            if ((startE1 >= E1) || (endE1 >= E1) || (startE1>endE1))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_transition_band_3d(...) : (startE1>=E1) || (endE1>=E1) || (startE1>endE1) ... ");
+                return;
+            }
+
+            if ((startE2 >= E2) || (endE2 >= E2) || (startE2>endE2))
+            {
+                dst = src;
+                GWARN_STREAM("partial_fourier_transition_band_3d(...) : (startE2>=E2) || (endE2>=E2) || (startE2>endE2) ... ");
+                return;
+            }
+
+            while (transBandRO>1 && startRO + transBandRO > RO / 2)
+            {
+                transBandRO--;
+            }
+
+            while (transBandRO>1 && endRO - transBandRO < RO / 2)
+            {
+                transBandRO--;
+            }
+
+            while (transBandE1>1 && startE1 + transBandE1 > E1 / 2)
+            {
+                transBandE1--;
+            }
+
+            while (transBandE1>1 && endE1 - transBandE1 < E1 / 2)
+            {
+                transBandE1--;
+            }
+
+            while (transBandE2>1 && startE2 + transBandE2 > E2 / 2)
+            {
+                transBandE2--;
+            }
+
+            while (transBandE2>1 && endE2 - transBandE2 < E2 / 2)
+            {
+                transBandE2--;
+            }
+
+            ISMRMRDKSPACEFILTER filterType = ISMRMRD_FILTER_TAPERED_HANNING;
+            bool densityComp = false;
+
+            hoNDArray<T> filter_src_RO, filter_src_E1, filter_src_E2;
+
+            if (startRO == 0 && endRO == RO - 1)
+            {
+                Gadgetron::generate_asymmetric_filter(RO, startRO, endRO, filter_src_RO, ISMRMRD_FILTER_NONE, transBandRO, densityComp);
+            }
+            else
+            {
+                Gadgetron::generate_asymmetric_filter(RO, startRO, endRO, filter_src_RO, ISMRMRD_FILTER_TAPERED_HANNING, transBandRO, densityComp);
+            }
+
+            if (startE1 == 0 && endE1 == E1 - 1)
+            {
+                Gadgetron::generate_asymmetric_filter(E1, startE1, endE1, filter_src_E1, ISMRMRD_FILTER_NONE, transBandE1, densityComp);
+            }
+            else
+            {
+                Gadgetron::generate_asymmetric_filter(E1, startE1, endE1, filter_src_E1, ISMRMRD_FILTER_TAPERED_HANNING, transBandE1, densityComp);
+            }
+
+            if (startE2 == 0 && endE2 == E2 - 1)
+            {
+                Gadgetron::generate_asymmetric_filter(E2, startE2, endE2, filter_src_E2, ISMRMRD_FILTER_NONE, transBandE2, densityComp);
+            }
+            else
+            {
+                Gadgetron::generate_asymmetric_filter(E2, startE2, endE2, filter_src_E2, ISMRMRD_FILTER_TAPERED_HANNING, transBandE2, densityComp);
+            }
+
+            // in this way, the SNR unit scale property is perserved
+            T midValue = filter_src_RO(RO / 2);
+            T scalFactor = T(1.0) / midValue;
+            Gadgetron::scal(scalFactor, filter_src_RO);
+
+            midValue = filter_src_E1(E1 / 2);
+            scalFactor = T(1.0) / midValue;
+            Gadgetron::scal(scalFactor, filter_src_E1);
+
+            midValue = filter_src_E2(E2 / 2);
+            scalFactor = T(1.0) / midValue;
+            Gadgetron::scal(scalFactor, filter_src_E2);
+
+            hoNDArray<T> filter_dst_RO(RO), filter_dst_E1(E1), filter_dst_E2(E2);
+
+            size_t ii;
+            for (ii = 0; ii<RO; ii++)
+            {
+                filter_dst_RO(ii) = T(1.0) - filter_src_RO(ii);
+            }
+
+            for (ii = 0; ii<E1; ii++)
+            {
+                filter_dst_E1(ii) = T(1.0) - filter_src_E1(ii);
+            }
+
+            for (ii = 0; ii<E2; ii++)
+            {
+                filter_dst_E2(ii) = T(1.0) - filter_src_E2(ii);
+            }
+
+            hoNDArray<T> srcFiltered(src), dstFiltered(dst);
+            if (endRO <= RO - 1 && startE1 == 0 && endE1 == E1 - 1 && startE2 == 0 && endE1 == E2 - 1)
+            {
+                Gadgetron::apply_kspace_filter_RO(src, filter_src_E1, srcFiltered);
+                Gadgetron::apply_kspace_filter_RO(dst, filter_dst_E1, dstFiltered);
+            }
+            else if (startRO == 0 && endRO == RO - 1 && endE1 <= E1 - 1 && startE2 == 0 && endE1 == E2 - 1)
+            {
+                Gadgetron::apply_kspace_filter_E1(src, filter_src_RO, srcFiltered);
+                Gadgetron::apply_kspace_filter_E1(dst, filter_dst_RO, dstFiltered);
+            }
+            else if (startRO == 0 && endRO == RO - 1 && startE1 == 0 && endE1 == E1 - 1 && endE1 <= E2 - 1)
+            {
+                Gadgetron::apply_kspace_filter_E2(src, filter_src_RO, srcFiltered);
+                Gadgetron::apply_kspace_filter_E2(dst, filter_dst_RO, dstFiltered);
+            }
+            else
+            {
+                Gadgetron::apply_kspace_filter_ROE1E2(src, filter_src_RO, filter_src_E1, filter_src_E2, srcFiltered);
+
+                hoNDArray<T> fxyz;
+                Gadgetron::compute_3d_filter(filter_src_RO, filter_src_E1, filter_src_E2, fxyz);
+
+                size_t Nxyz = RO*E1*E2;
+                for (ii = 0; ii<Nxyz; ii++)
+                {
+                    fxyz(ii) = T(1.0) - fxyz(ii);
+                }
+
+                Gadgetron::apply_kspace_filter_ROE1E2(dst, fxyz, dstFiltered);
+            }
+
+            Gadgetron::add(srcFiltered, dstFiltered, dst);
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partial_fourier_transition_band_3d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_conjugate_symmetry_2d(const hoNDArray<T>& kspace, hoNDArray<T>& kspaceConj)
+    {
+        try
+        {
+            if (!kspaceConj.dimensions_equal(&kspace))
+            {
+                kspaceConj.create(kspace.get_dimensions());
+            }
+
+            long long RO = kspace.get_size(0);
+            long long E1 = kspace.get_size(1);
+            long long num = kspace.get_number_of_elements() / (RO*E1);
+
+            long long centerRO = RO / 2;
+            long long centerE1 = E1 / 2;
+
+            long long ii;
+
+#pragma omp parallel for default(none) private(ii) shared(RO, E1, num, centerRO, centerE1, kspace, kspaceConj)
+            for (ii = 0; ii<num; ii++)
+            {
+                ho2DArray<T> src(RO, E1, const_cast<T*>(kspace.begin() + ii*RO*E1));
+                ho2DArray<T> dst(RO, E1, const_cast<T*>(kspaceConj.begin() + ii*RO*E1));
+
+                long long ro, e1;
+                long long cro, ce1;
+
+                for (e1 = 0; e1<E1; e1++)
+                {
+                    ce1 = 2 * centerE1 - e1;
+                    if (ce1 > E1 - 1)
+                    {
+                        ce1 -= E1;
+                    }
+
+                    for (ro = 0; ro<RO; ro++)
+                    {
+                        cro = 2 * centerRO - ro;
+                        if (cro > RO - 1)
+                        {
+                            cro -= RO;
+                        }
+
+                        dst(ro, e1) = std::conj(src(cro, ce1));
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partial_fourier_conjugate_symmetry_2d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_conjugate_symmetry_3d(const hoNDArray<T>& kspace, hoNDArray<T>& kspaceConj)
+    {
+        try
+        {
+            if (!kspaceConj.dimensions_equal(&kspace))
+            {
+                kspaceConj.create(kspace.get_dimensions());
+            }
+
+            long long RO = kspace.get_size(0);
+            long long E1 = kspace.get_size(1);
+            long long E2 = kspace.get_size(2);
+            long long num = kspace.get_number_of_elements() / (RO*E1*E2);
+
+            long long centerRO = RO / 2;
+            long long centerE1 = E1 / 2;
+            long long centerE2 = E2 / 2;
+
+            long long ii;
+
+#pragma omp parallel for default(none) private(ii) shared(RO, E1, E2, num, centerRO, centerE1, centerE2, kspace, kspaceConj)
+            for (ii = 0; ii<num; ii++)
+            {
+                ho3DArray<T> src(RO, E1, E2, const_cast<T*>(kspace.begin() + ii*RO*E1*E2));
+                ho3DArray<T> dst(RO, E1, E2, const_cast<T*>(kspaceConj.begin() + ii*RO*E1*E2));
+
+                long long ro, e1, e2;
+                long long cro, ce1, ce2;
+
+                for (e2 = 0; e2<E2; e2++)
+                {
+                    ce2 = 2 * centerE2 - e2;
+                    if (ce2 > E2 - 1)
+                    {
+                        ce2 -= E2;
+                    }
+
+                    for (e1 = 0; e1<E1; e1++)
+                    {
+                        ce1 = 2 * centerE1 - e1;
+                        if (ce1 > E1 - 1)
+                        {
+                            ce1 -= E1;
+                        }
+
+                        for (ro = 0; ro<RO; ro++)
+                        {
+                            cro = 2 * centerRO - ro;
+                            if (cro > RO - 1)
+                            {
+                                cro -= RO;
+                            }
+
+                            dst(ro, e1, e2) = std::conj(src(cro, ce1, ce2));
+                        }
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partial_fourier_conjugate_symmetry_3d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    /// kspace: input kspae [RO E1 E2 ...]
+    /// if is3D==false, 2D POCS is performed, otherwise 3D POCS is performed
+    /// startRO, endRO, startE1, endE1, startE2, endE2: acquired kspace range
+    /// transit_band_RO/E1/E2: transition band width in pixel for RO/E1/E2
+    /// iter: number of maximal iterations for POCS
+    /// thres: iteration threshold
+    template <typename T> 
+    void partial_fourier_POCS(const hoNDArray<T>& kspace,
+                            size_t startRO, size_t endRO, 
+                            size_t startE1, size_t endE1, 
+                            size_t startE2, size_t endE2,
+                            size_t transit_band_RO, 
+                            size_t transit_band_E1, 
+                            size_t transit_band_E2,
+                            size_t iter, double thres, 
+                            bool is3D, 
+                            hoNDArray<T>& res,
+                            bool verbose)
+    {
+        try
+        {
+            size_t RO = kspace.get_size(0);
+            size_t E1 = kspace.get_size(1);
+            size_t E2 = kspace.get_size(2);
+
+            res = kspace;
+
+            // check whether partial fourier is used
+            if (startRO >= RO || endRO >= RO || startRO >= endRO)
+            {
+                GWARN_STREAM("partial_fourier_POCS(...) : (startRO >= RO || endRO >= RO || startRO >= endRO) ... ");
+                startRO = 0;
+                endRO = RO - 1;
+            }
+
+            if (startE1 >= E1 || endE1 >= E1 || startE1 >= endE1)
+            {
+                GWARN_STREAM("partial_fourier_POCS(...) : (startE1 >= E1 || endE1 >= E1 || startE1 >= endE1) ... ");
+                startE1 = 0;
+                endE1 = E1 - 1;
+            }
+
+            if (is3D)
+            {
+                if (startE2 >= E2 || endE2 >= E2 || startE2 >= endE2)
+                {
+                    GWARN_STREAM("partial_fourier_POCS(...) : (startE2 >= E2 || endE2 >= E2 || startE2 >= endE2) ... ");
+                    startE2 = 0;
+                    endE2 = E2 - 1;
+                }
+            }
+
+            if ((endRO - startRO + 1 == RO) && (endE1 - startE1 + 1 == E1) && (endE2 - startE2 + 1 == E2))
+            {
+                GWARN_STREAM("partial_fourier_POCS(...) : (endRO - startRO + 1 == RO) && (endE1 - startE1 + 1 == E1) && (endE2 - startE2 + 1 == E2) ... ");
+                return;
+            }
+
+            // create kspace filter for homodyne phase estimation
+            hoNDArray<T> filterRO(RO);
+            Gadgetron::generate_symmetric_filter_ref(RO, startRO, endRO, filterRO);
+
+            hoNDArray<T> filterE1(E1);
+            Gadgetron::generate_symmetric_filter_ref(E1, startE1, endE1, filterE1);
+
+            hoNDArray<T> filterE2(E2);
+            if (is3D)
+            {
+                Gadgetron::generate_symmetric_filter_ref(E2, startE2, endE2, filterE2);
+            }
+
+            hoNDArray<T> kspaceIter(kspace);
+            // magnitude of complex images
+            hoNDArray<typename realType<T>::Type> mag(kspace.get_dimensions());
+            hoNDArray<T> magComplex(kspace.get_dimensions());
+
+            // kspace filter
+            hoNDArray<T> buffer_partial_fourier(kspaceIter), buffer(kspaceIter);
+
+            if (is3D)
+            {
+                Gadgetron::apply_kspace_filter_ROE1E2(kspaceIter, filterRO, filterE1, filterE2, buffer_partial_fourier);
+
+                // go to image domain
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft3c(buffer_partial_fourier);
+            }
+            else
+            {
+                Gadgetron::apply_kspace_filter_ROE1(kspaceIter, filterRO, filterE1, buffer_partial_fourier);
+
+                // go to image domain
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft2c(buffer_partial_fourier);
+            }
+
+            // get the complex image phase for the filtered kspace
+            Gadgetron::abs(buffer_partial_fourier, mag);
+            Gadgetron::addEpsilon(mag);
+            magComplex.copyFrom(mag);
+            Gadgetron::divide(buffer_partial_fourier, magComplex, buffer);
+
+            // complex images, initialized as not filtered complex image
+            hoNDArray<T> complexIm(kspaceIter);
+
+            if (is3D)
+            {
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft3c(kspaceIter, complexIm);
+            }
+            else
+            {
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft2c(kspaceIter, complexIm);
+            }
+
+            hoNDArray<T> complexImPOCS(complexIm);
+
+            // the kspace during iteration is buffered here
+            hoNDArray<T> buffer_partial_fourier_Iter(kspaceIter);
+
+            size_t ii;
+            for (ii = 0; ii<iter; ii++)
+            {
+                Gadgetron::abs(complexImPOCS, mag);
+                magComplex.copyFrom(mag);
+                Gadgetron::multiply(magComplex, buffer, complexImPOCS);
+
+                // go back to kspace
+                if (is3D)
+                {
+                    Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->fft3c(complexImPOCS, kspaceIter);
+                }
+                else
+                {
+                    Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->fft2c(complexImPOCS, kspaceIter);
+                }
+
+                // buffer kspace during iteration
+                buffer_partial_fourier_Iter = kspaceIter;
+
+                // restore the acquired region
+                if (is3D)
+                {
+                    partial_fourier_reset_kspace_3d(kspace, kspaceIter, startRO, endRO, startE1, endE1, startE2, endE2);
+
+                    // update complex image
+                    Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft3c(kspaceIter, complexImPOCS);
+                }
+                else
+                {
+                    partial_fourier_reset_kspace_2d(kspace, kspaceIter, startRO, endRO, startE1, endE1);
+
+                    // update complex image
+                    Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft2c(kspaceIter, complexImPOCS);
+                }
+
+                // compute threshold to stop the iteration
+                Gadgetron::subtract(complexImPOCS, complexIm, buffer_partial_fourier);
+                typename realType<T>::Type diff, prev;
+                Gadgetron::norm2(complexIm, prev);
+                Gadgetron::norm2(buffer_partial_fourier, diff);
+
+                typename realType<T>::Type t = diff / prev;
+
+                if (verbose)
+                {
+                    GDEBUG_STREAM("POCS iter : " << ii << " - thres : " << t << " ... ");
+                }
+
+                if (t < thres)
+                {
+                    break;
+                }
+
+                complexIm = complexImPOCS;
+            }
+
+            if (transit_band_RO == 0 && transit_band_E1 == 0 && transit_band_E2==0)
+            {
+                res = kspaceIter;
+            }
+            else
+            {
+                if (is3D)
+                {
+                    Gadgetron::partial_fourier_transition_band_3d(kspace, buffer_partial_fourier_Iter, startRO, endRO, startE1, endE1, startE2, endE2, transit_band_RO, transit_band_E1, transit_band_E2);
+                }
+                else
+                {
+                    Gadgetron::partial_fourier_transition_band_2d(kspace, buffer_partial_fourier_Iter, startRO, endRO, startE1, endE1, transit_band_RO, transit_band_E1);
+                }
+
+                res = buffer_partial_fourier_Iter;
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors happened in partial_fourier_POCS(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_FengHuang_calib_2d(const hoNDArray<T>& src, const hoNDArray<T>& dst, size_t kRO, size_t kE1, double thres, hoNDArray<T>& kernel)
+    {
+        try
+        {
+            GADGET_CHECK_THROW(src.dimensions_equal(&dst));
+
+            long long RO = (long long)src.get_size(0);
+            long long E1 = (long long)src.get_size(1);
+
+            long long kx = (long long)kRO;
+            long long ky = (long long)kE1;
+
+            if (kx % 2 == 0) kx++;
+            if (ky % 2 == 0) ky++;
+
+            long long halfKx = (long long)kx / 2;
+            long long halfKy = (long long)ky / 2;
+
+            /// the cross-channel kernel is not estimated
+            std::vector<size_t> dim;
+            src.get_dimensions(dim);
+
+            dim[0] = kx;
+            dim[1] = ky;
+
+            kernel.create(dim);
+
+            long long ii = 0;
+            long long num = kernel.get_number_of_elements() / (kx*ky);
+
+            size_t startRO = halfKx;
+            size_t endRO = RO - halfKx - 1;
+
+            size_t startE1 = halfKy;
+            size_t endE1 = E1 - halfKy - 1;
+
+            long long rowA, colA, rowB, colB;
+            rowA = (endE1 - startE1 + 1)*(endRO - startRO + 1);
+            colA = kx*ky;
+
+            rowB = rowA;
+            colB = 1;
+
+#pragma omp parallel default(none) private(ii) shared(num, RO, E1, kx, ky, src, dst, kernel, rowA, colA, rowB, colB, startRO, endRO, startE1, endE1, halfKx, halfKy, thres)
+            {
+                hoMatrix<T> A(rowA, colA);
+                T* pA = A.begin();
+
+                hoMatrix<T> B(rowB, colB);
+                T* pB = B.begin();
+
+                hoMatrix<T> K(colA, colB);
+
+#pragma omp for
+                for (ii = 0; ii<num; ii++)
+                {
+                    T* pSrc2D = const_cast<T*>(src.begin()) + ii*RO*E1;
+                    T* pDst2D = const_cast<T*>(dst.begin()) + ii*RO*E1;
+
+                    size_t ro, e1, row(0);
+                    long long x, y;
+
+                    for (e1 = startE1; e1 <= endE1; e1++)
+                    {
+                        for (ro = startRO; ro <= endRO; ro++)
+                        {
+
+                            size_t colInd(0);
+                            for (y = -halfKy; y <= halfKy; y++)
+                            {
+                                for (x = -halfKx; x <= halfKx; x++)
+                                {
+                                    pA[row + colInd*rowA] = pSrc2D[ro + x + (e1 + y)*RO];
+                                    colInd++;
+                                }
+                            }
+
+                            pB[row] = pDst2D[ro + e1*RO];
+
+                            row++;
+                        }
+                    }
+
+                    Gadgetron::SolveLinearSystem_Tikhonov(A, B, K, thres);
+
+                    memcpy(kernel.begin() + ii*kx*ky, K.begin(), sizeof(T)*kx*ky);
+                }
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors happened in partial_fourier_FengHuang_calib_2d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_FengHuang_apply_kernel_2d(const hoNDArray<T>& kspaceConj, size_t startRO, size_t endRO, size_t startE1, size_t endE1, const hoNDArray<T>& kernel, hoNDArray<T>& kspace)
+    {
+        try
+        {
+            GADGET_CHECK_THROW(kspaceConj.dimensions_equal(&kspace));
+
+            long long RO = (long long)kspace.get_size(0);
+            long long E1 = (long long)kspace.get_size(1);
+
+            long long kx = (long long)kernel.get_size(0);
+            long long ky = (long long)kernel.get_size(1);
+
+            long long halfKx = kx / 2;
+            long long halfKy = ky / 2;
+
+            long long num = kspace.get_number_of_elements() / (RO*E1);
+
+            long long rowD = RO*E1 - ((endE1 - startE1 + 1) * (endRO - startRO + 1));
+            long long colD = kx*ky;
+
+            ho2DArray<size_t> coeffX(rowD, colD);
+            ho2DArray<size_t> coeffY(rowD, colD);
+
+            long long ro, e1, row(0);
+            long long x, y, dx, dy;
+
+            for (e1 = 0; e1<E1; e1++)
+            {
+                for (ro = 0; ro<RO; ro++)
+                {
+                    if ((ro >= (long long)startRO) && (ro <= (long long)endRO) && (e1 >= (long long)startE1) && (e1 <= (long long)endE1))
+                    {
+                        continue;
+                    }
+
+                    size_t colInd(0);
+                    for (y = -halfKy; y <= halfKy; y++)
+                    {
+                        dy = e1 + y;
+                        if (dy < 0) dy += E1;
+                        if (dy > E1 - 1) dy -= E1;
+
+                        for (x = -halfKx; x <= halfKx; x++)
+                        {
+                            dx = ro + x;
+                            if (dx < 0) dx += RO;
+                            if (dx > RO - 1) dx -= RO;
+
+                            coeffX(row, colInd) = dx;
+                            coeffY(row, colInd) = dy;
+                            colInd++;
+                        }
+                    }
+
+                    row++;
+                }
+            }
+
+            long long ii;
+#pragma omp parallel default(none) private(ii) shared(num, RO, E1, kspaceConj, kspace, kernel, rowD, colD, coeffX, coeffY)
+            {
+                hoMatrix<T> D(rowD, colD);
+                hoMatrix<T> K(colD, 1);
+                hoMatrix<T> R(rowD, 1);
+
+                Gadgetron::clear(D);
+                Gadgetron::clear(K);
+                Gadgetron::clear(R);
+
+#pragma omp for
+                for (ii = 0; ii<num; ii++)
+                {
+                    ho2DArray<T> src2D(RO, E1, const_cast<T*>(kspaceConj.begin()) + ii*RO*E1);
+                    ho2DArray<T> dst2D(RO, E1, kspace.begin() + ii*RO*E1);
+
+                    long long row, col;
+                    for (col = 0; col<colD; col++)
+                    {
+                        for (row = 0; row<rowD; row++)
+                        {
+                            D(row, col) = src2D(coeffX(row, col), coeffY(row, col));
+                        }
+                    }
+
+                    memcpy(K.begin(), kernel.begin() + ii*colD, sizeof(T)*colD);
+
+                    // R = D*K
+                    Gadgetron::gemm(R, D, false, K, false);
+
+                    for (row = 0; row<rowD; row++)
+                    {
+                        dst2D(coeffX(row, colD / 2), coeffY(row, colD / 2)) = R(row, 0);
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors happened in partial_fourier_FengHuang_apply_kernel_2d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    void partial_fourier_FengHuang_2d(const hoNDArray<T>& kspace,
+                                    size_t startRO, size_t endRO,
+                                    size_t startE1, size_t endE1,
+                                    size_t transit_band_RO,
+                                    size_t transit_band_E1,
+                                    size_t kRO, size_t kE1,
+                                    double thres,
+                                    hoNDArray<T>& res)
+    {
+        try
+        {
+            size_t RO = kspace.get_size(0);
+            size_t E1 = kspace.get_size(1);
+
+            res = kspace;
+
+            if (startRO >= RO || endRO >= RO || startRO >= endRO)
+            {
+                GWARN_STREAM("partial_fourier_FengHuang_2d(...) : (startRO >= RO || endRO >= RO || startRO >= endRO) ... ");
+                startRO = 0;
+                endRO = RO - 1;
+            }
+
+            if (startE1 >= E1 || endE1 >= E1 || startE1 >= endE1)
+            {
+                GWARN_STREAM("partial_fourier_FengHuang_2d(...) : (startE1 >= E1 || endE1 >= E1 || startE1 >= endE1) ... ");
+                startE1 = 0;
+                endE1 = E1 - 1;
+            }
+
+            if ((endRO - startRO + 1 == RO) && (endE1 - startE1 + 1 == E1) )
+            {
+                GWARN_STREAM("partial_fourier_FengHuang_2d(...) : (endRO - startRO + 1 == RO) && (endE1 - startE1 + 1 == E1) ... ");
+                return;
+            }
+
+            // compute the conjugate symmetric kspace
+            hoNDArray<T> buffer2DT_;
+            Gadgetron::partial_fourier_conjugate_symmetry_2d(kspace, buffer2DT_);
+
+            // find the symmetric region in the kspace
+            size_t startSymRO, endSymRO;
+            Gadgetron::find_symmetric_sampled_region(startRO, endRO, RO / 2, startSymRO, endSymRO);
+
+            size_t startSymE1, endSymE1;
+            Gadgetron::find_symmetric_sampled_region(startE1, endE1, E1 / 2, startSymE1, endSymE1);
+
+            // the reference kspace for kernel estimation
+            hoNDArray<T> src, dst;
+            Gadgetron::vector_td<size_t, 2> start, size;
+
+            start[0] = startSymRO;
+            start[1] = startSymE1;
+
+            size[0] = endSymRO - startSymRO + 1;
+            size[1] = endSymE1 - startSymE1 + 1;
+
+            Gadgetron::crop(start, size, &buffer2DT_, &src);
+            Gadgetron::crop(start, size, const_cast< hoNDArray<T>* >(&kspace), &dst);
+
+            // estimate the kernels
+            hoNDArray<T> kernel;
+            Gadgetron::partial_fourier_FengHuang_calib_2d(src, dst, kRO, kE1, thres, kernel);
+
+            // perform the recon
+            if (transit_band_RO == 0 && transit_band_E1 == 0)
+            {
+                partial_fourier_FengHuang_apply_kernel_2d(buffer2DT_, startRO, endRO, startE1, endE1, kernel, res);
+            }
+            else
+            {
+                size_t sRO(startRO), eRO(endRO), sE1(startE1), eE1(endE1);
+
+                if (startRO > 0)
+                {
+                    startRO += transit_band_RO;
+                    if (startRO > RO) startRO = 0;
+                }
+
+                if (endRO < RO - 1)
+                {
+                    endRO -= transit_band_RO;
+                }
+
+                if (startRO > endRO)
+                {
+                    startRO = 0;
+                    endRO = RO - 1;
+                }
+
+                if (startE1 > 0)
+                {
+                    startE1 += transit_band_E1;
+                    if (startE1 > E1) startE1 = 0;
+                }
+
+                if (endE1 < E1 - 1)
+                {
+                    endE1 -= transit_band_E1;
+                }
+
+                if (startE1 > endE1)
+                {
+                    startE1 = 0;
+                    endE1 = E1 - 1;
+                }
+
+                Gadgetron::partial_fourier_FengHuang_apply_kernel_2d(buffer2DT_, startRO, endRO, startE1, endE1, kernel, res);
+
+                Gadgetron::partial_fourier_transition_band_2d(kspace, res, sRO, eRO, sE1, eE1, transit_band_RO, transit_band_E1);
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors happened in partial_fourier_FengHuang_2d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_FengHuang_calib_3d(const hoNDArray<T>& src, const hoNDArray<T>& dst, size_t kRO, size_t kE1, size_t kE2, double thres, hoNDArray<T>& kernel)
+    {
+        try
+        {
+            GADGET_CHECK_THROW(src.dimensions_equal(&dst));
+
+            long long RO = (long long)src.get_size(0);
+            long long E1 = (long long)src.get_size(1);
+            long long E2 = (long long)src.get_size(2);
+
+            long long kx = (long long)kRO;
+            long long ky = (long long)kE1;
+            long long kz = (long long)kE2;
+
+            if (kx % 2 == 0) kx++;
+            if (ky % 2 == 0) ky++;
+            if (kz % 2 == 0) kz++;
+
+            long long halfKx = (long long)kx / 2;
+            long long halfKy = (long long)ky / 2;
+            long long halfKz = (long long)kz / 2;
+
+            // the cross-channel kernel is not estimated
+            std::vector<size_t> dim;
+            src.get_dimensions(dim);
+
+            dim[0] = kx;
+            dim[1] = ky;
+            dim[2] = kz;
+
+            kernel.create(dim);
+
+            long long ii = 0;
+            long long num = kernel.get_number_of_elements()/(kx*ky*kz);
+
+            long long startRO = halfKx;
+            long long endRO = RO - halfKx - 1;
+
+            long long startE1 = halfKy;
+            long long endE1 = E1 - halfKy - 1;
+
+            long long startE2 = halfKz;
+            long long endE2 = E2 - halfKz - 1;
+
+            long long rowA, colA, rowB, colB;
+            rowA = (endE2 - startE2 + 1)*(endE1 - startE1 + 1)*(endRO - startRO + 1);
+            colA = kx*ky*kz;
+
+            rowB = rowA;
+            colB = 1;
+
+#pragma omp parallel default(none) private(ii) shared(num, RO, E1, E2, kx, ky, kz, src, dst, kernel, rowA, colA, rowB, colB, startRO, endRO, startE1, endE1, startE2, endE2, halfKx, halfKy, halfKz, thres) if ( num > 1 ) num_threads( (int)(num<16 ? num : 16) )
+            {
+                hoNDArray<T> A_mem(rowA, colA);
+                hoNDArray<T> B_mem(rowB, colB);
+                hoNDArray<T> K_mem(colA, colB);
+
+                hoMatrix<T> A(rowA, colA, A_mem.begin());
+                hoMatrix<T> B(rowB, colB, B_mem.begin());
+                hoMatrix<T> K(colA, colB, K_mem.begin());
+
+#pragma omp for
+                for (ii = 0; ii<num; ii++)
+                {
+                    ho3DArray<T> src3D(RO, E1, E2, const_cast<T*>(src.begin()) + ii*RO*E1*E2);
+                    ho3DArray<T> dst3D(RO, E1, E2, const_cast<T*>(dst.begin()) + ii*RO*E1*E2);
+
+                    long long ro, e1, e2, row(0);
+                    long long x, y, z;
+
+                    for (e2 = startE2; e2 <= endE2; e2++)
+                    {
+                        for (e1 = startE1; e1 <= endE1; e1++)
+                        {
+                            for (ro = startRO; ro <= endRO; ro++)
+                            {
+
+                                size_t colInd(0);
+                                for (z = -halfKz; z <= halfKz; z++)
+                                {
+                                    for (y = -halfKy; y <= halfKy; y++)
+                                    {
+                                        for (x = -halfKx; x <= halfKx; x++)
+                                        {
+                                            A(row, colInd++) = src3D(ro + x, e1 + y, e2 + z);
+                                        }
+                                    }
+                                }
+
+                                B(row, 0) = dst3D(ro, e1, e2);
+
+                                row++;
+                            }
+                        }
+                    }
+
+                    Gadgetron::SolveLinearSystem_Tikhonov(A, B, K, thres);
+
+                    memcpy(kernel.begin() + ii*kx*ky*kz, K.begin(), sizeof(T)*kx*ky*kz);
+                }
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors happened in partial_fourier_FengHuang_calib_3d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_FengHuang_apply_kernel_3d(const hoNDArray<T>& kspaceConj, size_t startRO, size_t endRO, size_t startE1, size_t endE1, size_t startE2, size_t endE2, const hoNDArray<T>& kernel, hoNDArray<T>& kspace)
+    {
+        try
+        {
+            GADGET_CHECK_THROW(kspaceConj.dimensions_equal(&kspace));
+
+            long long RO = (long long)kspace.get_size(0);
+            long long E1 = (long long)kspace.get_size(1);
+            long long E2 = (long long)kspace.get_size(2);
+
+            long long kx = (long long)kernel.get_size(0);
+            long long ky = (long long)kernel.get_size(1);
+            long long kz = (long long)kernel.get_size(2);
+
+            long long halfKx = kx / 2;
+            long long halfKy = ky / 2;
+            long long halfKz = kz / 2;
+
+            long long num = kspace.get_number_of_elements()/(RO*E1*E2);
+
+            long long rowD = RO*E1*E2 - ((endE2 - startE2 + 1) * (endE1 - startE1 + 1) * (endRO - startRO + 1));
+            long long colD = kx*ky*kz;
+
+            ho2DArray<long long> coeffX(colD, rowD);
+            long long* pCx = coeffX.begin();
+
+            ho2DArray<long long> coeffY(colD, rowD);
+            long long* pCy = coeffY.begin();
+
+            ho2DArray<long long> coeffZ(colD, rowD);
+            long long* pCz = coeffZ.begin();
+
+            long long ro, e1, e2;
+            long long row(0);
+            long long x, y, z;
+
+            ho2DArray<long long> rowInd(3, rowD);
+            long long* pRowInd = rowInd.begin();
+
+            hoNDArray<long long> offsetX(colD);
+            long long* pOffsetX = offsetX.begin();
+
+            hoNDArray<long long> offsetY(colD);
+            long long* pOffsetY = offsetY.begin();
+
+            hoNDArray<long long> offsetZ(colD);
+            long long* pOffsetZ = offsetZ.begin();
+
+            long long colInd(0);
+            for (z = -halfKz; z <= halfKz; z++)
+            {
+                for (y = -halfKy; y <= halfKy; y++)
+                {
+                    for (x = -halfKx; x <= halfKx; x++)
+                    {
+                        offsetX(colInd) = x;
+                        offsetY(colInd) = y;
+                        offsetZ(colInd) = z;
+                        colInd++;
+                    }
+                }
+            }
+
+            long long* pRowIndCurr;
+            for (e2 = 0; e2<E2; e2++)
+            {
+                for (e1 = 0; e1<E1; e1++)
+                {
+                    for (ro = 0; ro<RO; ro++)
+                    {
+                        if ((ro >= (long long)startRO) && (ro <= (long long)endRO) && (e1 >= (long long)startE1) && (e1 <= (long long)endE1) && (e2 >= (long long)startE2) && (e2 <= (long long)endE2))
+                        {
+                            continue;
+                        }
+
+                        pRowIndCurr = pRowInd + row * 3;
+
+                        pRowIndCurr[0] = ro;
+                        pRowIndCurr[1] = e1;
+                        pRowIndCurr[2] = e2;
+
+                        row++;
+                    }
+                }
+            }
+
+            long long r;
+#pragma omp parallel for default(none) private(r) shared(rowD, colD, pCx, pCy, pCz, pRowInd, pRowIndCurr, pOffsetX, pOffsetY, pOffsetZ)
+            for (r = 0; r<rowD; r++)
+            {
+                long long offsetC = r*colD;
+                pRowIndCurr = pRowInd + r * 3;
+
+                for (int colInd = 0; colInd<colD; colInd++)
+                {
+                    pCx[offsetC + colInd] = pRowIndCurr[0] + pOffsetX[colInd];
+                    pCy[offsetC + colInd] = pRowIndCurr[1] + pOffsetY[colInd];
+                    pCz[offsetC + colInd] = pRowIndCurr[2] + pOffsetZ[colInd];
+                }
+            }
+
+#pragma omp parallel for default(none) private(r) shared(rowD, colD, pCx, pCy, pCz, RO, E1, E2)
+            for (r = 0; r<rowD; r++)
+            {
+                for (int c = 0; c<colD; c++)
+                {
+                    long long offset = c + r*colD;
+
+                    if (pCx[offset] < 0)
+                    {
+                        pCx[offset] += RO;
+                    }
+                    else if (pCx[offset] > RO - 1)
+                    {
+                        pCx[offset] -= RO;
+                    }
+
+                    if (pCy[offset] < 0)
+                    {
+                        pCy[offset] += E1;
+                    }
+                    else if (pCy[offset] > E1 - 1)
+                    {
+                        pCy[offset] -= E1;
+                    }
+
+                    if (pCz[offset] < 0)
+                    {
+                        pCz[offset] += E2;
+                    }
+                    else if (pCz[offset] > E2 - 1)
+                    {
+                        pCz[offset] -= E2;
+                    }
+                }
+            }
+
+            long long ii;
+            int numOfThreads = (int)((num>4) ? 4 : num);
+#pragma omp parallel default(none) private(ii) shared(num, RO, E1, E2, kspaceConj, kspace, kernel, rowD, colD, coeffX, coeffY, coeffZ, pCx, pCy, pCz) if ( num > 1 ) num_threads( numOfThreads )
+            {
+                hoNDArray<T> D_mem(rowD, colD);
+
+                hoMatrix<T> D(rowD, colD, D_mem.begin());
+                T* pD = D.begin();
+
+                hoMatrix<T> K(colD, 1);
+                hoMatrix<T> R(rowD, 1);
+
+                Gadgetron::clear(D);
+                Gadgetron::clear(K);
+                Gadgetron::clear(R);
+
+#pragma omp for
+                for (ii = 0; ii<num; ii++)
+                {
+                    ho3DArray<T> src3D(RO, E1, E2, const_cast<T*>(kspaceConj.begin()) + ii*RO*E1*E2);
+                    ho3DArray<T> dst3D(RO, E1, E2, kspace.begin() + ii*RO*E1*E2);
+
+                    long long row;
+
+                    for (row = 0; row<rowD; row++)
+                    {
+                        for (long long col = 0; col<colD; col++)
+                        {
+                            long long offset = col + row*colD;
+                            pD[offset] = src3D(pCx[offset], pCy[offset], pCz[offset]);
+                        }
+                    }
+
+                    memcpy(K.begin(), kernel.begin() + ii*colD, sizeof(T)*colD);
+
+                    // R = D*K
+                    Gadgetron::gemm(R, D, false, K, false);
+
+                    size_t colCenter = colD / 2;
+
+                    for (row = 0; row<rowD; row++)
+                    {
+                        dst3D(coeffX(colCenter, row), coeffY(colCenter, row), coeffZ(colCenter, row)) = R(row, 0);
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors happened in partial_fourier_FengHuang_apply_kernel_3d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void partial_fourier_FengHuang_3d(const hoNDArray<T>& kspace,
+        size_t startRO, size_t endRO,
+        size_t startE1, size_t endE1,
+        size_t startE2, size_t endE2,
+        size_t transit_band_RO,
+        size_t transit_band_E1,
+        size_t transit_band_E2,
+        size_t kRO, size_t kE1, size_t kE2,
+        double thres,
+        hoNDArray<T>& res)
+    {
+        try
+        {
+            size_t RO = kspace.get_size(0);
+            size_t E1 = kspace.get_size(1);
+            size_t E2 = kspace.get_size(2);
+
+            res = kspace;
+
+            if (startRO >= RO || endRO >= RO || startRO >= endRO)
+            {
+                GWARN_STREAM("partial_fourier_FengHuang_3d(...) : (startRO >= RO || endRO >= RO || startRO >= endRO) ... ");
+                startRO = 0;
+                endRO = RO - 1;
+            }
+
+            if (startE1 >= E1 || endE1 >= E1 || startE1 >= endE1)
+            {
+                GWARN_STREAM("partial_fourier_FengHuang_3d(...) : (startE1 >= E1 || endE1 >= E1 || startE1 >= endE1) ... ");
+                startE1 = 0;
+                endE1 = E1 - 1;
+            }
+
+            if (startE2 >= E2 || endE2 >= E2 || startE2 >= endE2)
+            {
+                GWARN_STREAM("partial_fourier_FengHuang_3d(...) : (startE2 >= E2 || endE2 >= E2 || startE2 >= endE2) ... ");
+                startE2 = 0;
+                endE2 = E2 - 1;
+            }
+
+            if ((endRO - startRO + 1 == RO) && (endE1 - startE1 + 1 == E1) && (endE2 - startE2 + 1 == E2))
+            {
+                GWARN_STREAM("partial_fourier_FengHuang_3d(...) : (endRO - startRO + 1 == RO) && (endE1 - startE1 + 1 == E1) && (endE2 - startE2 + 1 == E2) ... ");
+                return;
+            }
+
+            // compute the conjugate symmetric kspace
+            hoNDArray<T> buffer3DT(kspace.get_dimensions());
+            Gadgetron::partial_fourier_conjugate_symmetry_3d(kspace, buffer3DT);
+
+            // find the symmetric region in the kspace
+            size_t startSymRO, endSymRO;
+            Gadgetron::find_symmetric_sampled_region(startRO, endRO, RO / 2, startSymRO, endSymRO);
+
+            size_t startSymE1, endSymE1;
+            Gadgetron::find_symmetric_sampled_region(startE1, endE1, E1 / 2, startSymE1, endSymE1);
+
+            size_t startSymE2, endSymE2;
+            Gadgetron::find_symmetric_sampled_region(startE2, endE2, E2 / 2, startSymE2, endSymE2);
+
+            // the reference kspace for kernel estimation
+            hoNDArray<T> src, dst;
+            Gadgetron::vector_td<size_t, 3> start, size;
+
+            start[0] = startSymRO;
+            start[1] = startSymE1;
+            start[2] = startSymE2;
+
+            size[0] = endSymRO - startSymRO + 1;
+            size[1] = endSymE1 - startSymE1 + 1;
+            size[2] = endSymE2 - startSymE2 + 1;;
+
+            Gadgetron::crop(start, size, &buffer3DT, &src);
+            Gadgetron::crop(start, size, const_cast< hoNDArray<T>* >(&kspace), &dst);
+
+            // estimate the kernels
+            hoNDArray<T> kernel;
+            Gadgetron::partial_fourier_FengHuang_calib_3d(src, dst, kRO, kE1, kE2, thres, kernel);
+
+            // perform the recon
+            if (transit_band_RO == 0 && transit_band_E1 == 0 && transit_band_E2 == 0)
+            {
+                Gadgetron::partial_fourier_FengHuang_apply_kernel_3d(buffer3DT, startRO, endRO, startE1, endE1, startE2, endE2, kernel, res);
+            }
+            else
+            {
+                long long sRO(startRO), eRO(endRO), sE1(startE1), eE1(endE1), sE2(startE2), eE2(endE2);
+
+                if (startRO > 0)
+                {
+                    startRO += transit_band_RO;
+                    if (startRO > RO) startRO = 0;
+                }
+
+                if (endRO < RO - 1)
+                {
+                    endRO -= transit_band_RO;
+                }
+
+                if (startRO > endRO)
+                {
+                    startRO = 0;
+                    endRO = RO - 1;
+                }
+
+                if (startE1 > 0)
+                {
+                    startE1 += transit_band_E1;
+                    if (startE1 > E1) startE1 = 0;
+                }
+
+                if (endE1 < E1 - 1)
+                {
+                    endE1 -= transit_band_E1;
+                }
+
+                if (startE1 > endE1)
+                {
+                    startE1 = 0;
+                    endE1 = E1 - 1;
+                }
+
+                if (startE2 > 0)
+                {
+                    startE2 += transit_band_E2;
+                    if (startE2 > E2) startE2 = 0;
+                }
+
+                if (endE2 < E2 - 1)
+                {
+                    endE2 -= transit_band_E2;
+                }
+
+                if (startE2 > endE2)
+                {
+                    startE2 = 0;
+                    endE2 = E2 - 1;
+                }
+
+                Gadgetron::partial_fourier_FengHuang_apply_kernel_3d(buffer3DT, startRO, endRO, startE1, endE1, startE2, endE2, kernel, res);
+
+
+                Gadgetron::partial_fourier_transition_band_3d(kspace, res, sRO, eRO, sE1, eE1, sE2, eE2, transit_band_RO, transit_band_E1, transit_band_E2);
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors happened in partial_fourier_FengHuang_3d(...) ... ");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    partialFourierCartesianHandler<T>::partialFourierCartesianHandler()
+    {
+        start_RO_ = 0;
+        end_RO_ = 0;
+
+        start_E1_ = 0;
+        end_E1_ = 0;
+
+        start_E2_ = 0;
+        end_E2_ = 0;
+
+        transit_band_RO_ = 24;
+        transit_band_E1_ = 24;
+        transit_band_E2_ = 24;
+
+        verbose_ = false;
+    }
+
+    template <typename T>
+    partialFourierCartesianHandler<T>::~partialFourierCartesianHandler()
+    {
+    }
+
+    template <typename T>
+    void partialFourierCartesianHandler<T>::dump(std::ostream& os) const
+    {
+        using namespace std;
+        os << "-------------------------------------------------------------------------------" << endl;
+        os << "partialFourierCartesianHandler will fill the unsampled region in case of partial fourier or asymmetric echo for the signle/multi-channel complex images ... " << endl;
+        os << "partial_fourier_2d and partial_fourier_3d functions should be implemented ... " << endl;
+        os << "-------------------------------------------------------------------------------" << endl;
+    }
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    partialFourierCartesianFilterHandler<T>::partialFourierCartesianFilterHandler() : BaseClass()
+    {
+        filter_pf_density_comp_ = false;
+        filter_pf_width_RO_ = 0.15;
+        filter_pf_width_E1_ = 0.15;
+        filter_pf_width_E2_ = 0.15;
+    }
+
+    template <typename T>
+    partialFourierCartesianFilterHandler<T>::~partialFourierCartesianFilterHandler()
+    {
+    }
+
+    template <typename T>
+    void partialFourierCartesianFilterHandler<T>::partial_fourier(const hoNDArray<T>& kspace, hoNDArray<T>& res)
+    {
+        try
+        {
+            size_t RO = kspace.get_size(0);
+            size_t E1 = kspace.get_size(1);
+            size_t E2 = kspace.get_size(2);
+
+            size_t lenRO = end_RO_ - start_RO_ + 1;
+            if (filter_RO_pf_.get_size(0) != RO && lenRO<RO)
+            {
+                Gadgetron::generate_asymmetric_filter(RO, start_RO_, end_RO_, filter_RO_pf_, ISMRMRD_FILTER_TAPERED_HANNING, (size_t)(RO*filter_pf_width_RO_), filter_pf_density_comp_);
+            }
+
+            size_t lenE1 = end_E1_ - start_E1_ + 1;
+            if (filter_E1_pf_.get_size(0) != E1 && lenE1<E1)
+            {
+                Gadgetron::generate_asymmetric_filter(E1, start_E1_, end_E1_, filter_E1_pf_, ISMRMRD_FILTER_TAPERED_HANNING, (size_t)(E1*filter_pf_width_E1_), filter_pf_density_comp_);
+            }
+
+            res = kspace;
+
+            size_t lenE2 = end_E2_ - start_E2_ + 1;
+
+            if (E2 > 1)
+            {
+                if (filter_E2_pf_.get_size(0) != E2 && lenE2 < E2)
+                {
+                    Gadgetron::generate_asymmetric_filter(E2, start_E2_, end_E2_, filter_E2_pf_, ISMRMRD_FILTER_TAPERED_HANNING, (size_t)(E2*filter_pf_width_E2_), filter_pf_density_comp_);
+                }
+
+                if ((filter_RO_pf_.get_number_of_elements() == RO) && (filter_E1_pf_.get_number_of_elements() == E1) && (filter_E2_pf_.get_number_of_elements() == E2))
+                {
+                    Gadgetron::apply_kspace_filter_ROE1E2(kspace, filter_RO_pf_, filter_E1_pf_, filter_E2_pf_, res);
+                }
+                else
+                {
+                    if ((filter_RO_pf_.get_number_of_elements() == RO)
+                        || (filter_E1_pf_.get_number_of_elements() == E1)
+                        || (filter_E2_pf_.get_number_of_elements() == E2))
+                    {
+                        hoNDArray<T> kspace_copy(kspace);
+
+                        hoNDArray<T>* pSrc = const_cast<hoNDArray<T>*>(&kspace_copy);
+                        hoNDArray<T>* pDst = &res;
+
+                        bool filterPerformed = false;
+
+                        if (filter_RO_pf_.get_number_of_elements() == RO)
+                        {
+                            Gadgetron::apply_kspace_filter_RO(*pSrc, filter_RO_pf_, *pDst);
+                            std::swap(pSrc, pDst);
+                            filterPerformed = true;
+                        }
+
+                        if (filter_E1_pf_.get_number_of_elements() == E1)
+                        {
+                            Gadgetron::apply_kspace_filter_E1(*pSrc, filter_E1_pf_, *pDst);
+                            std::swap(pSrc, pDst);
+                            filterPerformed = true;
+                        }
+
+                        if (filter_E2_pf_.get_number_of_elements() == E2)
+                        {
+                            Gadgetron::apply_kspace_filter_E2(*pSrc, filter_E2_pf_, *pDst);
+                            std::swap(pSrc, pDst);
+                            filterPerformed = true;
+                        }
+
+                        if (filterPerformed && pDst != &res)
+                        {
+                            res = *pDst;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if ((filter_RO_pf_.get_number_of_elements() == RO) && (filter_E1_pf_.get_number_of_elements() == E1))
+                {
+                    Gadgetron::apply_kspace_filter_ROE1(kspace, filter_RO_pf_, filter_E1_pf_, res);
+                }
+                else
+                {
+                    if (filter_RO_pf_.get_number_of_elements() == RO && filter_E1_pf_.get_number_of_elements() != E1)
+                    {
+                        Gadgetron::apply_kspace_filter_RO(kspace, filter_RO_pf_, res);
+                    }
+                    else if (filter_RO_pf_.get_number_of_elements() != RO && filter_E1_pf_.get_number_of_elements() == E1)
+                    {
+                        Gadgetron::apply_kspace_filter_E1(kspace, filter_E1_pf_, res);
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partialFourierCartesianFilterHandler<T>::partial_fourier(...) ... ");
+        }
+    }
+
+    template <typename T>
+    void partialFourierCartesianFilterHandler<T>::dump(std::ostream& os) const
+    {
+        using namespace std;
+        os << "-------------------------------------------------------------------------------" << endl;
+        os << "partialFourierCartesianFilterHandler ... " << endl;
+        os << "filter_pf_density_comp_ is " << filter_pf_density_comp_ << endl;
+        os << "filter_pf_width_RO_ is " << filter_pf_width_RO_ << endl;
+        os << "filter_pf_width_E1_ is " << filter_pf_width_E1_ << endl;
+        os << "filter_pf_width_E2_ is " << filter_pf_width_E2_ << endl;
+        os << "-------------------------------------------------------------------------------" << endl;
+    }
+
+    template class EXPORTMRICORE partialFourierCartesianFilterHandler < std::complex<float> >;
+    template class EXPORTMRICORE partialFourierCartesianFilterHandler < std::complex<double> >;
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    partialFourierCartesianPOCSHandler<T>::partialFourierCartesianPOCSHandler() : BaseClass()
+    {
+        iter_ = 5;
+        thres_ = 0.001;
+    }
+
+    template <typename T>
+    partialFourierCartesianPOCSHandler<T>::~partialFourierCartesianPOCSHandler()
+    {
+    }
+
+    template <typename T>
+    void partialFourierCartesianPOCSHandler<T>::partial_fourier(const hoNDArray<T>& kspace, hoNDArray<T>& res)
+    {
+        try
+        {
+            size_t E2 = kspace.get_size(2);
+
+            if (E2 > 1)
+            {
+                Gadgetron::partial_fourier_POCS(kspace, start_RO_, end_RO_, start_E1_, end_E1_, start_E2_, end_E2_, transit_band_RO_, transit_band_E1_, transit_band_E2_, iter_, thres_, true, res, verbose_);
+            }
+            else
+            {
+                Gadgetron::partial_fourier_POCS(kspace, start_RO_, end_RO_, start_E1_, end_E1_, 0, 0, transit_band_RO_, transit_band_E1_, 0, iter_, thres_, false, res, verbose_);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partialFourierCartesianPOCSHandler<T>::partial_fourier(...) ... ");
+        }
+    }
+
+    template <typename T>
+    void partialFourierCartesianPOCSHandler<T>::dump(std::ostream& os) const
+    {
+        using namespace std;
+        os << "-------------------------------------------------------------------------------" << endl;
+        os << "partialFourierCartesianPOCSHandler ... " << endl;
+        os << "iter_ is " << iter_ << endl;
+        os << "thres_ is " << thres_ << endl;
+        os << "-------------------------------------------------------------------------------" << endl;
+    }
+
+    template class EXPORTMRICORE partialFourierCartesianPOCSHandler < std::complex<float> >;
+    template class EXPORTMRICORE partialFourierCartesianPOCSHandler < std::complex<double> >;
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    partialFourierCartesianFengHuangHandler<T>::partialFourierCartesianFengHuangHandler() : BaseClass()
+    {
+        kRO_ = 5;
+        kE1_ = 5;
+        kE2_ = 5;
+        thres_ = 0.01;
+    }
+
+    template <typename T>
+    partialFourierCartesianFengHuangHandler<T>::~partialFourierCartesianFengHuangHandler()
+    {
+    }
+
+    template <typename T>
+    void partialFourierCartesianFengHuangHandler<T>::partial_fourier(const hoNDArray<T>& kspace, hoNDArray<T>& res)
+    {
+        try
+        {
+            size_t E2 = kspace.get_size(2);
+
+            if (E2 > 1)
+            {
+                Gadgetron::partial_fourier_FengHuang_3d(kspace, start_RO_, end_RO_, start_E1_, end_E1_, start_E2_, end_E2_, transit_band_RO_, transit_band_E1_, transit_band_E2_, kRO_, kE1_, kE2_, thres_, res);
+            }
+            else
+            {
+                Gadgetron::partial_fourier_FengHuang_2d(kspace, start_RO_, end_RO_, start_E1_, end_E1_, transit_band_RO_, transit_band_E1_, kRO_, kE1_, thres_, res);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in partialFourierCartesianFengHuangHandler<T>::partial_fourier(...) ... ");
+        }
+    }
+
+    template <typename T>
+    void partialFourierCartesianFengHuangHandler<T>::dump(std::ostream& os) const
+    {
+        using namespace std;
+        os << "-------------------------------------------------------------------------------" << endl;
+        os << "partialFourierCartesianFengHuangHandler ... " << endl;
+        os << "kRO_ is " << kRO_ << endl;
+        os << "kE1_ is " << kE1_ << endl;
+        os << "kE2_ is " << kE2_ << endl;
+        os << "thres_ is " << thres_ << endl;
+        os << "-------------------------------------------------------------------------------" << endl;
+    }
+
+    template class EXPORTMRICORE partialFourierCartesianFengHuangHandler < std::complex<float> >;
+    template class EXPORTMRICORE partialFourierCartesianFengHuangHandler < std::complex<double> >;
+
+    // ------------------------------------------------------------------------
+}

--- a/toolboxes/mri_core/mri_core_partial_fourier.h
+++ b/toolboxes/mri_core/mri_core_partial_fourier.h
@@ -1,0 +1,186 @@
+﻿
+/** \file   mri_core_partial_fourier.h
+    \brief  Implementation partial fourier handling functionalities for 2D and 3D MRI
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include "mri_core_export.h"
+#include "hoNDArray.h"
+
+namespace Gadgetron
+{
+    // --------------------------------------------------------------------------
+    /// define the partial fourier handling of ISMRMRD
+    // --------------------------------------------------------------------------
+    enum ismrmrdPARTIALFOURIERHANDLINGALGO
+    {
+        ISMRMRD_PF_None,
+        ISMRMRD_PF_Zerofilling_filter,
+        ISMRMRD_PF_Pocs,
+        ISMRMRD_PF_FengHuang
+    };
+
+    EXPORTMRICORE std::string get_ismrmrd_partial_fourier_handling_algo_name(ismrmrdPARTIALFOURIERHANDLINGALGO v);
+    EXPORTMRICORE ismrmrdPARTIALFOURIERHANDLINGALGO get_ismrmrd_partial_fourier_handling_algo(const std::string& name);
+
+    
+    // --------------------------------------------------------------------------
+    /// define the partial fourier handler for cartesian sampling
+    // --------------------------------------------------------------------------
+    template <typename T>
+    class EXPORTMRICORE partialFourierCartesianHandler
+    {
+    public:
+
+        partialFourierCartesianHandler();
+        virtual ~partialFourierCartesianHandler();
+
+        /// complexIm: [RO E1 E2 ...]
+        /// if E2==1, 2D imaging will be assumed
+        virtual void partial_fourier(const hoNDArray<T>& kspace, hoNDArray<T>& res) = 0;
+
+        virtual void dump(std::ostream& os) const;
+
+        /// sampled region in kspace
+        size_t start_RO_;
+        size_t end_RO_;
+
+        size_t start_E1_;
+        size_t end_E1_;
+
+        size_t start_E2_;
+        size_t end_E2_;
+
+        /// transition band width in pixel
+        /// a transition band can help to remove the ringing caused by imperfect partial foureir computation
+        size_t transit_band_RO_;
+        size_t transit_band_E1_;
+        size_t transit_band_E2_;
+
+        /// whether to print out more information
+        bool verbose_;
+    };
+
+    /// ------------------------------------------------------------------------
+    /// filter handler
+    /// perform the asymmetric partial fourier filter
+    /// ------------------------------------------------------------------------
+    template <typename T>
+    class EXPORTMRICORE partialFourierCartesianFilterHandler : public partialFourierCartesianHandler<T>
+    {
+    public:
+
+        typedef partialFourierCartesianHandler<T> BaseClass;
+        typedef typename realType<T>::Type value_type;
+
+        partialFourierCartesianFilterHandler();
+        virtual ~partialFourierCartesianFilterHandler();
+
+        virtual void partial_fourier(const hoNDArray<T>& kspace, hoNDArray<T>& res);
+
+        virtual void dump(std::ostream& os) const;
+
+        using BaseClass::start_RO_;
+        using BaseClass::end_RO_;
+        using BaseClass::start_E1_;
+        using BaseClass::end_E1_;
+        using BaseClass::start_E2_;
+        using BaseClass::end_E2_;
+        using BaseClass::verbose_;
+
+        /// PF filter is tapered hanning
+        /// whether to perform density compensation
+        bool filter_pf_density_comp_;
+
+        /// PF filter tapered width [0 1]
+        double filter_pf_width_RO_;
+        double filter_pf_width_E1_;
+        double filter_pf_width_E2_;
+
+        /// parfial fourier filter
+        hoNDArray<T> filter_RO_pf_;
+        hoNDArray<T> filter_E1_pf_;
+        hoNDArray<T> filter_E2_pf_;
+    };
+
+    /// ------------------------------------------------------------------------
+    /// POCS
+    /// perform the iterative POCS reconstruction
+    /// Magnetic Resonance Imaging : Physical Principles and Sequence Design.Page 296 - 297.
+    /// E.Mark Haacke, Robert W.Brown, Michael R.Thompson, Ramesh Venkatesan.
+    /// Wiley - Liss, ISBN - 10 : 0471351288.
+    /// ------------------------------------------------------------------------
+    template <typename T>
+    class EXPORTMRICORE partialFourierCartesianPOCSHandler : public partialFourierCartesianHandler<T>
+    {
+    public:
+
+        typedef partialFourierCartesianHandler<T> BaseClass;
+        typedef typename realType<T>::Type value_type;
+
+        partialFourierCartesianPOCSHandler();
+        virtual ~partialFourierCartesianPOCSHandler();
+
+        virtual void partial_fourier(const hoNDArray<T>& kspace, hoNDArray<T>& res);
+
+        virtual void dump(std::ostream& os) const;
+
+        using BaseClass::start_RO_;
+        using BaseClass::end_RO_;
+        using BaseClass::start_E1_;
+        using BaseClass::end_E1_;
+        using BaseClass::start_E2_;
+        using BaseClass::end_E2_;
+        using BaseClass::transit_band_RO_;
+        using BaseClass::transit_band_E1_;
+        using BaseClass::transit_band_E2_;
+        using BaseClass::verbose_;
+
+        /// number of iterations for POCS
+        size_t iter_;
+        /// threshold for iteration
+        double thres_;
+    };
+
+    /// ------------------------------------------------------------------------
+    /// Feng Huang method
+    /// Feng Huang, Wei Lin, and Yu Li.
+    /// Partial Fourier Reconstruction Through Data Fitting and Convolution in k-Space.
+    /// Magnetic Resonance in Medicine, Vol 62, page 1261-1269, 2009.
+    /// ------------------------------------------------------------------------
+    template <typename T>
+    class EXPORTMRICORE partialFourierCartesianFengHuangHandler : public partialFourierCartesianHandler<T>
+    {
+    public:
+
+        typedef partialFourierCartesianHandler<T> BaseClass;
+        typedef typename realType<T>::Type value_type;
+
+        partialFourierCartesianFengHuangHandler();
+        virtual ~partialFourierCartesianFengHuangHandler();
+
+        virtual void partial_fourier(const hoNDArray<T>& kspace, hoNDArray<T>& res);
+
+        virtual void dump(std::ostream& os) const;
+
+        using BaseClass::start_RO_;
+        using BaseClass::end_RO_;
+        using BaseClass::start_E1_;
+        using BaseClass::end_E1_;
+        using BaseClass::start_E2_;
+        using BaseClass::end_E2_;
+        using BaseClass::transit_band_RO_;
+        using BaseClass::transit_band_E1_;
+        using BaseClass::transit_band_E2_;
+        using BaseClass::verbose_;
+
+        /// kernel size
+        size_t kRO_;
+        size_t kE1_;
+        size_t kE2_;
+        /// threshold for calibration regularization
+        double thres_;
+    };
+}

--- a/toolboxes/mri_core/mri_core_recon_para.cpp
+++ b/toolboxes/mri_core/mri_core_recon_para.cpp
@@ -1,0 +1,258 @@
+/** \file   mri_core_recon_para.cpp
+    \brief  Define the structures storing the reconstruction parameters for different algorithms
+    \author Hui Xue
+*/
+
+#include "mri_core_recon_para.h"
+
+namespace Gadgetron
+{
+    // --------------------------------------------------------------------
+
+    std::string get_ismrmrd_dimension_name(IsmrmrdCONDITION v)
+    {
+        std::string name;
+
+        switch (v)
+        {
+        case KSPACE_ENCODE_STEP_1:
+            name = "E1";
+            break;
+
+        case KSPACE_ENCODE_STEP_2:
+            name = "E2";
+            break;
+
+        case AVERAGE:
+            name = "average";
+            break;
+
+        case SLICE:
+            name = "slice";
+            break;
+
+        case CONTRAST:
+            name = "constrast";
+            break;
+
+        case PHASE:
+            name = "phase";
+            break;
+
+        case REPETITION:
+            name = "repetition";
+            break;
+
+        case SET:
+            name = "set";
+            break;
+
+        case SEGMENT:
+            name = "segment";
+            break;
+
+        case USER_0:
+            name = "user_0";
+            break;
+
+        case USER_1:
+            name = "user_1";
+            break;
+
+        case USER_2:
+            name = "user_2";
+            break;
+
+        case USER_3:
+            name = "user_3";
+            break;
+
+        case USER_4:
+            name = "user_4";
+            break;
+
+        case USER_5:
+            name = "user_5";
+            break;
+
+        case USER_6:
+            name = "user_6";
+            break;
+
+        case USER_7:
+            name = "user_7";
+            break;
+
+        case NONE:
+            name = "none";
+            break;
+
+        default:
+            GERROR_STREAM("Unrecognized ISMRMRD dimension name : " << v);
+        }
+
+        return name;
+    }
+
+    IsmrmrdCONDITION get_ismrmrd_dimension(const std::string& name)
+    {
+        IsmrmrdCONDITION v;
+
+        if (name == "E1")
+        {
+            v = KSPACE_ENCODE_STEP_1;
+        }
+        else if (name == "E2")
+        {
+            v = KSPACE_ENCODE_STEP_2;
+        }
+        else if (name == "average")
+        {
+            v = AVERAGE;
+        }
+        else if (name == "slice")
+        {
+            v = SLICE;
+        }
+        else if (name == "contrast")
+        {
+            v = CONTRAST;
+        }
+        else if (name == "phase")
+        {
+            v = PHASE;
+        }
+        else if (name == "repetition")
+        {
+            v = REPETITION;
+        }
+        else if (name == "set")
+        {
+            v = SET;
+        }
+        else if (name == "segment")
+        {
+            v = SEGMENT;
+        }
+        else if (name == "user_0")
+        {
+            v = USER_0;
+        }
+        else if (name == "user_1")
+        {
+            v = USER_1;
+        }
+        else if (name == "user_2")
+        {
+            v = USER_2;
+        }
+        else if (name == "user_3")
+        {
+            v = USER_3;
+        }
+        else if (name == "user_4")
+        {
+            v = USER_4;
+        }
+        else if (name == "user_5")
+        {
+            v = USER_5;
+        }
+        else if (name == "user_6")
+        {
+            v = USER_6;
+        }
+        else if (name == "user_7")
+        {
+            v = USER_7;
+        }
+        else if (name == "none")
+        {
+            v = NONE;
+        }
+        else
+        {
+            GERROR_STREAM("Unrecognized ISMRMRD dimension name : " << name);
+        }
+
+        return v;
+    }
+
+    // --------------------------------------------------------------------
+
+    std::string get_ismrmrd_calib_mode_name(ismrmrdCALIBMODE v)
+    {
+        std::string name;
+
+        switch (v)
+        {
+        case ISMRMRD_embedded:
+            name = "embedded";
+            break;
+
+        case ISMRMRD_interleaved:
+            name = "interleaved";
+            break;
+
+        case ISMRMRD_separate:
+            name = "seperate";
+            break;
+
+        case ISMRMRD_external:
+            name = "external";
+            break;
+
+        case ISMRMRD_other:
+            name = "other";
+            break;
+
+        case ISMRMRD_noacceleration:
+            name = "noacceleration";
+            break;
+
+        default:
+            GERROR_STREAM("Unrecognized ISMRMRD calibration mode type : " << v);
+        }
+
+        return name;
+    }
+
+    ismrmrdCALIBMODE get_ismrmrd_calib_mode(const std::string& name)
+    {
+        ismrmrdCALIBMODE v;
+
+        if (name == "embedded")
+        {
+            v = ISMRMRD_embedded;
+        }
+        else if (name == "interleaved")
+        {
+            v = ISMRMRD_interleaved;
+        }
+        else if (name == "seperate")
+        {
+            v = ISMRMRD_separate;
+        }
+        else if (name == "external")
+        {
+            v = ISMRMRD_external;
+        }
+        else if (name == "other")
+        {
+            v = ISMRMRD_other;
+        }
+        else if (name == "noacceleration")
+        {
+            v = ISMRMRD_noacceleration;
+        }
+        else
+        {
+            GERROR_STREAM("Unrecognized ISMRMRD calibration mode name : " << name);
+        }
+
+        return v;
+    }
+
+    // --------------------------------------------------------------------
+
+}

--- a/toolboxes/mri_core/mri_core_recon_para.h
+++ b/toolboxes/mri_core/mri_core_recon_para.h
@@ -1,0 +1,36 @@
+/** \file   mri_core_recon_para.h
+    \brief  Define the structures storing the reconstruction parameters for different algorithms
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include "ismrmrd/ismrmrd.h"
+
+#include "mri_core_export.h"
+#include "mri_core_data.h"
+
+namespace Gadgetron
+{
+    // --------------------------------------------------------------------------
+    /// naming conversion functions for ISMRMRD dimensions
+    // --------------------------------------------------------------------------
+    EXPORTMRICORE std::string get_ismrmrd_dimension_name(IsmrmrdCONDITION v);
+    EXPORTMRICORE IsmrmrdCONDITION get_ismrmrd_dimension(const std::string& name);
+
+    // --------------------------------------------------------------------------
+    /// define the calibration mode of ISMRMRD
+    // --------------------------------------------------------------------------
+    enum ismrmrdCALIBMODE
+    {
+        ISMRMRD_embedded,
+        ISMRMRD_interleaved,
+        ISMRMRD_separate,
+        ISMRMRD_external,
+        ISMRMRD_other,
+        ISMRMRD_noacceleration
+    };
+
+    EXPORTMRICORE std::string get_ismrmrd_calib_mode_name(ismrmrdCALIBMODE v);
+    EXPORTMRICORE ismrmrdCALIBMODE get_ismrmrd_calib_mode(const std::string& name);
+}

--- a/toolboxes/mri_core/mri_core_reference_preparation.cpp
+++ b/toolboxes/mri_core/mri_core_reference_preparation.cpp
@@ -1,0 +1,922 @@
+﻿
+/** \file   mri_core_reference_preparation.cpp
+    \brief  Implementation different calibration reference data preparation strategy for 2D and 3D MRI
+    \author Hui Xue
+*/
+
+#include "mri_core_reference_preparation.h"
+#include "mri_core_utility.h"
+#include "hoNDArray_utils.h"
+#include "hoNDArray_elemwise.h"
+
+namespace Gadgetron
+{
+    template<typename T> 
+    referencePreparer<T>::referencePreparer()
+    {
+        calib_mode_ = ISMRMRD_noacceleration;
+
+        gt_timer1_.set_timing_in_destruction(false);
+        gt_timer2_.set_timing_in_destruction(false);
+        gt_timer3_.set_timing_in_destruction(false);
+        perform_timing_ = false;
+
+        verbose_ = false;
+    }
+
+    template<typename T>
+    referencePreparer<T>::~referencePreparer()
+    {
+    }
+
+    template<typename T>
+    void referencePreparer<T>::dump(std::ostream& os) const
+    {
+        using namespace std;
+        os << "-------------------------------------------------------------------------------" << endl;
+        os << "referencePreparer will prepare the ref_calib_ array used for calibration and kernel estimation ... " << endl;
+        os << "pref_ref should be implemented ... " << endl;
+        os << "-------------------------------------------------------------------------------" << endl;
+    }
+
+    /// ------------------------------------------------------------------------
+
+    template<typename T>
+    referenceCartesianPreparer<T>::referenceCartesianPreparer() : BaseClass()
+    {
+        recon_RO_ = 0;
+        recon_E1_ = 0;
+        recon_E2_ = 0;
+
+        average_all_ref_N_ = true;
+        average_all_ref_S_ = false;
+        filter_ref_coil_map_ = true;
+        interleave_dim_along_N_ = true;
+    }
+
+    template<typename T>
+    referenceCartesianPreparer<T>::~referenceCartesianPreparer()
+    {
+    }
+
+    template<typename T>
+    void referenceCartesianPreparer<T>::average_ref(const hoNDArray<T>& ref)
+    {
+        try
+        {
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            // if interleaved mode is used, we have to count the sampled times for every kspace location, in case the kspace has cartesian irregular sampling
+            if (calib_mode_ == ISMRMRD_interleaved)
+            {
+                // average over N
+                if (interleave_dim_along_N_)
+                {
+                    if (N > 1)
+                    {
+                        // averaging by counting the sampled times
+                        Gadgetron::average_kspace_across_N(ref, ref_calib_);
+                    }
+                    else
+                    {
+                        ref_calib_ = ref;
+                    }
+
+                    if (!debug_folder_.empty())
+                    {
+                        // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_interleaved_ave_N");
+                    }
+
+                    if (average_all_ref_S_) // since S is not the interleaved dimension, the sum can be used
+                    {
+                        if (S > 1)
+                        {
+                            hoNDArray<T> ref_recon_buf;
+                            Gadgetron::sum_over_dimension(ref_calib_, ref_recon_buf, 5);
+                            Gadgetron::scal((value_type)(1.0 / S), ref_recon_buf);
+                            ref_calib_ = ref_recon_buf;
+                        }
+
+                        if (!debug_folder_.empty())
+                        {
+                            // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_interleaved_ave_S");
+                        }
+                    }
+                }
+                else
+                    // average over S
+                {
+                    if (S > 1)
+                    {
+                        // averaging by counting the sampled times
+                        Gadgetron::average_kspace_across_S(ref, ref_calib_);
+                    }
+                    else
+                    {
+                        ref_calib_ = ref;
+                    }
+
+                    if (!debug_folder_.empty())
+                    {
+                        // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_interleaved_ave_S");
+                    }
+
+                    if (average_all_ref_N_)
+                    {
+                        if (N > 1)
+                        {
+                            hoNDArray<T> ref_recon_buf;
+                            Gadgetron::sum_over_dimension(ref_calib_, ref_recon_buf, 4);
+                            Gadgetron::scal((value_type)(1.0 / N), ref_recon_buf);
+                            ref_calib_ = ref_recon_buf;
+                        }
+
+                        if (!debug_folder_.empty())
+                        {
+                            // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_interleaved_ave_N");
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (average_all_ref_N_)
+                {
+                    if (N > 1)
+                    {
+                        Gadgetron::sum_over_dimension(ref, ref_calib_, (size_t)4);
+                        Gadgetron::scal((value_type)(1.0 / N), ref_calib_);
+
+                        if (!debug_folder_.empty())
+                        {
+                            // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_after_averaging_N");
+                        }
+                    }
+                    else
+                    {
+                        ref_calib_ = ref;
+                    }
+                }
+                else
+                {
+                    ref_calib_ = ref;
+                }
+
+                if (average_all_ref_S_)
+                {
+                    if (S > 1)
+                    {
+                        hoNDArray<T> ref_recon_buf;
+                        Gadgetron::sum_over_dimension(ref_calib_, ref_recon_buf, 5);
+                        Gadgetron::scal((value_type)(1.0 / S), ref_recon_buf);
+                        ref_calib_ = ref_recon_buf;
+
+                        if (!debug_folder_.empty())
+                        {
+                            // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_after_averaging_S");
+                        }
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceCartesianPreparer<T>::average_ref(...) ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceCartesianPreparer<T>::prep_ref_no_acceleration(const hoNDArray<T>& ref)
+    {
+        try
+        {
+            size_t RO  = ref.get_size(0);
+            size_t E1  = ref.get_size(1);
+            size_t E2  = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N   = ref.get_size(4);
+            size_t S   = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            this->average_ref(ref);
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_noacceleration");
+            }
+
+            if (filter_ref_coil_map_)
+            {
+                if (E2 > 1)
+                {
+                    Gadgetron::apply_kspace_filter_ROE1E2(ref_calib_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_, ref_coil_map_);
+                }
+                else
+                {
+                    Gadgetron::apply_kspace_filter_ROE1(ref_calib_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_coil_map_);
+                }
+            }
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_noacceleration");
+            }
+
+            if (recon_RO_ > RO || recon_E1_ > E1 || recon_E2_ > E2)
+            {
+                hoNDArray<T> ref_recon_buf;
+                Gadgetron::pad(recon_RO_, recon_E1_, recon_E2_, &ref_coil_map_, &ref_recon_buf);
+                ref_coil_map_ = ref_recon_buf;
+
+                if (!debug_folder_.empty())
+                {
+                    // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_padded_noacceleration");
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceCartesianPreparer<T>::prep_ref_no_acceleration(...) ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceCartesianPreparer<T>::prep_ref_interleaved(const hoNDArray<T>& ref)
+    {
+        try
+        {
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            this->average_ref(ref);
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_interleaved");
+            }
+
+            // perform Ref filtering
+            if (filter_ref_coil_map_)
+            {
+                if (E2 > 1)
+                {
+                    Gadgetron::apply_kspace_filter_ROE1E2(ref_calib_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_, ref_coil_map_);
+                }
+                else
+                {
+                    Gadgetron::apply_kspace_filter_ROE1(ref_calib_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_coil_map_);
+                }
+            }
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_interleaved");
+            }
+
+            // pad the ref_coil_map into the data array
+            if (recon_RO_ > RO || recon_E1_ > E1 || recon_E1_ > E2)
+            {
+                hoNDArray<T> ref_recon_buf;
+                Gadgetron::pad(recon_RO_, recon_E1_, recon_E2_, &ref_coil_map_, &ref_recon_buf);
+                ref_coil_map_ = ref_recon_buf;
+
+                if (!debug_folder_.empty())
+                {
+                    // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_padded_interleaved");
+                }
+            }
+
+            // crop the ref_calib_ to make it ready for calibration, because only sampled kspace region is needed in calibration
+            size_t len_RO = sampling_limits_[0].max_ - sampling_limits_[0].min_ + 1;
+            size_t len_E1 = sampling_limits_[1].max_ - sampling_limits_[1].min_ + 1;
+            size_t len_E2 = (E2 > 1) ? (sampling_limits_[2].max_ - sampling_limits_[2].min_ + 1) : 1;
+
+            if (len_RO < RO || len_E1 < E1 || len_E2 < E2)
+            {
+                vector_td<size_t, 3> crop_offset;
+                crop_offset[0] = sampling_limits_[0].min_;
+                crop_offset[1] = sampling_limits_[1].min_;
+                crop_offset[2] = (E2>1) ? sampling_limits_[2].min_ : 0;
+
+                vector_td<size_t, 3> crop_size;
+                crop_size[0] = len_RO;
+                crop_size[1] = len_E1;
+                crop_size[2] = len_E2;
+
+                hoNDArray<T> ref_recon_buf;
+                Gadgetron::crop(crop_offset, crop_size, &ref_calib_, &ref_recon_buf);
+                ref_calib_ = ref_recon_buf;
+
+                if (!debug_folder_.empty())
+                {
+                    // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_after_crop_interleaved");
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceCartesianPreparer<T>::prep_ref_interleaved(...) ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceCartesianPreparer<T>::prep_ref_embedded(const hoNDArray<T>& ref)
+    {
+        try
+        {
+            // ref lines should be in the center of kspace
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            this->average_ref(ref);
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_after_averaging_embedded");
+            }
+
+            // detect sampled region in ref
+            size_t start_E1(0), end_E1(0);
+            Gadgetron::detect_sampled_region_E1(ref_calib_, start_E1, end_E1);
+
+            size_t start_E2(0), end_E2(0);
+            if (E2 > 1)
+            {
+                Gadgetron::detect_sampled_region_E2(ref_calib_, start_E2, end_E2);
+            }
+
+            hoNDArray<T> ref_recon_buf;
+
+            // crop the ref, along E1 and E2
+            vector_td<size_t, 3> crop_offset;
+            crop_offset[0] = 0;
+            crop_offset[1] = start_E1;
+            crop_offset[2] = start_E2;
+
+            vector_td<size_t, 3> crop_size;
+            crop_size[0] = RO;
+            crop_size[1] = end_E1 - start_E1 + 1;
+            crop_size[2] = end_E2 - start_E2 + 1;
+
+            Gadgetron::crop(crop_offset, crop_size, &ref_calib_, &ref_recon_buf);
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_recon_buf, debug_folder_ + "ref_recon_buf_after_crop_embedded");
+            }
+
+            ref_calib_ = ref_recon_buf;
+
+            // generate ref filter
+            if (filter_ref_coil_map_)
+            {
+                SamplingLimit sampleLimE1, sampleLimE2;
+                sampleLimE1.min_ = 0;
+                sampleLimE1.max_ = ref_recon_buf.get_size(1)-1;
+
+                sampleLimE2.min_ = 0;
+                sampleLimE2.max_ = ref_recon_buf.get_size(2) - 1;
+
+                Gadgetron::generate_ref_filter_for_coil_map(ref_recon_buf, sampling_limits_[0], sampleLimE1, sampleLimE2, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
+
+                if (!debug_folder_.empty())
+                {
+                    // gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_ + "filter_RO_ref_coi_map_embedded");
+                    // gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_ + "filter_E1_ref_coi_map_embedded");
+                    if (E2 > 1) 
+                    {
+                        // gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_ + "filter_E2_ref_coi_map_embedded"); 
+                    }
+                }
+
+                if (E2 > 1)
+                {
+                    Gadgetron::apply_kspace_filter_ROE1E2(ref_calib_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_, ref_recon_buf);
+                }
+                else
+                {
+                    Gadgetron::apply_kspace_filter_ROE1(ref_calib_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_recon_buf);
+                }
+
+                if (!debug_folder_.empty())
+                {
+                    // gt_exporter_.exportArrayComplex(ref_recon_buf, debug_folder_ + "ref_recon_buf_ref_filtered");
+                }
+            }
+
+            // pad ref_calib_ into the data size
+            Gadgetron::pad(recon_RO_, recon_E1_, recon_E2_, &ref_recon_buf, &ref_coil_map_);
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_embedded");
+            }
+
+            // further crop along RO
+            if (sampling_limits_[0].min_ > 0 || sampling_limits_[0].max_ < RO - 1)
+            {
+                crop_offset[0] = sampling_limits_[0].min_;
+                crop_offset[1] = 0;
+                crop_offset[2] = 0;
+
+                crop_size[0] = sampling_limits_[0].max_ - sampling_limits_[0].min_ + 1;
+                crop_size[1] = ref_calib_.get_size(1) - 1;
+                crop_size[2] = ref_calib_.get_size(2) - 1;
+
+                Gadgetron::crop(crop_offset, crop_size, &ref_calib_, &ref_recon_buf);
+
+                if (!debug_folder_.empty())
+                {
+                    // gt_exporter_.exportArrayComplex(ref_recon_buf, debug_folder_ + "ref_recon_buf_after_crop_RO_embedded");
+                }
+
+                ref_calib_ = ref_recon_buf;
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceCartesianPreparer<T>::prep_ref_embedded(...) ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceCartesianPreparer<T>::prep_ref_separate(const hoNDArray<T>& ref)
+    {
+        try
+        {
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            this->average_ref(ref);
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_after_averaging_separate");
+            }
+
+            hoNDArray<T> ref_recon_buf;
+
+            // detect sampled region in ref
+            size_t start_E1(0), end_E1(0);
+            Gadgetron::detect_sampled_region_E1(ref, start_E1, end_E1);
+
+            size_t start_E2(0), end_E2(0);
+            if (E2 > 1)
+            {
+                Gadgetron::detect_sampled_region_E2(ref, start_E2, end_E2);
+            }
+
+            // crop the ref_calib_, along E1 and E2
+            vector_td<size_t, 3> crop_offset;
+            crop_offset[0] = sampling_limits_[0].min_;
+            crop_offset[1] = start_E1;
+            crop_offset[2] = start_E2;
+
+            vector_td<size_t, 3> crop_size;
+            crop_size[0] = sampling_limits_[0].max_ - sampling_limits_[0].min_ + 1;
+            crop_size[1] = end_E1 - start_E1 + 1;
+            crop_size[2] = end_E2 - start_E2 + 1;
+
+            Gadgetron::crop(crop_offset, crop_size, &ref_calib_, &ref_recon_buf);
+            ref_calib_ = ref_recon_buf;
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_after_crop_separate");
+            }
+
+            // create filter if needed
+            if (filter_ref_coil_map_)
+            {
+                if ( filter_RO_ref_coi_map_.get_size(0) != RO 
+                    || filter_E1_ref_coi_map_.get_size(0) != ref_calib_.get_size(1) 
+                    || ((E2 > 1) && (filter_E2_ref_coi_map_.get_size(0) != ref_calib_.get_size(2))) )
+                {
+                    SamplingLimit sE1;
+                    sE1.min_ = 0;
+                    sE1.max_ = ref_calib_.get_size(1) - 1;
+
+                    SamplingLimit sE2;
+                    sE2.min_ = 0;
+                    sE2.max_ = ref_calib_.get_size(2) - 1;
+
+                    Gadgetron::generate_ref_filter_for_coil_map(ref_calib_, sampling_limits_[0], sE1, sE2, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
+                }
+
+                if (!debug_folder_.empty())
+                {
+                    // gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_ + "filter_RO_ref_coi_map_separate");
+                    // gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_ + "filter_E1_ref_coi_map_separate");
+                    if (E2 > 1) 
+                    {
+                        // gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_ + "filter_E2_ref_coi_map_separate"); 
+                    }
+                }
+            }
+
+            // filter the ref_coil_map_
+            ref_coil_map_ = ref_calib_;
+
+            if (filter_ref_coil_map_)
+            {
+                if (E2 > 1)
+                {
+                    Gadgetron::apply_kspace_filter_ROE1E2(ref_coil_map_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_, ref_recon_buf);
+                }
+                else
+                {
+                    Gadgetron::apply_kspace_filter_ROE1(ref_coil_map_, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_recon_buf);
+                }
+
+                ref_coil_map_ = ref_recon_buf;
+            }
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_separate");
+            }
+
+            // pad the ref_coil_map into the data array
+            Gadgetron::pad(recon_RO_, recon_E1_, recon_E2_, &ref_coil_map_, &ref_recon_buf);
+            ref_coil_map_ = ref_recon_buf;
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_padded_separate");
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceCartesianPreparer<T>::prep_ref_separate(...) ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceCartesianPreparer<T>::prep_ref(const hoNDArray<T>& ref, const hoNDArray<float>& traj)
+    {
+        try
+        {
+            size_t RO  = ref.get_size(0);
+            size_t E1  = ref.get_size(1);
+            size_t E2  = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N   = ref.get_size(4);
+            size_t S   = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            // if needed, generate the ref filter
+            if (calib_mode_ == ISMRMRD_noacceleration
+                || calib_mode_ == ISMRMRD_interleaved)
+            {
+                if (filter_ref_coil_map_)
+                {
+                    if (filter_RO_ref_coi_map_.get_size(0) != RO || filter_E1_ref_coi_map_.get_size(0) != E1 || ((E2 > 1) && (filter_E2_ref_coi_map_.get_size(0) != E2)))
+                    {
+                        Gadgetron::generate_ref_filter_for_coil_map(ref, sampling_limits_[0], sampling_limits_[1], sampling_limits_[2],
+                            filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
+                    }
+
+                    if (!debug_folder_.empty())
+                    {
+                        // gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_ + "filter_RO_ref_coi_map");
+                        // gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_ + "filter_E1_ref_coi_map");
+                        if (E2 > 1) 
+                        { 
+                            // gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_ + "filter_E2_ref_coi_map"); 
+                        }
+                    }
+                }
+            }
+
+            // -------------------------------------------------------------------------------
+
+            if (calib_mode_ == ISMRMRD_noacceleration)
+            {
+                this->prep_ref_no_acceleration(ref);
+            }
+
+            // -------------------------------------------------------------------------------
+
+            else if (calib_mode_ == ISMRMRD_interleaved)
+            {
+                this->prep_ref_interleaved(ref);
+            }
+
+            // -------------------------------------------------------------------------------
+
+            else if (calib_mode_ == ISMRMRD_embedded)
+            {
+                this->prep_ref_embedded(ref);
+            }
+
+            // -------------------------------------------------------------------------------
+
+            else if (calib_mode_ == ISMRMRD_separate || calib_mode_ == ISMRMRD_external || calib_mode_ == ISMRMRD_other)
+            {
+                this->prep_ref_separate(ref);
+            }
+            else
+            {
+                GADGET_THROW("Unrecognized calibration mode ... ");
+            }
+
+            // -------------------------------------------------------------------------------
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_after_all_prep");
+            }
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_coil_map_, debug_folder_ + "ref_coil_map_after_all_prep");
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceCartesianPreparer<T>::prep_ref() ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceCartesianPreparer<T>::dump(std::ostream& os) const
+    {
+        using namespace std;
+        os << "-------------------------------------------------------------------------------" << endl;
+        os << "referenceCartesianPreparer ... " << endl;
+        os << "calib_mode_ is " << Gadgetron::get_ismrmrd_calib_mode_name(calib_mode_) << endl;
+        os << "recon image size is [" << recon_RO_ << " " << recon_E1_ << " " << recon_E2_ << "]" << endl;
+        os << "average_all_ref_N_ is " << average_all_ref_N_ << endl;
+        os << "average_all_ref_S_ is " << average_all_ref_S_ << endl;
+        os << "filter_ref_coil_map_ is " << filter_ref_coil_map_ << endl;
+        os << "interleave_dim_along_N_ is " << interleave_dim_along_N_ << endl;
+        os << "verbose_ is " << verbose_ << endl;
+        os << "-------------------------------------------------------------------------------" << endl;
+    }
+
+    template class EXPORTMRICORE referenceCartesianPreparer < std::complex<float> >;
+    template class EXPORTMRICORE referenceCartesianPreparer < std::complex<double> >;
+
+    /// ------------------------------------------------------------------------
+
+    template<typename T>
+    referenceNonCartesianPreparer<T>::referenceNonCartesianPreparer() : BaseClass()
+    {
+        combine_all_ref_N_ = true;
+        combine_all_ref_S_ = false;
+        interleave_dim_along_N_ = true;
+    }
+
+    template<typename T>
+    referenceNonCartesianPreparer<T>::~referenceNonCartesianPreparer()
+    {
+    }
+
+    template<typename T>
+    void referenceNonCartesianPreparer<T>::combine_along_N_S(const hoNDArray<T>& ref, const hoNDArray<float>& traj, bool combineN, bool combineS)
+    {
+        try
+        {
+            if (!combineN && !combineS)
+            {
+                ref_calib_ = ref;
+                traj_calib_ = traj;
+                return;
+            }
+
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            size_t TRAJ = traj.get_size(0);
+
+            if (E2 > 1)
+            {
+                if (combineN && combineS)
+                {
+                    ref_calib_.create(RO, E1, E2*N*S, CHA, 1, 1, SLC);
+                    traj_calib_.create(TRAJ, E1, E2*N*S, CHA, 1, 1, SLC);
+                }
+                else if (combineN && !combineS)
+                {
+                    ref_calib_.create(RO, E1, E2*N, CHA, 1, S, SLC);
+                    traj_calib_.create(TRAJ, E1, E2*N, CHA, 1, S, SLC);
+                }
+                else if (!combineN && combineS)
+                {
+                    ref_calib_.create(RO, E1, E2*S, CHA, N, 1, SLC);
+                    traj_calib_.create(TRAJ, E1, E2*S, CHA, N, 1, SLC);
+                }
+            }
+            else
+            {
+                if (combineN && combineS)
+                {
+                    ref_calib_.create(RO, E1*N*S, E2, CHA, 1, 1, SLC);
+                    traj_calib_.create(TRAJ, E1*N*S, E2, CHA, 1, 1, SLC);
+                }
+                else if (combineN && !combineS)
+                {
+                    ref_calib_.create(RO, E1*N, E2, CHA, 1, S, SLC);
+                    traj_calib_.create(TRAJ, E1*N, E2, CHA, 1, S, SLC);
+                }
+                else if (!combineN && combineS)
+                {
+                    ref_calib_.create(RO, E1*S, E2, CHA, N, 1, SLC);
+                    traj_calib_.create(TRAJ, E1*S, E2, CHA, N, 1, SLC);
+                }
+            }
+
+            const T* pRef = ref.begin();
+            const float* pTraj= traj.begin();
+
+            T* pRefCalib = ref_calib_.begin();
+            float* pTrajCalib = traj_calib_.begin();
+
+            long long num;
+            long long NUM = SLC*S*N*CHA;
+
+#pragma omp parallel for private(num) shared(RO, E1, E2, CHA, N, S, TRAJ, NUM, ref, traj)
+            for (num = 0; num < NUM; num++)
+            {
+                size_t slc = num / (CHA*N*S);
+                size_t s = (num - slc*CHA*N*S) / (CHA*N);
+                size_t n = (num - slc*CHA*N*S - s*CHA*N) / (CHA);
+                size_t cha = num - slc*CHA*N*S - s*CHA*N - n*CHA;
+
+                size_t e1, e2;
+
+                for (e2 = 0; e2 < E2; e2++)
+                {
+                    for (e1 = 0; e1 < E1; e1++)
+                    {
+                        const T* pR = &(ref(0, e1, e2, cha, n, s, slc));
+                        const float* pT = &(traj(0, e1, e2, cha, n, s, slc));
+
+                        T* pRC;
+                        float* pTC;
+
+                        if (combineN && combineS)
+                        {
+                            if (E2 > 1)
+                            {
+                                pRC = &(ref_calib_(0, e1, e2 + n*E2 + s*N*E2, cha, 0, 0, slc));
+                                pTC = &(traj_calib_(0, e1, e2 + n*E2 + s*N*E2, cha, 0, 0, slc));
+                            }
+                            else
+                            {
+                                pRC = &(ref_calib_(0, e1 + n*E1 + s*N*E1, e2, cha, 0, 0, slc));
+                                pTC = &(traj_calib_(0, e1 + n*E1 + s*N*E1, e2, cha, 0, 0, slc));
+                            }
+                        }
+                        else if (combineN && !combineS)
+                        {
+                            if (E2 > 1)
+                            {
+                                pRC = &(ref_calib_(0, e1, e2 + n*E2, cha, 0, s, slc));
+                                pTC = &(traj_calib_(0, e1, e2 + n*E2, cha, 0, s, slc));
+                            }
+                            else
+                            {
+                                pRC = &(ref_calib_(0, e1 + n*E1, e2, cha, 0, s, slc));
+                                pTC = &(traj_calib_(0, e1 + n*E1, e2, cha, 0, s, slc));
+                            }
+                        }
+                        else // !combineN && combineS
+                        {
+                            if (E2 > 1)
+                            {
+                                pRC = &(ref_calib_(0, e1, e2 + s*E2, cha, n, 0, slc));
+                                pTC = &(traj_calib_(0, e1, e2 + s*E2, cha, n, 0, slc));
+                            }
+                            else
+                            {
+                                pRC = &(ref_calib_(0, e1 + s*E1, e2, cha, n, 0, slc));
+                                pTC = &(traj_calib_(0, e1 + s*E1, e2, cha, n, 0, slc));
+                            }
+                        }
+
+                        memcpy(pRC, pR, sizeof(T)*RO);
+                        memcpy(pTC, pT, sizeof(float)*TRAJ);
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceNonCartesianPreparer<T>::combine_along_N_S() ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceNonCartesianPreparer<T>::prep_ref(const hoNDArray<T>& ref, const hoNDArray<float>& traj)
+    {
+        try
+        {
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            GADGET_CHECK_THROW(traj.get_size(1) == E1);
+            GADGET_CHECK_THROW(traj.get_size(2) == E2);
+            GADGET_CHECK_THROW(traj.get_size(3) == CHA);
+            GADGET_CHECK_THROW(traj.get_size(4) == N);
+            GADGET_CHECK_THROW(traj.get_size(5) == S);
+            GADGET_CHECK_THROW(traj.get_size(6) == SLC);
+
+            if (calib_mode_ == ISMRMRD_interleaved)
+            {
+                if (interleave_dim_along_N_) // must combine along N
+                {
+                    if (combine_all_ref_S_)
+                    {
+                        this->combine_along_N_S(ref, traj, true, true);
+                    }
+                    else
+                    {
+                        this->combine_along_N_S(ref, traj, true, false);
+                    }
+                }
+                else
+                {
+                    if (combine_all_ref_N_)
+                    {
+                        this->combine_along_N_S(ref, traj, true, true);
+                    }
+                    else
+                    {
+                        this->combine_along_N_S(ref, traj, false, true);
+                    }
+                }
+            }
+            else
+            {
+                this->combine_along_N_S(ref, traj, combine_all_ref_N_, combine_all_ref_S_);
+            }
+
+            if (!debug_folder_.empty())
+            {
+                // gt_exporter_.exportArrayComplex(ref_calib_, debug_folder_ + "ref_calib_after_combine_N_S");
+            }
+
+            // make the ref_coil_map_ and traj_coil_map_
+
+            std::vector<size_t> dim;
+            ref_calib_.get_dimensions(dim);
+            ref_coil_map_.create(dim, ref_calib_.begin());
+
+            traj_calib_.get_dimensions(dim);
+            traj_coil_map_.create(dim, traj_calib_.begin());
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in referenceNonCartesianPreparer<T>::prep_ref() ... ");
+        }
+    }
+
+    template<typename T>
+    void referenceNonCartesianPreparer<T>::dump(std::ostream& os) const
+    {
+        using namespace std;
+        os << "-------------------------------------------------------------------------------" << endl;
+        os << "referenceNonCartesianPreparer ... " << endl;
+        os << "calib_mode_ is " << Gadgetron::get_ismrmrd_calib_mode_name(calib_mode_) << endl;
+        os << "combine_all_ref_N_ is " << combine_all_ref_N_ << endl;
+        os << "combine_all_ref_S_ is " << combine_all_ref_S_ << endl;
+        os << "interleave_dim_along_N_ is " << interleave_dim_along_N_ << endl;
+        os << "verbose_ is " << verbose_ << endl;
+        os << "-------------------------------------------------------------------------------" << endl;
+    }
+
+    template class EXPORTMRICORE referenceNonCartesianPreparer < std::complex<float> >;
+    template class EXPORTMRICORE referenceNonCartesianPreparer < std::complex<double> >;
+}

--- a/toolboxes/mri_core/mri_core_reference_preparation.h
+++ b/toolboxes/mri_core/mri_core_reference_preparation.h
@@ -1,0 +1,213 @@
+﻿
+/** \file   mri_core_reference_preparation.h
+    \brief  Implementation different calibration reference data preparation strategy for 2D and 3D MRI
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include "mri_core_export.h"
+#include "GadgetronTimer.h"
+#include "hoNDArray.h"
+#include "mri_core_recon_para.h"
+
+// #include "gtPlusIOAnalyze.h"
+
+namespace Gadgetron
+{
+    /// ------------------------------------------------------------------------
+    /// define the reference preparation base class
+    /// ------------------------------------------------------------------------
+    template <typename T>
+    class EXPORTMRICORE referencePreparer
+    {
+    public:
+
+        referencePreparer();
+        virtual ~referencePreparer();
+
+        /// ref: [RO E1 E2 CHA N S SLC]
+        /// traj: [TRAJ E1 E2 CHA N S SLC], can be empty
+        /// after the ref preparation, ref_calib_ are filled
+        /// ref_calib_ is used for calibration and kernel estimation
+        virtual void prep_ref(const hoNDArray<T>& ref, const hoNDArray<float>& traj) = 0;
+
+        /// dump the class status
+        virtual void dump(std::ostream& os) const;
+
+        /// reference data for calibration
+        /// [RO E1 E2 CHA Nor1 Sor1 SLC]
+        hoNDArray<T> ref_calib_;
+
+        /// reference data ready for coil map estimation
+        /// [RO E1 E2 CHA Nor1 Sor1 SLC]
+        hoNDArray<T> ref_coil_map_;
+
+        /// calibration mode
+        ismrmrdCALIBMODE calib_mode_;
+
+        /// sampled range along RO, E1, E2 (for asymmetric echo and partial fourier)
+        /// min, max and center
+        SamplingLimit sampling_limits_[3];
+
+        // -----------------------------------------------
+        /// for debug 
+        // -----------------------------------------------
+
+        /// clock for timing
+        Gadgetron::GadgetronTimer gt_timer1_;
+        Gadgetron::GadgetronTimer gt_timer2_;
+        Gadgetron::GadgetronTimer gt_timer3_;
+
+        bool perform_timing_;
+
+        /// exporter
+        // Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
+
+        /// debug folder
+        std::string debug_folder_;
+
+        /// whether to print out more information
+        bool verbose_;
+    };
+
+    /// ------------------------------------------------------------------------
+    /// reference preparation for cartesian sampling
+    /// ------------------------------------------------------------------------
+    template <typename T>
+    class EXPORTMRICORE referenceCartesianPreparer : public referencePreparer<T>
+    {
+    public:
+
+        typedef referencePreparer<T> BaseClass;
+        typedef typename realType<T>::Type value_type;
+
+        referenceCartesianPreparer();
+        virtual ~referenceCartesianPreparer();
+
+        /// besides filling the ref_calib_, the ref_coil_map_ is also filled
+        /// ref_coil_map_ is used for coil map estimation and is padded to the reconed image size
+        virtual void prep_ref(const hoNDArray<T>& ref, const hoNDArray<float>& traj);
+
+        /// dump the class status
+        virtual void dump(std::ostream& os) const;
+
+        using BaseClass::ref_calib_;
+        using BaseClass::ref_coil_map_;
+        using BaseClass::calib_mode_;
+        using BaseClass::sampling_limits_;
+        using BaseClass::verbose_;
+
+        using BaseClass::gt_timer1_;
+        using BaseClass::gt_timer2_;
+        using BaseClass::gt_timer3_;
+        using BaseClass::perform_timing_;
+        // using BaseClass::gt_exporter_;
+        using BaseClass::debug_folder_;
+
+        /// ref filter for coil map estimation
+        /// these filters will be created when they are first used
+        hoNDArray<T> filter_RO_ref_coi_map_;
+        hoNDArray<T> filter_E1_ref_coi_map_;
+        hoNDArray<T> filter_E2_ref_coi_map_;
+
+        /// reconed image size
+        size_t recon_RO_;
+        size_t recon_E1_;
+        size_t recon_E2_;
+
+        /// whether to average all N for ref generation
+        bool average_all_ref_N_;
+        /// whether to average all S for ref generation
+        bool average_all_ref_S_;
+        /// whether to filter ref for coil map estimation
+        bool filter_ref_coil_map_;
+        /// for interleaved mode, whether the interleaved dimension is along N
+        /// if false, then the interleaved dimension is along S
+        bool interleave_dim_along_N_;
+
+    protected:
+        /// prepare functions for every calibration mode
+
+        /// first, averaging over N or S
+        /// second, filter the ref_calib_ to perpare ref_coil_map_
+        void prep_ref_no_acceleration(const hoNDArray<T>& ref);
+
+        /// first, averaging over N or S, depending the interleaved dimension
+        /// second, filter the ref_calib_ to perpare ref_coil_map_
+        /// them, crop the unsampled region from ref_calib_, in case of partial fourier or asymmetric echo is used
+        /// after cropping, ref_calib_ only includes the fully sampled data and ready for calibration
+        void prep_ref_interleaved(const hoNDArray<T>& ref);
+
+        /// first, averaging over N or S
+        /// second, detect sampled region for reference along E1 and E2
+        /// set up and filter the fully sampled ref data
+        /// padding the filtered ref data to have the recon image size; this is the ref_coil_map_
+        /// crop the ref data to make ref_calib_ ready
+        void prep_ref_embedded(const hoNDArray<T>& ref);
+
+        /// first, averaging over N or S
+        /// second, detect sampled region for reference
+        /// set up and filter the fully sampled ref data
+        /// padding the filtered ref data to have the recon image size; this is the ref_coil_map_
+        /// crop the ref data to make ref_calib_ ready
+        void prep_ref_separate(const hoNDArray<T>& ref);
+
+        /// average across N and/or S
+        /// results are stored in ref_calib_
+        void average_ref(const hoNDArray<T>& ref);
+    };
+
+    /// ------------------------------------------------------------------------
+    /// reference preparation for non-cartesian sampling
+    /// ------------------------------------------------------------------------
+    template <typename T>
+    class EXPORTMRICORE referenceNonCartesianPreparer : public referencePreparer<T>
+    {
+    public:
+
+        typedef referencePreparer<T> BaseClass;
+        typedef typename realType<T>::Type value_type;
+
+        referenceNonCartesianPreparer();
+        virtual ~referenceNonCartesianPreparer();
+
+        /// ref: [RO E1 E2 CHA N S SLC]
+        virtual void prep_ref(const hoNDArray<T>& ref, const hoNDArray<float>& traj);
+
+        /// dump the class status
+        virtual void dump(std::ostream& os) const;
+
+        using BaseClass::ref_calib_;
+        using BaseClass::ref_coil_map_;
+        using BaseClass::calib_mode_;
+        using BaseClass::sampling_limits_;
+        using BaseClass::verbose_;
+
+        using BaseClass::gt_timer1_;
+        using BaseClass::gt_timer2_;
+        using BaseClass::gt_timer3_;
+        using BaseClass::perform_timing_;
+        // using BaseClass::gt_exporter_;
+        using BaseClass::debug_folder_;
+
+        /// trajectory for calibration data
+        /// [TRAJ E1 E2 CHA Nor1 Sor1 SLC]
+        hoNDArray<float> traj_calib_;
+
+        /// the default implementation in this calls maks ref_coil_map_ a shared-memory duplicate of ref_calib_, so is the traj_coil_map_
+        hoNDArray<float> traj_coil_map_;
+
+        /// whether to combine (not average) all N for ref generation
+        bool combine_all_ref_N_;
+        /// whether to combine (not average) all S for ref generation
+        bool combine_all_ref_S_;
+        /// for interleaved mode, whether the interleaved dimension is along N
+        /// if false, then the interleaved dimension is along S
+        bool interleave_dim_along_N_;
+
+    protected:
+        /// combine ref and traj array along N and S, controlled by combineN and combineS
+        void combine_along_N_S(const hoNDArray<T>& ref, const hoNDArray<float>& traj, bool combineN, bool combinedS);
+    };
+}

--- a/toolboxes/mri_core/mri_core_utility.cpp
+++ b/toolboxes/mri_core/mri_core_utility.cpp
@@ -6,8 +6,444 @@
 
 #include "mri_core_utility.h"
 #include "hoNDArray_elemwise.h"
+#include "hoNDFFT.h"
+#include "hoNDArray_utils.h"
 
 namespace Gadgetron
 {
+    template <typename T> 
+    void detect_readout_sampling_status(const hoNDArray<T>& data, hoNDArray<float>& sampled)
+    {
+        try
+        {
+            typedef typename realType<T>::Type value_type;
 
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            sampled.create(E1, E2, N, S, SLC);
+            Gadgetron::clear(sampled);
+
+            size_t slc, s, n, e2, e1;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                value_type v = 0;
+                                const T* pData = &(data(0, e1, e2, 0, n, s, slc));
+
+                                size_t ro;
+                                for (ro = 0; ro < RO; ro++)
+                                {
+                                    v += std::abs(pData[ro]);
+                                }
+
+                                if ( v > 0 )
+                                {
+                                    sampled(e1, e2, n, s, slc) = 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in detect_readout_sampling_status(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< float >& data, hoNDArray<float>& sampled);
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< double >& data, hoNDArray<float>& sampled);
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< std::complex<float> >& data, hoNDArray<float>& sampled);
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< std::complex<double> >& data, hoNDArray<float>& sampled);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    void average_kspace_across_N(const hoNDArray<T>& data, hoNDArray<T>& averaged)
+    {
+        typedef typename realType<T>::Type value_type;
+
+        try
+        {
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            hoNDArray<float> sampled;
+            Gadgetron::detect_readout_sampling_status(data, sampled);
+
+            Gadgetron::sum_over_dimension(data, averaged, 4);
+
+            hoNDArray<float> sampled_across_N;
+            Gadgetron::sum_over_dimension(sampled, sampled_across_N, 2);
+
+            size_t ro, e1, e2, cha, s, slc;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (cha = 0; cha < CHA; cha++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                value_type freq = sampled_across_N(e1, e2, 0, s, slc);
+
+                                if (freq > 1)
+                                {
+                                    value_type freq_reciprocal = (value_type)(1.0 / freq);
+
+                                    T* pAve = &(averaged(0, e1, e2, cha, 0, s, slc));
+                                    for (ro = 0; ro < RO; ro++)
+                                    {
+                                        pAve[ro] *= freq_reciprocal;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in average_kspace_across_N(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void average_kspace_across_N(const hoNDArray< float >& data, hoNDArray< float >& averaged);
+    template EXPORTMRICORE void average_kspace_across_N(const hoNDArray< double >& data, hoNDArray< double >& averaged);
+    template EXPORTMRICORE void average_kspace_across_N(const hoNDArray< std::complex<float> >& data, hoNDArray< std::complex<float> >& averaged);
+    template EXPORTMRICORE void average_kspace_across_N(const hoNDArray< std::complex<double> >& data, hoNDArray< std::complex<double> >& averaged);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    void average_kspace_across_S(const hoNDArray<T>& data, hoNDArray<T>& averaged)
+    {
+        typedef typename realType<T>::Type value_type;
+
+        try
+        {
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            hoNDArray<float> sampled;
+            Gadgetron::detect_readout_sampling_status(data, sampled);
+
+            Gadgetron::sum_over_dimension(data, averaged, 5);
+
+            hoNDArray<float> sampled_across_S;
+            Gadgetron::sum_over_dimension(sampled, sampled_across_S, 3);
+
+            size_t ro, e1, e2, cha, n, slc;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (n = 0; n < N; n++)
+                {
+                    for (cha = 0; cha < CHA; cha++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                value_type freq = sampled_across_S(e1, e2, n, 0, slc);
+
+                                if (freq > 1)
+                                {
+                                    value_type freq_reciprocal = (value_type)(1.0 / freq);
+
+                                    T* pAve = &(averaged(0, e1, e2, cha, n, 0, slc));
+                                    for (ro = 0; ro < RO; ro++)
+                                    {
+                                        pAve[ro] *= freq_reciprocal;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in average_kspace_across_S(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void average_kspace_across_S(const hoNDArray< float >& data, hoNDArray< float >& averaged);
+    template EXPORTMRICORE void average_kspace_across_S(const hoNDArray< double >& data, hoNDArray< double >& averaged);
+    template EXPORTMRICORE void average_kspace_across_S(const hoNDArray< std::complex<float> >& data, hoNDArray< std::complex<float> >& averaged);
+    template EXPORTMRICORE void average_kspace_across_S(const hoNDArray< std::complex<double> >& data, hoNDArray< std::complex<double> >& averaged);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    void detect_sampled_region_E1(const hoNDArray<T>& data, size_t& start_E1, size_t& end_E1)
+    {
+        try
+        {
+            hoNDArray<float> sampled;
+            Gadgetron::detect_readout_sampling_status(data, sampled);
+
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            start_E1 = E1;
+            end_E1 = 0;
+
+            size_t e1, e2, n, s, slc;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                if (sampled(e1, e2, n, s, slc)>0)
+                                {
+                                    if (e1 < start_E1) start_E1 = e1;
+                                    if (e1 > end_E1) end_E1 = e1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in detect_sampled_region_E1(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<float>& data, size_t& start_E1, size_t& end_E1);
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<double>& data, size_t& start_E1, size_t& end_E1);
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray< std::complex<float> >& data, size_t& start_E1, size_t& end_E1);
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray< std::complex<double> >& data, size_t& start_E1, size_t& end_E1);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void detect_sampled_region_E2(const hoNDArray<T>& data, size_t& start_E2, size_t& end_E2)
+    {
+        try
+        {
+            hoNDArray<float> sampled;
+            Gadgetron::detect_readout_sampling_status(data, sampled);
+
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            start_E2 = E2;
+            end_E2 = 0;
+
+            size_t e1, e2, n, s, slc;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                if (sampled(e1, e2, n, s, slc)>0)
+                                {
+                                    if (e2 < start_E2) start_E2 = e2;
+                                    if (e2 > end_E2) end_E2 = e2;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in detect_sampled_region_E2(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<float>& data, size_t& start_E2, size_t& end_E2);
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<double>& data, size_t& start_E2, size_t& end_E2);
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray< std::complex<float> >& data, size_t& start_E2, size_t& end_E2);
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray< std::complex<double> >& data, size_t& start_E2, size_t& end_E2);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    void generate_ref_filter_for_coil_map(const hoNDArray<T>& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray<T>& filter_RO, hoNDArray<T>& filter_E1, hoNDArray<T>& filter_E2)
+    {
+        try
+        {
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+
+            Gadgetron::generate_symmetric_filter_ref(RO, lim_RO.min_, lim_RO.max_, filter_RO);
+            Gadgetron::generate_symmetric_filter_ref(E1, lim_E1.min_, lim_E1.max_, filter_E1);
+
+            if (E2 > 1)
+            {
+                Gadgetron::generate_symmetric_filter_ref(E2, lim_E2.min_, lim_E2.max_, filter_E2);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in generate_ref_filter_for_coil_map(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<float> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<float> >& filter_RO, hoNDArray< std::complex<float> >& filter_E1, hoNDArray< std::complex<float> >& filter_E2);
+    template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<double> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<double> >& filter_RO, hoNDArray< std::complex<double> >& filter_E1, hoNDArray< std::complex<double> >& filter_E2);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    void zero_pad_resize(const hoNDArray<T>& complexIm, size_t sizeRO, size_t sizeE1, size_t sizeE2, hoNDArray<T>& complexImResized)
+    {
+        try
+        {
+            std::vector<size_t> dim;
+            complexIm.get_dimensions(dim);
+
+            size_t RO = complexIm.get_size(0);
+            size_t E1 = complexIm.get_size(1);
+            size_t E2 = complexIm.get_size(2);
+
+            GADGET_CHECK_THROW(sizeRO >= RO);
+            GADGET_CHECK_THROW(sizeE1 >= E1);
+
+            if (sizeE2 > 1)
+            {
+                if (RO == sizeRO && E1 == sizeE1 && E2 == sizeE2)
+                {
+                    complexImResized = complexIm;
+                    return;
+                }
+
+                if (complexImResized.get_size(0) != sizeRO || complexImResized.get_size(1) != sizeE1 || complexImResized.get_size(2) != sizeE2)
+                {
+                    dim[0] = sizeRO;
+                    dim[1] = sizeE1;
+                    dim[2] = sizeE2;
+                    complexImResized.create(dim);
+                }
+
+                Gadgetron::clear(&complexImResized);
+
+                hoNDArray<T> kspace(complexIm);
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->fft3c(complexIm, kspace);
+
+                Gadgetron::pad(sizeRO, sizeE1, sizeE2, &kspace, &complexImResized);
+
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft3c(complexImResized);
+
+                typename realType<T>::Type scaling = (typename realType<T>::Type)(std::sqrt((double)sizeRO*sizeE1*sizeE2) / std::sqrt((double)RO*E1));
+                Gadgetron::scal(scaling, complexImResized);
+            }
+            else
+            {
+                if (RO == sizeRO && E1 == sizeE1)
+                {
+                    complexImResized = complexIm;
+                    return;
+                }
+
+                if (complexImResized.get_size(0) != sizeRO || complexImResized.get_size(1) != sizeE1)
+                {
+                    dim[0] = sizeRO;
+                    dim[1] = sizeE1;
+                    complexImResized.create(dim);
+                }
+
+                Gadgetron::clear(&complexImResized);
+
+                hoNDArray<T> kspace(complexIm);
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->fft2c(complexIm, kspace);
+
+                Gadgetron::pad(sizeRO, sizeE1, &kspace, &complexImResized);
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifft2c(complexImResized);
+
+                typename realType<T>::Type scaling = (typename realType<T>::Type)(std::sqrt((double)sizeRO*sizeE1) / std::sqrt((double)RO*E1));
+                Gadgetron::scal(scaling, complexImResized);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in zero_pad_resize(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void zero_pad_resize(const hoNDArray< std::complex<float> >& complexIm, size_t sizeRO, size_t sizeE1, size_t sizeE2, hoNDArray< std::complex<float> >& complexImResized);
+    template EXPORTMRICORE void zero_pad_resize(const hoNDArray< std::complex<double> >& complexIm, size_t sizeRO, size_t sizeE1, size_t sizeE2, hoNDArray< std::complex<double> >& complexImResized);
+
+    // ------------------------------------------------------------------------
+
+    void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath)
+    {
+        char* v = std::getenv("GADGETRON_DEBUG_FOLDER");
+        if (v == NULL)
+        {
+#ifdef _WIN32
+            debugFolderPath = "c:/temp/gadgetron";
+#else
+            debugFolderPath = "/tmp/gadgetron";
+#endif // _WIN32
+        }
+        else
+        {
+            debugFolderPath = std::string(v);
+        }
+
+        debugFolderPath.append("/");
+        debugFolderPath.append(debugFolder);
+        debugFolderPath.append("/");
+    }
 }

--- a/toolboxes/mri_core/mri_core_utility.h
+++ b/toolboxes/mri_core/mri_core_utility.h
@@ -1,6 +1,7 @@
 
 /** \file   mri_core_utility.h
-    \brief  Implementation useful utility functionalities for 2D and 3D MRI parallel imaging
+    \brief  Implementation useful utility functionalities for 2D and 3D MRI reconstruction
+            The data structures defined in mri_core_data.h are used
     \author Hui Xue
 */
 
@@ -8,7 +9,41 @@
 
 #include "mri_core_export.h"
 #include "hoNDArray.h"
+#include "mri_core_data.h"
+#include "mri_core_kspace_filter.h"
 
 namespace Gadgetron
 {
+    // --------------------------------------------------------------------------
+    /// detect whether a readout has been sampled or not
+    // --------------------------------------------------------------------------
+    /// data: [RO E1 E2 CHA N S SLC]
+
+    /// sampled: [E1 E2 N S SLC], if a readout is sampled, corresponding sampled location is 1; otherwise, 0
+    template <typename T> EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray<T>& data, hoNDArray<float>& sampled );
+
+    /// average kspace across N
+    template <typename T> EXPORTMRICORE void average_kspace_across_N(const hoNDArray<T>& data, hoNDArray<T>& averaged);
+
+    /// average kspace across S
+    template <typename T> EXPORTMRICORE void average_kspace_across_S(const hoNDArray<T>& data, hoNDArray<T>& averaged);
+
+    /// detect sampled region along E1
+    template <typename T> EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<T>& data, size_t& start_E1, size_t& end_E1);
+
+    /// detect sampled region along E2
+    template <typename T> EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<T>& data, size_t& start_E2, size_t& end_E2);
+
+    /// detect sampled region along E2
+
+    /// set up the kspace filter for ref used for coil map estimation
+    template <typename T> EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray<T>& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray<T>& filter_RO, hoNDArray<T>& filter_E1, hoNDArray<T>& filter_E2);
+
+    /// zero padding resize for kspace and complex images
+    /// if sizeE2<=1, 2D zero padding resize is performed
+    template <typename T> EXPORTMRICORE void zero_pad_resize(const hoNDArray<T>& complexIm, size_t sizeRO, size_t sizeE1, size_t sizeE2, hoNDArray<T>& complexImResized);
+
+    /// get the path of debug folder
+    // environmental variable GADGETRON_DEBUG_FOLDER is used 
+    EXPORTMRICORE void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath);
 }


### PR DESCRIPTION
Second PR for generic chain.

a) Implement class objects for coil map maker, partial fourier handler and reference preparation.

b) Split ACE dependency definition into mri_core_acquisition_bucket.h; therefore, recon part does not need to know acquisition bucket, but only recon bit.

c) Update the coil map estimation, pf handling in gtplus with new class interfaces. 