### PR TITLE
Acquisition bucket header

### DIFF
--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
@@ -8,7 +8,7 @@
 #include <ismrmrd/ismrmrd.h>
 #include <complex>
 #include <map>
-#include "mri_core_data.h"
+#include "mri_core_acquisition_bucket.h"
 
 namespace Gadgetron{
 

--- a/gadgets/mri_core/BucketToBufferGadget.h
+++ b/gadgets/mri_core/BucketToBufferGadget.h
@@ -9,7 +9,7 @@
 #include <ismrmrd/xml.h>
 #include <complex>
 #include <map>
-#include "mri_core_data.h"
+#include "mri_core_acquisition_bucket.h"
 
 namespace Gadgetron{
 

--- a/toolboxes/mri_core/CMakeLists.txt
+++ b/toolboxes/mri_core/CMakeLists.txt
@@ -37,7 +37,8 @@ set( mri_core_header_files
         mri_core_utility.h
         mri_core_kspace_filter.h
         mri_core_grappa.h 
-        mri_core_coil_map_estimation.h )
+        mri_core_coil_map_estimation.h 
+        mri_core_acquisition_bucket.h )
 
 set( mri_core_source_files
         mri_core_utility.cpp 

--- a/toolboxes/mri_core/mri_core_acquisition_bucket.h
+++ b/toolboxes/mri_core/mri_core_acquisition_bucket.h
@@ -1,0 +1,168 @@
+#ifndef MRI_CORE_ACQUISITION_BUCKET_H
+#define MRI_CORE_ACQUISITION_BUCKET_H
+
+#include "GadgetContainerMessage.h"
+#include "mri_core_data.h"
+
+namespace Gadgetron 
+{
+
+  /** 
+      This class functions as a storage unit for statistics related to
+      the @IsmrmrdAcquisitionData objects.
+
+   */
+  class IsmrmrdAcquisitionBucketStats
+  {
+    public:
+      // Set of labels found in the data or ref part of a bucket
+      //11D, fixed order [RO, E1, E2, CHA, SLC, PHS, CON, REP, SET, SEG, AVE]
+      std::set<uint16_t> kspace_encode_step_1;
+      std::set<uint16_t> kspace_encode_step_2;
+      std::set<uint16_t> slice;
+      std::set<uint16_t> phase;
+      std::set<uint16_t> contrast;
+      std::set<uint16_t> repetition;
+      std::set<uint16_t> set;
+      std::set<uint16_t> segment;
+      std::set<uint16_t> average;
+  };
+
+  /** 
+      This class functions as a storage unit for GadgetContainerMessage pointers
+      that point to acquisiton headers, data and trajectories.
+
+      It is the storage used in the @IsmrmrdAcquisitionBucket structure. 
+
+   */
+  class IsmrmrdAcquisitionData
+  {
+  public:
+    /**
+       Default Constructor
+    */
+    IsmrmrdAcquisitionData()
+      : head_(0)
+      , data_(0)
+      , traj_(0)
+      {
+
+      }
+    
+    /**
+       Constructor
+    */
+    IsmrmrdAcquisitionData(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head,
+                           GadgetContainerMessage< hoNDArray< std::complex<float> > >* data,
+                           GadgetContainerMessage< hoNDArray< float > >* traj = 0)
+    {
+      if (head) {
+	head_ = head->duplicate();
+      } else {
+	head_ = 0;
+      }
+
+      if (data) {
+	data_ = data->duplicate();
+      } else {
+	data_ = 0;
+      }
+
+      if (traj) {
+	traj_ = traj->duplicate();
+      } else {
+	traj_ = 0;
+      }
+    }
+
+    /** 
+	Assignment operator
+     */
+    IsmrmrdAcquisitionData& operator=(const IsmrmrdAcquisitionData& d)
+      {
+	if (this != &d) { 
+	  if (d.head_) {
+	    if (head_) head_->release();
+	    head_ = d.head_->duplicate();
+	  } else {
+	    head_ = 0;
+	  }
+	  
+	  if (d.data_) {
+	    if (data_) data_->release();
+	    data_ = d.data_->duplicate();
+	  } else {
+	    data_ = 0;
+	  }
+	  
+	  if (d.traj_) {
+	    if (traj_) traj_->release();
+	    traj_ = d.traj_->duplicate();
+	  } else {
+	    traj_ = 0;
+	  }
+	}
+	return *this;
+      }
+
+    /**
+       Copy constructor
+     */
+    IsmrmrdAcquisitionData(const IsmrmrdAcquisitionData& d)
+      : head_(0)
+      , data_(0)
+      , traj_(0)
+      {
+	*this = d;
+      }
+
+
+    /**
+       Destructor. The memory in the GadgetContainer Messages will be deleted
+       when the object is destroyed. 
+     */
+    ~IsmrmrdAcquisitionData() {
+      if (head_) {
+	head_->release();
+	head_ = 0;
+      }
+
+      if (data_) {
+	data_->release();
+	data_ = 0;
+      }
+
+      if (traj_) {
+	traj_->release();
+	traj_ = 0;
+      }
+    }
+
+
+    GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head_;
+    GadgetContainerMessage< hoNDArray< std::complex<float> > >* data_;
+    GadgetContainerMessage< hoNDArray< float > > * traj_;
+  };
+
+
+  /**
+
+     This class serves as the storage unit for buffered data. 
+     The @IsmrmrdAcquisitionData structure contains pointers 
+     to the GadgetContainerMessages with the data. 
+
+     Data stored in these buckets will automatically get deleted when the object is
+     destroyed. 
+
+   */ 
+  class IsmrmrdAcquisitionBucket
+  {
+  public:
+    std::vector< IsmrmrdAcquisitionData > data_;
+    std::vector< IsmrmrdAcquisitionData > ref_;
+    std::vector< IsmrmrdAcquisitionBucketStats > datastats_;
+    std::vector< IsmrmrdAcquisitionBucketStats > refstats_;
+  };
+  
+}
+#endif //MRI_CORE_ACQUISITION_BUCKET_H

--- a/toolboxes/mri_core/mri_core_data.h
+++ b/toolboxes/mri_core/mri_core_data.h
@@ -1,7 +1,6 @@
 #ifndef MRI_CORE_DATA_H
 #define MRI_CORE_DATA_H
 
-#include "GadgetContainerMessage.h"
 #include "ismrmrd/ismrmrd.h"
 #include "ismrmrd/meta.h"
 #include <vector>
@@ -38,171 +37,22 @@ namespace Gadgetron
 	USER_7,
 	NONE
       };
-    
-  /** 
-      This class functions as a storage unit for statistics related to
-      the @IsmrmrdAcquisitionData objects.
 
-   */
-  class IsmrmrdAcquisitionBucketStats
-  {
-    public:
-      // Set of labels found in the data or ref part of a bucket
-      //11D, fixed order [RO, E1, E2, CHA, SLC, PHS, CON, REP, SET, SEG, AVE]
-      std::set<uint16_t> kspace_encode_step_1;
-      std::set<uint16_t> kspace_encode_step_2;
-      std::set<uint16_t> slice;
-      std::set<uint16_t> phase;
-      std::set<uint16_t> contrast;
-      std::set<uint16_t> repetition;
-      std::set<uint16_t> set;
-      std::set<uint16_t> segment;
-      std::set<uint16_t> average;
-  };
-
-  /** 
-      This class functions as a storage unit for GadgetContainerMessage pointers
-      that point to acquisiton headers, data and trajectories.
-
-      It is the storage used in the @IsmrmrdAcquisitionBucket structure. 
-
-   */
-  class IsmrmrdAcquisitionData
-  {
-  public:
-    /**
-       Default Constructor
-    */
-    IsmrmrdAcquisitionData()
-      : head_(0)
-      , data_(0)
-      , traj_(0)
-      {
-
-      }
-    
-    /**
-       Constructor
-    */
-    IsmrmrdAcquisitionData(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head,
-                           GadgetContainerMessage< hoNDArray< std::complex<float> > >* data,
-                           GadgetContainerMessage< hoNDArray< float > >* traj = 0)
-    {
-      if (head) {
-	head_ = head->duplicate();
-      } else {
-	head_ = 0;
-      }
-
-      if (data) {
-	data_ = data->duplicate();
-      } else {
-	data_ = 0;
-      }
-
-      if (traj) {
-	traj_ = traj->duplicate();
-      } else {
-	traj_ = 0;
-      }
-    }
-
-    /** 
-	Assignment operator
-     */
-    IsmrmrdAcquisitionData& operator=(const IsmrmrdAcquisitionData& d)
-      {
-	if (this != &d) { 
-	  if (d.head_) {
-	    if (head_) head_->release();
-	    head_ = d.head_->duplicate();
-	  } else {
-	    head_ = 0;
-	  }
-	  
-	  if (d.data_) {
-	    if (data_) data_->release();
-	    data_ = d.data_->duplicate();
-	  } else {
-	    data_ = 0;
-	  }
-	  
-	  if (d.traj_) {
-	    if (traj_) traj_->release();
-	    traj_ = d.traj_->duplicate();
-	  } else {
-	    traj_ = 0;
-	  }
-	}
-	return *this;
-      }
-
-    /**
-       Copy constructor
-     */
-    IsmrmrdAcquisitionData(const IsmrmrdAcquisitionData& d)
-      : head_(0)
-      , data_(0)
-      , traj_(0)
-      {
-	*this = d;
-      }
-
-
-    /**
-       Destructor. The memory in the GadgetContainer Messages will be deleted
-       when the object is destroyed. 
-     */
-    ~IsmrmrdAcquisitionData() {
-      if (head_) {
-	head_->release();
-	head_ = 0;
-      }
-
-      if (data_) {
-	data_->release();
-	data_ = 0;
-      }
-
-      if (traj_) {
-	traj_->release();
-	traj_ = 0;
-      }
-    }
-
-
-    GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* head_;
-    GadgetContainerMessage< hoNDArray< std::complex<float> > >* data_;
-    GadgetContainerMessage< hoNDArray< float > > * traj_;
-  };
-
-
-  /**
-
-     This class serves as the storage unit for buffered data. 
-     The @IsmrmrdAcquisitionData structure contains pointers 
-     to the GadgetContainerMessages with the data. 
-
-     Data stored in these buckets will automatically get deleted when the object is
-     destroyed. 
-
-   */ 
-  class IsmrmrdAcquisitionBucket
-  {
-  public:
-    std::vector< IsmrmrdAcquisitionData > data_;
-    std::vector< IsmrmrdAcquisitionData > ref_;
-    std::vector< IsmrmrdAcquisitionBucketStats > datastats_;
-    std::vector< IsmrmrdAcquisitionBucketStats > refstats_;
-  };
-  
-  
   class SamplingLimit
   {
   public:
     uint16_t min_;
     uint16_t center_;
     uint16_t max_;
+
+    SamplingLimit()
+    {
+        min_ = 0;
+        center_ = 0;
+        max_ = 0;
+    }
+
+    ~SamplingLimit() {}
   };
   
   class SamplingDescription
@@ -219,6 +69,27 @@ namespace Gadgetron
     // sampled range along RO, E1, E2 (for asymmetric echo and partial fourier)
     // min, max and center
     SamplingLimit sampling_limits_[3];
+
+    SamplingDescription()
+    {
+        encoded_FOV_[0] = 0;
+        encoded_FOV_[1] = 0;
+        encoded_FOV_[2] = 0;
+
+        recon_FOV_[0] = 0;
+        recon_FOV_[1] = 0;
+        recon_FOV_[2] = 0;
+
+        encoded_matrix_[0] = 0;
+        encoded_matrix_[1] = 0;
+        encoded_matrix_[2] = 0;
+
+        recon_matrix_[0] = 0;
+        recon_matrix_[1] = 0;
+        recon_matrix_[2] = 0;
+    }
+
+    ~SamplingDescription() {}
   };
   
   class IsmrmrdDataBuffered


### PR DESCRIPTION
Split acquisition bucket into its own header.
Add constructors for SamplingLimit and SamplingDescription, so their member variables are initialized.
