### PR TITLE
Single recon gadget

### DIFF
--- a/gadgets/gtPlus/GtPlusAccumulatorWorkOrderTriggerGadget.cpp
+++ b/gadgets/gtPlus/GtPlusAccumulatorWorkOrderTriggerGadget.cpp
@@ -344,7 +344,8 @@ int GtPlusAccumulatorWorkOrderTriggerGadget::process(GadgetContainerMessage<ISMR
     {
         if ( (workOrder_.start_RO_<0) && (workOrder_.end_RO_<0) )
         {
-            gtPlus_util_.findStartEndROAfterZeroFilling(m1->getObjectPtr()->center_sample, m1->getObjectPtr()->number_of_samples, workOrder_.start_RO_, workOrder_.end_RO_);
+	    workOrder_.start_RO_ = m1->getObjectPtr()->discard_pre;
+	    workOrder_.end_RO_ = m1->getObjectPtr()->number_of_samples - m1->getObjectPtr()->discard_post - 1;
 
             GDEBUG_CONDITION_STREAM(verboseMode_, "start_RO : " << workOrder_.start_RO_);
             GDEBUG_CONDITION_STREAM(verboseMode_, "end_RO : " << workOrder_.end_RO_);

--- a/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
+++ b/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
@@ -121,7 +121,7 @@ int AsymmetricEchoAdjustROGadget
 
             m1->cont(m3);
             m1->getObjectPtr()->number_of_samples = (uint16_t)data_out_dims[0];
-            // m1->getObjectPtr()->center_sample = m1->getObjectPtr()->number_of_samples / 2;
+            m1->getObjectPtr()->center_sample = m1->getObjectPtr()->number_of_samples / 2;
         }
 
         if (this->next()->putq(m1) == -1) 

--- a/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
+++ b/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
@@ -100,6 +100,9 @@ int AsymmetricEchoAdjustROGadget
                 {
                     memcpy(pM3 + c*maxRO_[encoding_ref] + maxRO_[encoding_ref] - samples, pM2 + c*samples, numOfBytes);
                 }
+
+                m1->getObjectPtr()->discard_pre = maxRO_[encoding_ref] - samples;
+                m1->getObjectPtr()->discard_post = 0;
             }
 
             if ( az == 2 ) // post zeros
@@ -109,12 +112,16 @@ int AsymmetricEchoAdjustROGadget
                 {
                     memcpy(pM3 + c*maxRO_[encoding_ref], pM2 + c*samples, numOfBytes);
                 }
+
+                m1->getObjectPtr()->discard_pre = 0;
+                m1->getObjectPtr()->discard_post = maxRO_[encoding_ref] - samples;
             }
 
             m2->release(); //We are done with this data
 
             m1->cont(m3);
-            m1->getObjectPtr()->number_of_samples = data_out_dims[0];
+            m1->getObjectPtr()->number_of_samples = (uint16_t)data_out_dims[0];
+            // m1->getObjectPtr()->center_sample = m1->getObjectPtr()->number_of_samples / 2;
         }
 
         if (this->next()->putq(m1) == -1) 

--- a/gadgets/mri_core/BucketToBufferGadget.cpp
+++ b/gadgets/mri_core/BucketToBufferGadget.cpp
@@ -548,25 +548,8 @@ namespace Gadgetron{
 
     // For cartesian trajectories, assume that any oversampling has been removed.
     if (encoding.trajectory.compare("cartesian") == 0) {
-
-        size_t num = acqhdr.number_of_samples / 2;
-
-        if (acqhdr.discard_pre == 0 && acqhdr.discard_post==0)
-        {
-            sampling.sampling_limits_[0].min_ = 0;
-            sampling.sampling_limits_[0].max_ = acqhdr.number_of_samples - 1;
-        }
-        else if (acqhdr.discard_pre>0) // pre zeros
-        {
-            sampling.sampling_limits_[0].min_ = acqhdr.discard_pre;
-            sampling.sampling_limits_[0].max_ = acqhdr.number_of_samples - 1;
-        }
-        else if (acqhdr.discard_post>0) // post zeros
-        {
-            sampling.sampling_limits_[0].min_ = 0;
-            sampling.sampling_limits_[0].max_ = acqhdr.number_of_samples - acqhdr.discard_post - 1;
-        }
-
+        sampling.sampling_limits_[0].min_ = acqhdr.discard_pre;
+        sampling.sampling_limits_[0].max_ = acqhdr.number_of_samples - acqhdr.discard_post - 1;
         sampling.sampling_limits_[0].center_ = acqhdr.number_of_samples / 2;
     } else {
         sampling.sampling_limits_[0].min_ = 0;

--- a/gadgets/mri_core/BucketToBufferGadget.cpp
+++ b/gadgets/mri_core/BucketToBufferGadget.cpp
@@ -99,7 +99,6 @@ namespace Gadgetron{
     //}
 
     //Iterate over the reference data of the bucket
-    size_t count = 0;
     for(std::vector<IsmrmrdAcquisitionData>::iterator it = m1->getObjectPtr()->ref_.begin();
         it != m1->getObjectPtr()->ref_.end(); ++it)
       {
@@ -131,7 +130,7 @@ namespace Gadgetron{
         IsmrmrdAcquisitionBucketStats & stats = m1->getObjectPtr()->refstats_[espace];
 
         //Fill the sampling description for this data buffer
-        if(count == 0 )
+        if (dataBuffer.sampling_.recon_matrix_[0] == 0)
             fillSamplingDescription(dataBuffer.sampling_, encoding, stats, acqhdr);
 
         //Make sure that the data storage for this data buffer has been allocated
@@ -140,15 +139,12 @@ namespace Gadgetron{
 
         // Stuff the data, header and trajectory into this data buffer
         stuff(it, dataBuffer, encoding);
-
-        count++;
       }
 
 
     //Iterate over the imaging data of the bucket
     // this is exactly the same code as for the reference data except for
     // the chunk of the data buffer.
-    count = 0;
     for(std::vector<IsmrmrdAcquisitionData>::iterator it = m1->getObjectPtr()->data_.begin();
         it != m1->getObjectPtr()->data_.end(); ++it)
       {
@@ -180,7 +176,7 @@ namespace Gadgetron{
         IsmrmrdAcquisitionBucketStats & stats = m1->getObjectPtr()->datastats_[espace];
 
         //Fill the sampling description for this data buffer
-        if (count == 0)
+        if (dataBuffer.sampling_.recon_matrix_[0] == 0)
             fillSamplingDescription(dataBuffer.sampling_, encoding, stats, acqhdr);
 
         //Make sure that the data storage for this data buffer has been allocated
@@ -189,8 +185,6 @@ namespace Gadgetron{
 
         // Stuff the data, header and trajectory into this data buffer
         stuff(it, dataBuffer, encoding);
-
-        count++;
       }
 
 

--- a/gadgets/mri_core/BucketToBufferGadget.cpp
+++ b/gadgets/mri_core/BucketToBufferGadget.cpp
@@ -129,8 +129,8 @@ namespace Gadgetron{
         //this bucket's reference stats
         IsmrmrdAcquisitionBucketStats & stats = m1->getObjectPtr()->refstats_[espace];
 
-        //Fill the sampling description for this data buffer
-        if (dataBuffer.sampling_.recon_matrix_[0] == 0)
+        //Fill the sampling description for this data buffer, only need to fill the sampling_ once
+        if (it == m1->getObjectPtr()->ref_.begin())
             fillSamplingDescription(dataBuffer.sampling_, encoding, stats, acqhdr);
 
         //Make sure that the data storage for this data buffer has been allocated
@@ -175,8 +175,8 @@ namespace Gadgetron{
         //this bucket's imaging data stats
         IsmrmrdAcquisitionBucketStats & stats = m1->getObjectPtr()->datastats_[espace];
 
-        //Fill the sampling description for this data buffer
-        if (dataBuffer.sampling_.recon_matrix_[0] == 0)
+        //Fill the sampling description for this data buffer, only need to fill sampling_ once
+        if (it == m1->getObjectPtr()->data_.begin())
             fillSamplingDescription(dataBuffer.sampling_, encoding, stats, acqhdr);
 
         //Make sure that the data storage for this data buffer has been allocated

--- a/gadgets/mri_core/BucketToBufferGadget.cpp
+++ b/gadgets/mri_core/BucketToBufferGadget.cpp
@@ -99,6 +99,7 @@ namespace Gadgetron{
     //}
 
     //Iterate over the reference data of the bucket
+    size_t count = 0;
     for(std::vector<IsmrmrdAcquisitionData>::iterator it = m1->getObjectPtr()->ref_.begin();
         it != m1->getObjectPtr()->ref_.end(); ++it)
       {
@@ -130,20 +131,24 @@ namespace Gadgetron{
         IsmrmrdAcquisitionBucketStats & stats = m1->getObjectPtr()->refstats_[espace];
 
         //Fill the sampling description for this data buffer
-        fillSamplingDescription(dataBuffer.sampling_, encoding, stats);
+        if(count == 0 )
+            fillSamplingDescription(dataBuffer.sampling_, encoding, stats, acqhdr);
 
         //Make sure that the data storage for this data buffer has been allocated
         //TODO should this check the limits, or should that be done in the stuff function?
-        allocateDataArrays(dataBuffer, acqhdr, encoding, stats);
+        allocateDataArrays(dataBuffer, acqhdr, encoding, stats, true);
 
         // Stuff the data, header and trajectory into this data buffer
         stuff(it, dataBuffer, encoding);
+
+        count++;
       }
 
 
     //Iterate over the imaging data of the bucket
     // this is exactly the same code as for the reference data except for
     // the chunk of the data buffer.
+    count = 0;
     for(std::vector<IsmrmrdAcquisitionData>::iterator it = m1->getObjectPtr()->data_.begin();
         it != m1->getObjectPtr()->data_.end(); ++it)
       {
@@ -175,14 +180,17 @@ namespace Gadgetron{
         IsmrmrdAcquisitionBucketStats & stats = m1->getObjectPtr()->datastats_[espace];
 
         //Fill the sampling description for this data buffer
-        fillSamplingDescription(dataBuffer.sampling_, encoding, stats);
+        if (count == 0)
+            fillSamplingDescription(dataBuffer.sampling_, encoding, stats, acqhdr);
 
         //Make sure that the data storage for this data buffer has been allocated
         //TODO should this check the limits, or should that be done in the stuff function?
-        allocateDataArrays(dataBuffer, acqhdr, encoding, stats);
+        allocateDataArrays(dataBuffer, acqhdr, encoding, stats, false);
 
         // Stuff the data, header and trajectory into this data buffer
         stuff(it, dataBuffer, encoding);
+
+        count++;
       }
 
 
@@ -357,7 +365,7 @@ namespace Gadgetron{
 
   }
 
-  void BucketToBufferGadget::allocateDataArrays(IsmrmrdDataBuffered & dataBuffer, ISMRMRD::AcquisitionHeader & acqhdr, ISMRMRD::Encoding encoding, IsmrmrdAcquisitionBucketStats & stats)
+  void BucketToBufferGadget::allocateDataArrays(IsmrmrdDataBuffered & dataBuffer, ISMRMRD::AcquisitionHeader & acqhdr, ISMRMRD::Encoding encoding, IsmrmrdAcquisitionBucketStats & stats, bool forref)
   {
     if (dataBuffer.data_.get_number_of_elements() == 0)
       {
@@ -366,14 +374,31 @@ namespace Gadgetron{
         //11D, fixed order [E0, E1, E2, CHA, SLC, PHS, CON, REP, SET, SEG, AVE]
         uint16_t NE0;
         if (encoding.trajectory.compare("cartesian") == 0) {
-            NE0 = encoding.reconSpace.matrixSize.x;
+            // if seperate or external calibration mode, using the acq length for NE0
+            if (forref && (encoding.parallelImaging.get().calibrationMode.get() == "separate"
+                || encoding.parallelImaging.get().calibrationMode.get() == "external"))
+            {
+                NE0 = acqhdr.number_of_samples;
+            }
+            else
+            {
+                NE0 = encoding.reconSpace.matrixSize.x;
+            }
         } else {
             NE0 = acqhdr.number_of_samples - acqhdr.discard_pre - acqhdr.discard_post;
         }
 
         uint16_t NE1;
         if (encoding.trajectory.compare("cartesian") == 0) {
-            NE1 = encoding.encodedSpace.matrixSize.y;
+            if (forref && (encoding.parallelImaging.get().calibrationMode.get() == "separate"
+                || encoding.parallelImaging.get().calibrationMode.get() == "external") )
+            {
+                NE1 = *stats.kspace_encode_step_1.rbegin() - *stats.kspace_encode_step_1.begin() + 1;
+            }
+            else
+            {
+                NE1 = encoding.encodedSpace.matrixSize.y;
+            }
         } else {
             if (encoding.encodingLimits.kspace_encoding_step_1.is_present()) {
                 NE1 = encoding.encodingLimits.kspace_encoding_step_1->maximum - encoding.encodingLimits.kspace_encoding_step_1->minimum + 1;
@@ -384,7 +409,15 @@ namespace Gadgetron{
 
         uint16_t NE2;
         if (encoding.trajectory.compare("cartesian") == 0) {
-            NE2 = encoding.encodedSpace.matrixSize.z;
+            if (forref && (encoding.parallelImaging.get().calibrationMode.get() == "separate"
+                || encoding.parallelImaging.get().calibrationMode.get() == "external"))
+            {
+                NE2 = encoding.encodingLimits.kspace_encoding_step_2->maximum - encoding.encodingLimits.kspace_encoding_step_2->minimum + 1;
+            }
+            else
+            {
+                NE2 = encoding.encodedSpace.matrixSize.z;
+            }
         } else {
             if (encoding.encodingLimits.kspace_encoding_step_2.is_present()) {
                 NE2 = encoding.encodingLimits.kspace_encoding_step_2->maximum - encoding.encodingLimits.kspace_encoding_step_2->minimum + 1;
@@ -494,7 +527,7 @@ namespace Gadgetron{
 
   }
 
-  void BucketToBufferGadget::fillSamplingDescription(SamplingDescription & sampling, ISMRMRD::Encoding & encoding, IsmrmrdAcquisitionBucketStats & stats)
+  void BucketToBufferGadget::fillSamplingDescription(SamplingDescription & sampling, ISMRMRD::Encoding & encoding, IsmrmrdAcquisitionBucketStats & stats, ISMRMRD::AcquisitionHeader& acqhdr)
   {
     // For cartesian trajectories, assume that any oversampling has been removed.
     if (encoding.trajectory.compare("cartesian") == 0) {
@@ -521,9 +554,26 @@ namespace Gadgetron{
 
     // For cartesian trajectories, assume that any oversampling has been removed.
     if (encoding.trajectory.compare("cartesian") == 0) {
-        sampling.sampling_limits_[0].min_ = 0;
-        sampling.sampling_limits_[0].max_ = encoding.reconSpace.matrixSize.x - 1;
-        sampling.sampling_limits_[0].center_ = encoding.reconSpace.matrixSize.x / 2;
+
+        size_t num = acqhdr.number_of_samples / 2;
+
+        if (acqhdr.discard_pre == 0 && acqhdr.discard_post==0)
+        {
+            sampling.sampling_limits_[0].min_ = 0;
+            sampling.sampling_limits_[0].max_ = acqhdr.number_of_samples - 1;
+        }
+        else if (acqhdr.discard_pre>0) // pre zeros
+        {
+            sampling.sampling_limits_[0].min_ = acqhdr.discard_pre;
+            sampling.sampling_limits_[0].max_ = acqhdr.number_of_samples - 1;
+        }
+        else if (acqhdr.discard_post>0) // post zeros
+        {
+            sampling.sampling_limits_[0].min_ = 0;
+            sampling.sampling_limits_[0].max_ = acqhdr.number_of_samples - acqhdr.discard_post - 1;
+        }
+
+        sampling.sampling_limits_[0].center_ = acqhdr.number_of_samples / 2;
     } else {
         sampling.sampling_limits_[0].min_ = 0;
         sampling.sampling_limits_[0].max_ = encoding.encodedSpace.matrixSize.x - 1;
@@ -591,11 +641,20 @@ namespace Gadgetron{
       }
 
     std::complex<float> *dataptr;
-    uint16_t NCHA = dataBuffer.data_.get_size(3);
+    uint16_t NCHA = (uint16_t)dataBuffer.data_.get_size(3);
+    uint16_t NN = (uint16_t)dataBuffer.data_.get_size(4);
+    uint16_t NS = (uint16_t)dataBuffer.data_.get_size(5);
+
+    uint16_t NUsed = (uint16_t)getN(acqhdr.idx);
+    if (NUsed >= NN) NUsed = NN - 1;
+
+    uint16_t SUsed = (uint16_t)getS(acqhdr.idx);
+    if (SUsed >= NS) SUsed = NS - 1;
+
     for (uint16_t cha = 0; cha < NCHA; cha++)
       {
         dataptr = & dataBuffer.data_(
-            offset, acqhdr.idx.kspace_encode_step_1, acqhdr.idx.kspace_encode_step_2, cha, getN(acqhdr.idx),  getS(acqhdr.idx), slice_loc);
+            offset, acqhdr.idx.kspace_encode_step_1, acqhdr.idx.kspace_encode_step_2, cha, NUsed, SUsed, slice_loc);
 
 
         memcpy(dataptr, &acqdata(acqhdr.discard_pre, cha), sizeof(std::complex<float>)*npts_to_copy);
@@ -603,16 +662,19 @@ namespace Gadgetron{
 
     //Stuff the header
     dataBuffer.headers_(acqhdr.idx.kspace_encode_step_1,
-        acqhdr.idx.kspace_encode_step_2, getN(acqhdr.idx),  getS(acqhdr.idx), slice_loc) = acqhdr;
+        acqhdr.idx.kspace_encode_step_2, NUsed, SUsed, slice_loc) = acqhdr;
 
     //Stuff the trajectory
     if (acqhdr.trajectory_dimensions > 0) {
+
         hoNDArray< float > & acqtraj = *it->traj_->getObjectPtr();  // TODO do we need to check this?
 
         float * trajptr;
+
         trajptr = &dataBuffer.trajectory_(0,
-            offset, acqhdr.idx.kspace_encode_step_1, acqhdr.idx.kspace_encode_step_2, getN(acqhdr.idx),  getS(acqhdr.idx), slice_loc);
-        memcpy(trajptr, & acqtraj(0,acqhdr.discard_pre ), sizeof(float)*npts_to_copy*acqhdr.trajectory_dimensions);
+            offset, acqhdr.idx.kspace_encode_step_1, acqhdr.idx.kspace_encode_step_2, NUsed, SUsed, slice_loc);
+
+        memcpy(trajptr, &acqtraj(0, acqhdr.discard_pre), sizeof(float)*npts_to_copy*acqhdr.trajectory_dimensions);
 
     }
   }
@@ -620,3 +682,4 @@ namespace Gadgetron{
   GADGET_FACTORY_DECLARE(BucketToBufferGadget)
 
 }
+

--- a/gadgets/mri_core/BucketToBufferGadget.h
+++ b/gadgets/mri_core/BucketToBufferGadget.h
@@ -9,6 +9,7 @@
 #include <ismrmrd/xml.h>
 #include <complex>
 #include <map>
+#include "mri_core_data.h"
 #include "mri_core_acquisition_bucket.h"
 
 namespace Gadgetron{
@@ -66,8 +67,8 @@ namespace Gadgetron{
       size_t getS(ISMRMRD::ISMRMRD_EncodingCounters idx);
 
       IsmrmrdReconBit & getRBit(std::map<size_t, GadgetContainerMessage<IsmrmrdReconData>* > & recon_data_buffers, size_t key, uint16_t espace);
-      void allocateDataArrays(IsmrmrdDataBuffered &  dataBuffer, ISMRMRD::AcquisitionHeader & acqhdr, ISMRMRD::Encoding encoding, IsmrmrdAcquisitionBucketStats & stats);
-      void fillSamplingDescription(SamplingDescription & sampling, ISMRMRD::Encoding & encoding, IsmrmrdAcquisitionBucketStats & stats);
+      void allocateDataArrays(IsmrmrdDataBuffered &  dataBuffer, ISMRMRD::AcquisitionHeader & acqhdr, ISMRMRD::Encoding encoding, IsmrmrdAcquisitionBucketStats & stats, bool forref);
+      void fillSamplingDescription(SamplingDescription & sampling, ISMRMRD::Encoding & encoding, IsmrmrdAcquisitionBucketStats & stats, ISMRMRD::AcquisitionHeader & acqhdr);
       void stuff(std::vector<IsmrmrdAcquisitionData>::iterator it, IsmrmrdDataBuffered & dataBuffer, ISMRMRD::Encoding encoding);
 
     };

--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -86,7 +86,8 @@ set( gadgetron_mricore_header_files GadgetMRIHeaders.h
                                     PseudoReplicatorGadget.h
                                     SimpleReconGadget.h
                                     ImageSortGadget.h
-                                    GenericCartesianGrappaReconGadget.h )
+                                    GenericCartesianGrappaReconGadget.h 
+                                    GenericCartesianReconReferencePrepGadget.h )
 
 set( gadgetron_mricore_src_files AcquisitionPassthroughGadget.cpp 
                                 AcquisitionFinishGadget.cpp 
@@ -120,7 +121,8 @@ set( gadgetron_mricore_src_files AcquisitionPassthroughGadget.cpp
                                 PseudoReplicatorGadget.cpp
                                 SimpleReconGadget.cpp
                                 ImageSortGadget.cpp
-                                GenericCartesianGrappaReconGadget.cpp)
+                                GenericCartesianGrappaReconGadget.cpp 
+                                GenericCartesianReconReferencePrepGadget.cpp )
 
 if (WIN32)
     set( gadgetron_mricore_header_files ${gadgetron_mricore_header_files} WhiteNoiseInjectorGadget.h )
@@ -155,6 +157,7 @@ target_link_libraries(gadgetron_mricore
     gadgetron_toolbox_cpufft
     gadgetron_toolbox_cpuklt
     gadgetron_toolbox_mri_core
+    gadgetron_toolbox_gtplus_io
     ${ISMRMRD_LIBRARIES} 
     ${FFTW3_LIBRARIES} 
     optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} 

--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -85,7 +85,8 @@ set( gadgetron_mricore_header_files GadgetMRIHeaders.h
                                     ImageArraySplitGadget.h
                                     PseudoReplicatorGadget.h
                                     SimpleReconGadget.h
-                                    ImageSortGadget.h)
+                                    ImageSortGadget.h
+                                    GenericCartesianGrappaReconGadget.h )
 
 set( gadgetron_mricore_src_files AcquisitionPassthroughGadget.cpp 
                                 AcquisitionFinishGadget.cpp 
@@ -118,7 +119,8 @@ set( gadgetron_mricore_src_files AcquisitionPassthroughGadget.cpp
                                 ImageArraySplitGadget.cpp
                                 PseudoReplicatorGadget.cpp
                                 SimpleReconGadget.cpp
-                                ImageSortGadget.cpp)
+                                ImageSortGadget.cpp
+                                GenericCartesianGrappaReconGadget.cpp)
 
 if (WIN32)
     set( gadgetron_mricore_header_files ${gadgetron_mricore_header_files} WhiteNoiseInjectorGadget.h )
@@ -132,6 +134,7 @@ set( gadgetron_mricore_config_files
     default_measurement_dependencies.xml
     isalive.xml
     gtquery.xml
+    Generic_Cartesian_Grappa_T2W.xml
 )
 
 add_library(gadgetron_mricore SHARED 
@@ -151,6 +154,8 @@ target_link_libraries(gadgetron_mricore
     gadgetron_toolbox_cpucore
     gadgetron_toolbox_cpufft
     gadgetron_toolbox_cpuklt
+    gadgetron_toolbox_mri_core
+    gadgetron_toolbox_gtplus_io
     ${ISMRMRD_LIBRARIES} 
     ${FFTW3_LIBRARIES} 
     optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} 

--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -155,7 +155,6 @@ target_link_libraries(gadgetron_mricore
     gadgetron_toolbox_cpufft
     gadgetron_toolbox_cpuklt
     gadgetron_toolbox_mri_core
-    gadgetron_toolbox_gtplus_io
     ${ISMRMRD_LIBRARIES} 
     ${FFTW3_LIBRARIES} 
     optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} 

--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -157,7 +157,7 @@ target_link_libraries(gadgetron_mricore
     gadgetron_toolbox_cpufft
     gadgetron_toolbox_cpuklt
     gadgetron_toolbox_mri_core
-    gadgetron_toolbox_gtplus_io
+    # gadgetron_toolbox_gtplus_io
     ${ISMRMRD_LIBRARIES} 
     ${FFTW3_LIBRARIES} 
     optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} 

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
@@ -1,0 +1,1745 @@
+
+#include "GenericCartesianGrappaReconGadget.h"
+#include <iomanip>
+
+#include "mri_core_kspace_filter.h"
+#include "hoNDArray_reductions.h"
+#include "mri_core_def.h"
+#include "mri_core_coil_map_estimation.h"
+#include "mri_core_grappa.h"
+#include "mri_core_utility.h"
+
+/// GenericCartesianGrappaReconObj
+namespace Gadgetron {
+
+    template<typename T>
+    GenericCartesianGrappaReconObj<T>::GenericCartesianGrappaReconObj()
+    {
+    }
+
+    template<typename T>
+    GenericCartesianGrappaReconObj<T>::GenericCartesianGrappaReconObj(const GenericCartesianGrappaReconObj<T>& v)
+    {
+        *this = v;
+    }
+
+    template<typename T>
+    GenericCartesianGrappaReconObj<T>::~GenericCartesianGrappaReconObj()
+    {
+    }
+
+    template<typename T>
+    GenericCartesianGrappaReconObj<T>& GenericCartesianGrappaReconObj<T>::operator=(const GenericCartesianGrappaReconObj<T>& v)
+    {
+        try
+        {
+            if (this == &v)
+                return *this;
+
+            this->recon_res_ = v.recon_res_;
+
+            this->gfactor_ = v.gfactor_;
+
+            this->kernel_ = v.kernel_;
+            this->kernelIm_ = v.kernelIm_;
+            this->unmixing_coeff_ = v.unmixing_coeff_;
+            this->coil_map_ = v.coil_map_;
+        }
+        catch (...)
+        {
+            GADGET_THROW("Erorros happened in GenericCartesianGrappaReconObj<T>::operator=(const GenericCartesianGrappaReconObj<T>& v) ... ");
+        }
+
+        return *this;
+    }
+
+    template class EXPORTGADGETSMRICORE GenericCartesianGrappaReconObj < std::complex<float> >;
+}
+
+
+namespace Gadgetron {
+
+    GenericCartesianGrappaReconGadget::GenericCartesianGrappaReconGadget()
+    {
+        num_encoding_spaces_ = 1;
+
+        process_called_times_ = 0;
+
+        std::string procTime;
+        this->get_current_moment(procTime);
+
+        GDEBUG_STREAM("* ======================================================================================================= *");
+        GDEBUG_STREAM("---> GenericCartesianGrappaReconGadget, constructor(), Currnt processing time : " << procTime << " <---");
+        GDEBUG_STREAM("* ======================================================================================================= *");
+    }
+
+    GenericCartesianGrappaReconGadget::~GenericCartesianGrappaReconGadget()
+    {
+        std::string procTime;
+        this->get_current_moment(procTime);
+
+        GDEBUG_STREAM("* ======================================================================================================= *");
+        GDEBUG_STREAM("---> GenericCartesianGrappaReconGadget, destructor(), Currnt processing time : " << procTime << " <---");
+        GDEBUG_STREAM("* ======================================================================================================= *");
+    }
+
+    int GenericCartesianGrappaReconGadget::process_config(ACE_Message_Block* mb)
+    {
+        // [Ro E1 Cha Slice E2 Con Phase Rep Set Seg Ave]
+        //   0  1  2   3    4   5    6     7  8   9   10
+
+        ISMRMRD::IsmrmrdHeader h;
+        try
+        {
+            deserialize(mb->rd_ptr(), h);
+        }
+        catch (...)
+        {
+            GDEBUG("Error parsing ISMRMRD Header");
+        }
+
+        if (!h.acquisitionSystemInformation)
+        {
+            GDEBUG("acquisitionSystemInformation not found in header. Bailing out");
+            return GADGET_FAIL;
+        }
+
+        // -------------------------------------------------
+
+        unsigned short num_acq_channels = h.acquisitionSystemInformation.get().receiverChannels.get();
+        GDEBUG_CONDITION_STREAM(verbose.value(), "Number of acquisition channels : " << num_acq_channels);
+
+        // -------------------------------------------------
+
+        if (!h.acquisitionSystemInformation->systemFieldStrength_T)
+        {
+            GDEBUG("acquisitionSystemInformation->systemFieldStrength_T not found in header. Bailing out");
+            return GADGET_FAIL;
+        }
+        float systemFieldStrength_T = h.acquisitionSystemInformation.get().systemFieldStrength_T.get();
+        GDEBUG_CONDITION_STREAM(verbose.value(), "System filed strength : " << systemFieldStrength_T);
+
+        // -------------------------------------------------
+
+        if (!h.measurementInformation)
+        {
+            GDEBUG("measurementInformation not found in header. Bailing out");
+            return GADGET_FAIL;
+        }
+
+        if (!h.measurementInformation->protocolName)
+        {
+            GDEBUG("measurementInformation->protocolName not found in header. Bailing out");
+            return GADGET_FAIL;
+        }
+
+        std::string protocolName = h.measurementInformation.get().protocolName.get();
+        GDEBUG_CONDITION_STREAM(verbose.value(), "Protocol name : " << protocolName);
+
+        // -------------------------------------------------
+
+        size_t NE = h.encoding.size();
+        num_encoding_spaces_ = NE;
+        GDEBUG_CONDITION_STREAM(verbose.value(), "Number of encoding spaces: " << NE);
+
+        meas_max_idx_.resize(NE);
+        acceFactorE1_.resize(NE, 1);
+        acceFactorE2_.resize(NE, 1);
+        calib_mode_.resize(NE, ISMRMRD_noacceleration);
+
+        recon_obj_.resize(NE);
+
+        size_t e;
+        for (e = 0; e < h.encoding.size(); e++)
+        {
+            ISMRMRD::EncodingSpace e_space = h.encoding[e].encodedSpace;
+            ISMRMRD::EncodingSpace r_space = h.encoding[e].reconSpace;
+            ISMRMRD::EncodingLimits e_limits = h.encoding[e].encodingLimits;
+
+            GDEBUG_CONDITION_STREAM(verbose.value(), "---> Encoding space : " << e << " <---");
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Encoding matrix size: " << e_space.matrixSize.x << " " << e_space.matrixSize.y << " " << e_space.matrixSize.z);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Encoding field_of_view : " << e_space.fieldOfView_mm.x << " " << e_space.fieldOfView_mm.y << " " << e_space.fieldOfView_mm.z);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Recon matrix size : " << r_space.matrixSize.x << " " << r_space.matrixSize.y << " " << r_space.matrixSize.z);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Recon field_of_view :  " << r_space.fieldOfView_mm.x << " " << r_space.fieldOfView_mm.y << " " << r_space.fieldOfView_mm.z);
+
+            if (e == 0)
+            {
+                gt_exporter_.setPixelSize(r_space.fieldOfView_mm.x / r_space.matrixSize.x,
+                    r_space.fieldOfView_mm.y / r_space.matrixSize.y,
+                    r_space.fieldOfView_mm.z / r_space.matrixSize.z);
+            }
+
+            meas_max_idx_[e].kspace_encode_step_1 = (uint16_t)e_space.matrixSize.y - 1;
+            meas_max_idx_[e].set = (e_limits.set && (e_limits.set->maximum > 0)) ? e_limits.set->maximum : 0;
+            meas_max_idx_[e].phase = (e_limits.phase && (e_limits.phase->maximum > 0)) ? e_limits.phase->maximum : 0;
+
+            meas_max_idx_[e].kspace_encode_step_2 = (uint16_t)e_space.matrixSize.z - 1;
+
+            meas_max_idx_[e].contrast = (e_limits.contrast && (e_limits.contrast->maximum > 0)) ? e_limits.contrast->maximum : 0;
+            meas_max_idx_[e].slice = (e_limits.slice && (e_limits.slice->maximum > 0)) ? e_limits.slice->maximum : 0;
+            meas_max_idx_[e].repetition = e_limits.repetition ? e_limits.repetition->maximum : 0;
+            meas_max_idx_[e].slice = (e_limits.slice && (e_limits.slice->maximum > 0)) ? e_limits.slice->maximum : 0;
+            meas_max_idx_[e].average = e_limits.average ? e_limits.average->maximum : 0;
+            meas_max_idx_[e].segment = 0;
+
+
+            if (!h.encoding[e].parallelImaging)
+            {
+                GDEBUG("Parallel Imaging section not found in header");
+                return GADGET_FAIL;
+            }
+
+            ISMRMRD::ParallelImaging p_imaging = *h.encoding[0].parallelImaging;
+
+            acceFactorE1_[e] = p_imaging.accelerationFactor.kspace_encoding_step_1;
+            acceFactorE2_[e] = p_imaging.accelerationFactor.kspace_encoding_step_2;
+            GDEBUG_CONDITION_STREAM(verbose.value(), "acceFactorE1 is " << acceFactorE1_[e]);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "acceFactorE2 is " << acceFactorE2_[e]);
+
+            std::string calib = *p_imaging.calibrationMode;
+
+            bool separate = (calib.compare("separate") == 0);
+            bool embedded = (calib.compare("embedded") == 0);
+            bool external = (calib.compare("external") == 0);
+            bool interleaved = (calib.compare("interleaved") == 0);
+            bool other = (calib.compare("other") == 0);
+
+            if (separate)
+            {
+                GDEBUG_CONDITION_STREAM(verbose.value(), "Colibration mode is separate");
+            }
+            else if (embedded)
+            {
+                GDEBUG_CONDITION_STREAM(verbose.value(), "Colibration mode is embedded");
+            }
+            else if (interleaved)
+            {
+                GDEBUG_CONDITION_STREAM(verbose.value(), "Colibration mode is interleaved");
+            }
+            else if (external)
+            {
+                GDEBUG_CONDITION_STREAM(verbose.value(), "Colibration mode is external");
+            }
+            else if (other)
+            {
+                GDEBUG_CONDITION_STREAM(verbose.value(), "Colibration mode is other");
+            }
+
+            calib_mode_[e] = Gadgetron::ISMRMRD_noacceleration;
+            if (acceFactorE1_[e] > 1 || acceFactorE2_[e] > 1)
+            {
+                if (interleaved)
+                {
+                    calib_mode_[e] = Gadgetron::ISMRMRD_interleaved;
+
+                    if (p_imaging.interleavingDimension)
+                    {
+                        if (p_imaging.interleavingDimension->compare("phase") == 0)
+                        {
+                            GDEBUG_CONDITION_STREAM(verbose.value(), "Interleaved dimension is phase");
+                        }
+                        else if (p_imaging.interleavingDimension->compare("repetition") == 0)
+                        {
+                            GDEBUG_CONDITION_STREAM(verbose.value(), "Interleaved dimension is repetition");
+                        }
+                        else if (p_imaging.interleavingDimension->compare("average") == 0)
+                        {
+                            GDEBUG_CONDITION_STREAM(verbose.value(), "Interleaved dimension is average");
+                        }
+                        else if (p_imaging.interleavingDimension->compare("contrast") == 0)
+                        {
+                            GDEBUG_CONDITION_STREAM(verbose.value(), "Interleaved dimension is contrast");
+                        }
+                        else if (p_imaging.interleavingDimension->compare("other") == 0)
+                        {
+                            GDEBUG_CONDITION_STREAM(verbose.value(), "Interleaved dimension is other1");
+                        }
+                        else
+                        {
+                            GDEBUG("Unknown interleaving dimension. Bailing out");
+                            return GADGET_FAIL;
+                        }
+                    }
+                }
+                else if (embedded)
+                {
+                    calib_mode_[e] = Gadgetron::ISMRMRD_embedded;
+                }
+                else if (separate)
+                {
+                    calib_mode_[e] = Gadgetron::ISMRMRD_separate;
+                }
+                else if (external)
+                {
+                    calib_mode_[e] = Gadgetron::ISMRMRD_external;
+                }
+                else if (other)
+                {
+                    calib_mode_[e] = Gadgetron::ISMRMRD_other;
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+        // generate the destination folder
+        if (!debug_folder.value().empty())
+        {
+            this->get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
+        }
+        else
+        {
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is not set ... ");
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+        return GADGET_OK;
+    }
+
+    int GenericCartesianGrappaReconGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1)
+    {
+        GDEBUG_CONDITION_STREAM(verbose.value(), "GenericCartesianGrappaReconGadget::process(...) starts ... ");
+
+        process_called_times_++;
+
+        IsmrmrdReconData* recon_bit_ = m1->getObjectPtr();
+
+        if (recon_bit_->rbit_.size() > num_encoding_spaces_)
+        {
+            GWARN_STREAM("Incoming recon_bit has more encoding spaces than the protocol : " << recon_bit_->rbit_.size() << " instead of " << num_encoding_spaces_);
+            GWARN_STREAM("Only first " << num_encoding_spaces_ << " encoding spaces will be processed ... ");
+        }
+
+        // for every encoding space
+        size_t e;
+        for (e = 0; e < recon_bit_->rbit_.size(); e++)
+        {
+            std::stringstream os;
+            os << "_encoding_" << e;
+
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Encoding space : " << e);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "======================================================================");
+
+            // ---------------------------------------------------------------
+            // export incoming data
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data" + os.str());
+            }
+
+            if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+            {
+                gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_traj" + os.str());
+            }
+
+            // ---------------------------------------------------------------
+            // compute the recon size with square pixel spacing and update recon_bit_
+            this->prepare_recon(recon_bit_->rbit_[e], recon_obj_[e], e);
+
+            // if needed, fill in the ref (in the noacceleration mode, the ref is often not filled)
+            if (calib_mode_[e] == Gadgetron::ISMRMRD_noacceleration 
+                && recon_bit_->rbit_[e].ref_.data_.get_number_of_elements()==0)
+            {
+                std::vector<size_t> dim;
+                recon_bit_->rbit_[e].data_.data_.get_dimensions(dim);
+                recon_bit_->rbit_[e].ref_.data_.create(dim, recon_bit_->rbit_[e].data_.data_.begin());
+
+                if (recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+                {
+                    recon_bit_->rbit_[e].data_.trajectory_.get_dimensions(dim);
+                    recon_bit_->rbit_[e].ref_.trajectory_.create(dim, recon_bit_->rbit_[e].data_.trajectory_.begin());
+                }
+
+                recon_bit_->rbit_[e].ref_.headers_ = recon_bit_->rbit_[e].data_.headers_;
+                recon_bit_->rbit_[e].ref_.sampling_ = recon_bit_->rbit_[e].data_.sampling_;
+            }
+
+            // ---------------------------------------------------------------
+            // if there are ref data, update the calibration
+            if (recon_bit_->rbit_[e].ref_.data_.get_number_of_elements() > 0)
+            {
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref" + os.str());
+                }
+
+                if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].ref_.trajectory_.get_number_of_elements() > 0)
+                {
+                    gt_exporter_.exportArray(recon_bit_->rbit_[e].ref_.trajectory_, debug_folder_full_path_ + "ref_traj" + os.str());
+                }
+
+                // ----------------------------------------------------------
+                // prep the ref data
+                // after this step, the recon_obj_[e].ref_calib_ and recon_obj_[e].ref_coil_map_ are set
+                if (perform_timing.value()) { gt_timer1_.start("prep_ref"); }
+                    this->prepare_ref(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+
+                // ----------------------------------------------------------
+                // export prepared ref for calibration and coil map
+                if (!debug_folder_full_path_.empty())
+                {
+                    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_calib_, debug_folder_full_path_ + "ref_calib" + os.str());
+                }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_coil_map_, debug_folder_full_path_ + "ref_coil_map" + os.str());
+                }
+
+                // ----------------------------------------------------------
+                // genearte destination channel
+                if (perform_timing.value()) { gt_timer1_.start("generate_downstream_dst_channel"); }
+                this->generate_downstream_dst_channel(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+
+                // ----------------------------------------------------------
+                // estimate coil map
+                if (perform_timing.value()) { gt_timer1_.start("estimate_coil_map"); }
+                this->perform_coil_map_estimation(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+
+                // ----------------------------------------------------------
+                // calibration
+                if (perform_timing.value()) { gt_timer1_.start("calibration"); }
+                this->perform_calib(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+
+                // clean the recon ref memory
+                recon_bit_->rbit_[e].ref_.data_.clear();
+                recon_bit_->rbit_[e].ref_.trajectory_.clear();
+            }
+
+            // ---------------------------------------------------------------
+            // perform unwrapping
+            if (recon_bit_->rbit_[e].data_.data_.get_number_of_elements() > 0)
+            {
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data_before_unwrapping" + os.str());
+                }
+
+                if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+                {
+                    gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_before_unwrapping_traj" + os.str());
+                }
+
+                if (perform_timing.value()) { gt_timer1_.start("unwrapping"); }
+                this->perform_unwrapping(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+
+                // ---------------------------------------------------------------
+                // compute image headers
+                if (perform_timing.value()) { gt_timer1_.start("compute_image_header"); }
+                this->compute_image_header(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+
+                if (perform_timing.value()) { gt_timer1_.start("send_out_image_array"); }
+                this->send_out_image_array(recon_bit_->rbit_[e], recon_obj_[e].recon_res_, e, image_series.value() + ((int)e + 1), GADGETRON_IMAGE_REGULAR);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+
+                // ---------------------------------------------------------------
+                // send out gfactor
+                if (send_out_gfactor.value() && recon_obj_[e].gfactor_.get_number_of_elements()>0)
+                {
+                    if (perform_timing.value()) { gt_timer1_.start("send out gfactor array"); }
+
+                    IsmrmrdImageArray res;
+                    Gadgetron::real_to_complex(recon_obj_[e].gfactor_, res.data_);
+                    res.headers_ = recon_obj_[e].recon_res_.headers_;
+                    res.meta_ = recon_obj_[e].recon_res_.meta_;
+
+                    this->send_out_image_array(recon_bit_->rbit_[e], res, e, image_series.value() + 10 * ((int)e + 1), GADGETRON_IMAGE_GFACTOR);
+
+                    if (perform_timing.value()) { gt_timer1_.stop(); }
+                }
+            }
+
+            recon_obj_[e].recon_res_.data_.clear();
+            recon_obj_[e].gfactor_.clear();
+        }
+
+        GDEBUG_CONDITION_STREAM(verbose.value(), "GenericCartesianGrappaReconGadget::process(...) ends ... ");
+
+        m1->release();
+        return GADGET_OK;
+    }
+
+    size_t GenericCartesianGrappaReconGadget::compute_image_number(ISMRMRD::ImageHeader& imheader, size_t encoding, size_t CHA, size_t cha, size_t E2)
+    {
+
+        if (encoding >= meas_max_idx_.size())
+        {
+            GWARN_STREAM("encoding >= meas_max_idx_.size()");
+            encoding = 0;
+        }
+
+        size_t SET = meas_max_idx_[encoding].set + 1;
+        size_t REP = meas_max_idx_[encoding].repetition + 1;
+        size_t PHS = meas_max_idx_[encoding].phase + 1;
+        size_t SLC = meas_max_idx_[encoding].slice + 1;
+        size_t CON = meas_max_idx_[encoding].contrast + 1;
+        if (E2 == 0) E2 = 1;
+
+        size_t imageNum = imheader.average*REP*SET*PHS*CON*SLC*E2*CHA + imheader.repetition*SET*PHS*CON*SLC*E2*CHA 
+            + imheader.set*PHS*CON*SLC*E2*CHA + imheader.phase*CON*SLC*E2*CHA + imheader.contrast*SLC*E2*CHA + imheader.slice*E2*CHA + cha + 1;
+
+        return imageNum;
+    }
+
+    int GenericCartesianGrappaReconGadget::send_out_image_array(IsmrmrdReconBit& recon_bit, IsmrmrdImageArray& res, size_t encoding, int series_num, const std::string& data_role)
+    {
+        try
+        {
+            size_t RO = res.data_.get_size(0);
+            size_t E1 = res.data_.get_size(1);
+            size_t E2 = res.data_.get_size(2);
+            size_t CHA = res.data_.get_size(3);
+            size_t N = res.data_.get_size(4);
+            size_t S = res.data_.get_size(5);
+            size_t SLC = res.data_.get_size(6);
+
+            GDEBUG_CONDITION_STREAM(true, "sending out image array, acquisition boundary [RO E1 E2 CHA N S SLC] = [" << RO << " " << E1 << " " << E2 << " " << CHA << " " << N << " " << S << " " << SLC << "] ");
+
+            // compute image numbers and fill the image meta
+            size_t n, s, slc;
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        ISMRMRD::ImageHeader header = res.headers_(n, s, slc);
+
+                        if (header.measurement_uid == 0)
+                        {
+                            continue;
+                        }
+
+                        res.headers_(n, s, slc).image_index = (uint16_t)this->compute_image_number(res.headers_(n, s, slc), encoding, CHA, 0, E2);
+                        res.headers_(n, s, slc).image_series_index = series_num;
+                        GDEBUG_CONDITION_STREAM(verbose.value(), "image number " << res.headers_(n, s, slc).image_index << "    image series " << res.headers_(n, s, slc).image_series_index << " ... ");
+
+                        // set the image attributes
+                        size_t offset = n + s*N + slc*N*S;
+
+                        res.meta_[offset].set(GADGETRON_IMAGENUMBER, (long)res.headers_(n, s, slc).image_index);
+                        res.meta_[offset].set(GADGETRON_IMAGEPROCESSINGHISTORY, "GT");
+
+                        if (data_role == GADGETRON_IMAGE_REGULAR)
+                        {
+                            res.headers_(n, s, slc).image_type = ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE;
+
+                            res.meta_[offset].append(GADGETRON_IMAGECOMMENT, "GT");
+
+                            res.meta_[offset].append(GADGETRON_SEQUENCEDESCRIPTION, "_GT");
+                            res.meta_[offset].set(GADGETRON_DATA_ROLE, GADGETRON_IMAGE_REGULAR);
+                        }
+                        else if (data_role == GADGETRON_IMAGE_GFACTOR)
+                        {
+                            res.headers_(n, s, slc).image_type = ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE;
+
+                            res.meta_[offset].append(GADGETRON_IMAGECOMMENT, GADGETRON_IMAGE_GFACTOR);
+                            res.meta_[offset].append(GADGETRON_SEQUENCEDESCRIPTION, GADGETRON_IMAGE_GFACTOR);
+                            res.meta_[offset].set(GADGETRON_DATA_ROLE, GADGETRON_IMAGE_GFACTOR);
+                        }
+                        else if (data_role == GADGETRON_IMAGE_SNR_MAP)
+                        {
+                            res.headers_(n, s, slc).image_type = ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE;
+
+                            res.meta_[offset].append(GADGETRON_IMAGECOMMENT, GADGETRON_IMAGE_SNR_MAP);
+                            res.meta_[offset].append(GADGETRON_SEQUENCEDESCRIPTION, GADGETRON_IMAGE_SNR_MAP);
+                            res.meta_[offset].set(GADGETRON_DATA_ROLE, GADGETRON_IMAGE_SNR_MAP);
+                        }
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            for (size_t cha = 0; cha < CHA; cha++)
+                            {
+                                std::ostringstream ostr;
+                                ostr << data_role << "_" << res.headers_(n, s, slc).image_index << "_cha_" << cha << "_encoding_" << encoding;
+
+                                hoNDArray< std::complex<float> > im;
+
+                                std::complex<float>* pData = &(res.data_(0, 0, 0, cha, n, s, slc));
+                                im.create(RO, E1, E2, pData);
+                                gt_exporter_.exportArrayComplex(im, debug_folder_full_path_ + ostr.str());
+                            }
+                        }
+
+                        if (verbose.value())
+                        {
+                            for (size_t cha = 0; cha < CHA; cha++)
+                            {
+                                GDEBUG_STREAM("sending out " << data_role << " image [CHA SLC CON PHS REP SET AVE] = ["
+                                    << cha << " "
+                                    << res.headers_(n, s, slc).slice << " "
+                                    << res.headers_(n, s, slc).contrast << " "
+                                    << res.headers_(n, s, slc).phase << " "
+                                    << res.headers_(n, s, slc).repetition << " "
+                                    << res.headers_(n, s, slc).set << " "
+                                    << res.headers_(n, s, slc).average << " " << "] "
+                                    << " -- Image number -- " << res.headers_(n, s, slc).image_index);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // send out the images
+            Gadgetron::GadgetContainerMessage<IsmrmrdImageArray>* cm1 = new Gadgetron::GadgetContainerMessage<IsmrmrdImageArray>();
+            *(cm1->getObjectPtr()) = res;
+
+            if (this->next()->putq(cm1) < 0)
+            {
+                GERROR_STREAM("Put image array to Q failed ... ");
+                return GADGET_FAIL;
+            }
+        }
+        catch (...)
+        {
+            GERROR_STREAM("Errors in GenericCartesianGrappaReconGadget::send_out_image_array(...) ... ");
+            return GADGET_FAIL;
+        }
+
+        return GADGET_OK;
+    }
+
+    int GenericCartesianGrappaReconGadget::close(unsigned long flags)
+    {
+        GDEBUG_CONDITION_STREAM(true, "GenericCartesianGrappaReconGadget - close(flags) : " << flags);
+
+        if (BaseClass::close(flags) != GADGET_OK) return GADGET_FAIL;
+
+        if (flags != 0)
+        {
+            std::string procTime;
+            this->get_current_moment(procTime);
+
+            GDEBUG_STREAM("* ======================================================================================================= *");
+            GDEBUG_STREAM("---> GenericCartesianGrappaReconGadget, close(flags), Currnt processing time : " << procTime << " <---");
+            GDEBUG_STREAM("* ======================================================================================================= *");
+        }
+
+        return GADGET_OK;
+    }
+
+    void GenericCartesianGrappaReconGadget::get_current_moment(std::string& procTime)
+    {
+        char timestamp[100];
+        time_t mytime;
+        struct tm *mytm;
+        mytime = time(NULL);
+        mytm = localtime(&mytime);
+        strftime(timestamp, sizeof(timestamp), "%a, %b %d %Y, %H:%M:%S", mytm);
+        procTime = timestamp;
+    }
+
+    // ----------------------------------------------------------------------------------------
+
+    void GenericCartesianGrappaReconGadget::prepare_recon(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding)
+    {
+        try
+        {
+            size_t RO = recon_bit.data_.data_.get_size(0);
+            size_t E1 = recon_bit.data_.data_.get_size(1);
+            size_t E2 = recon_bit.data_.data_.get_size(2);
+
+            size_t N = recon_bit.data_.data_.get_size(4);
+            size_t S = recon_bit.data_.data_.get_size(5);
+            size_t SLC = recon_bit.data_.data_.get_size(6);
+
+            // compensate for sampling limits under acceleration
+            if (E1-1 - recon_bit.data_.sampling_.sampling_limits_[1].max_ < acceFactorE1_[encoding])
+            {
+                recon_bit.data_.sampling_.sampling_limits_[1].max_ = (uint16_t)E1 - 1;
+            }
+
+            if ( (E2>1) && (E2-1 - recon_bit.data_.sampling_.sampling_limits_[2].max_ < acceFactorE2_[encoding]))
+            {
+                recon_bit.data_.sampling_.sampling_limits_[2].max_ = (uint16_t)E2 - 1;
+            }
+
+            float spacingE1 = recon_bit.data_.sampling_.recon_FOV_[1] / recon_bit.data_.sampling_.recon_matrix_[1];
+            size_t encodingE1 = (size_t)std::floor(recon_bit.data_.sampling_.encoded_FOV_[1] / spacingE1 + 0.5);
+
+            if (encodingE1 > E1)
+            {
+                GDEBUG_STREAM("recon_squared_pixel is true; change encoding E1 to be " << encodingE1);
+
+                // pad the data
+                hoNDArray< std::complex<float> > dataPadded;
+                Gadgetron::pad(RO, encodingE1, &recon_bit.data_.data_, &dataPadded);
+                recon_bit.data_.data_ = dataPadded;
+
+                // update the sampling_limits
+                uint16_t offsetE1 = (uint16_t)(encodingE1 / 2 - E1 / 2);
+
+                recon_bit.data_.sampling_.sampling_limits_[1].min_ += offsetE1;
+                recon_bit.data_.sampling_.sampling_limits_[1].max_ += offsetE1;
+
+                // update image headers
+                size_t headerE1 = recon_bit.data_.headers_.get_size(0);
+                size_t headerE2 = recon_bit.data_.headers_.get_size(1);
+
+                size_t n, s, slc, e1, e2;
+
+                for (slc = 0; slc < SLC; slc++)
+                {
+                    for (s = 0; s < S; s++)
+                    {
+                        for (n = 0; n < N; n++)
+                        {
+                            for (e2 = 0; e2 < headerE2; e2++)
+                            {
+                                for (e1 = 0; e1 < headerE1; e1++)
+                                {
+                                    if (recon_bit.data_.headers_(e1, e2, n, s, slc).measurement_uid != 0)
+                                    {
+                                        recon_bit.data_.headers_(e1, e2, n, s, slc).idx.kspace_encode_step_1 += offsetE1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // if calib_mode is embedded, pad the ref
+                if (calib_mode_[encoding] == Gadgetron::ISMRMRD_embedded)
+                {
+                    if (recon_bit.ref_.data_.get_size(0) == RO && recon_bit.ref_.data_.get_size(1) == E1)
+                    {
+                        Gadgetron::pad(RO, encodingE1, &recon_bit.ref_.data_, &dataPadded);
+                        recon_bit.ref_.data_ = dataPadded;
+
+                        recon_bit.ref_.sampling_.sampling_limits_[1].min_ += offsetE1;
+                        recon_bit.ref_.sampling_.sampling_limits_[1].max_ += offsetE1;
+                    }
+                }
+            }
+            else
+            {
+                GDEBUG_STREAM("recon_squared_pixel is true; but it is not required to change encoding E1 ... ");
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::prepare_recon(...) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::prepare_ref(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding)
+    {
+        try
+        {
+            hoNDArray< std::complex<float> >& ref = recon_bit.ref_.data_;
+            hoNDArray< std::complex<float> >& ref_calib = recon_obj.ref_calib_;
+            hoNDArray< std::complex<float> >& ref_coil_map = recon_obj.ref_coil_map_;
+
+            // sampling limits
+            SamplingLimit sampling_limits[3];
+            sampling_limits[0] = recon_bit.ref_.sampling_.sampling_limits_[0];
+            sampling_limits[1] = recon_bit.ref_.sampling_.sampling_limits_[1];
+            sampling_limits[2] = recon_bit.ref_.sampling_.sampling_limits_[2];
+
+            // recon size
+            size_t recon_RO = recon_bit.data_.data_.get_size(0);
+            size_t recon_E1 = recon_bit.data_.data_.get_size(1);
+            size_t recon_E2 = recon_bit.data_.data_.get_size(2);
+
+            // filter ref coil map
+            bool filter_ref_coil_map = true;
+
+            // ref array size
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
+
+            // -------------------------------------------------------------------------------
+
+            if (calib_mode_[encoding] == ISMRMRD_noacceleration)
+            {
+                GADGET_THROW("To be implemented ... ");
+            }
+
+            // -------------------------------------------------------------------------------
+
+            else if (calib_mode_[encoding] == ISMRMRD_interleaved)
+            {
+                GADGET_THROW("To be implemented ... ");
+            }
+
+            // -------------------------------------------------------------------------------
+
+            else if (calib_mode_[encoding] == ISMRMRD_embedded)
+            {
+                GADGET_THROW("To be implemented ... ");
+            }
+
+            // -------------------------------------------------------------------------------
+
+            else if (calib_mode_[encoding] == ISMRMRD_separate || calib_mode_[encoding] == ISMRMRD_external || calib_mode_[encoding] == ISMRMRD_other)
+            {
+                if (average_all_ref_N.value())
+                {
+                    if (N > 1)
+                    {
+                        Gadgetron::sum_over_dimension(ref, ref_calib, (size_t)4);
+                        Gadgetron::scal((float)(1.0 / N), ref_calib);
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_after_averaging_N");
+                        }
+                    }
+                    else
+                    {
+                        ref_calib = ref;
+                    }
+                }
+                else
+                {
+                    ref_calib = ref;
+                }
+
+                if (average_all_ref_S.value())
+                {
+                    if (S > 1)
+                    {
+                        hoNDArray< std::complex<float> > ref_recon_buf;
+                        Gadgetron::sum_over_dimension(ref_calib, ref_recon_buf, 5);
+                        Gadgetron::scal((float)(1.0 / S), ref_recon_buf);
+                        ref_calib = ref_recon_buf;
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_after_averaging_S");
+                        }
+                    }
+                }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_after_averaging_separate");
+                }
+
+                hoNDArray< std::complex<float> > ref_recon_buf;
+
+                // detect sampled region in ref
+                size_t start_E1(0), end_E1(0);
+                Gadgetron::detect_sampled_region_E1(ref, start_E1, end_E1);
+
+                size_t start_E2(0), end_E2(0);
+                if (E2 > 1)
+                {
+                    Gadgetron::detect_sampled_region_E2(ref, start_E2, end_E2);
+                }
+
+                // crop the ref_calib_, along E1 and E2
+                vector_td<size_t, 3> crop_offset;
+                crop_offset[0] = sampling_limits[0].min_;
+                crop_offset[1] = start_E1;
+                crop_offset[2] = start_E2;
+
+                vector_td<size_t, 3> crop_size;
+                crop_size[0] = sampling_limits[0].max_ - sampling_limits[0].min_ + 1;
+                crop_size[1] = end_E1 - start_E1 + 1;
+                crop_size[2] = end_E2 - start_E2 + 1;
+
+                Gadgetron::crop(crop_offset, crop_size, &ref_calib, &ref_recon_buf);
+                ref_calib = ref_recon_buf;
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_after_crop_separate");
+                }
+
+                // create filter if needed
+                if (filter_ref_coil_map)
+                {
+                    if (filter_RO_ref_coi_map_.get_size(0) != RO
+                        || filter_E1_ref_coi_map_.get_size(0) != ref_calib.get_size(1)
+                        || ((E2 > 1) && (filter_E2_ref_coi_map_.get_size(0) != ref_calib.get_size(2))))
+                    {
+                        SamplingLimit sE1;
+                        sE1.min_ = 0;
+                        sE1.max_ = (uint16_t)ref_calib.get_size(1) - 1;
+
+                        SamplingLimit sE2;
+                        sE2.min_ = 0;
+                        sE2.max_ = (uint16_t)ref_calib.get_size(2) - 1;
+
+                        Gadgetron::generate_ref_filter_for_coil_map(ref_calib, sampling_limits[0], sE1, sE2, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
+                    }
+
+                    if (!debug_folder_full_path_.empty())
+                    {
+                        gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_full_path_ + "filter_RO_ref_coi_map_separate");
+                        gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_full_path_ + "filter_E1_ref_coi_map_separate");
+                        if (E2 > 1) { gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_full_path_ + "filter_E2_ref_coi_map_separate"); }
+                    }
+                }
+
+                // filter the ref_coil_map_
+                ref_coil_map = ref_calib;
+
+                if (filter_ref_coil_map)
+                {
+                    if (E2 > 1)
+                    {
+                        Gadgetron::apply_kspace_filter_ROE1E2(ref_coil_map, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_, ref_recon_buf);
+                    }
+                    else
+                    {
+                        Gadgetron::apply_kspace_filter_ROE1(ref_coil_map, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_recon_buf);
+                    }
+
+                    ref_coil_map = ref_recon_buf;
+                }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_separate");
+                }
+
+                // pad the ref_coil_map into the data array
+                Gadgetron::pad(recon_RO, recon_E1, recon_E2, &ref_coil_map, &ref_recon_buf);
+                ref_coil_map = ref_recon_buf;
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_padded_separate");
+                }
+            }
+            else
+            {
+                GADGET_THROW("Unrecognized calibration mode ... ");
+            }
+
+            // -------------------------------------------------------------------------------
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(recon_obj.ref_calib_, debug_folder_full_path_ + "ref_calib_after_all_prep");
+            }
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(recon_obj.ref_coil_map_, debug_folder_full_path_ + "ref_coil_map_after_all_prep");
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::prepare_ref(...) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::generate_downstream_dst_channel(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding)
+    {
+        try
+        {
+            std::vector<size_t> dim;
+
+            recon_obj.ref_calib_.get_dimensions(dim);
+            recon_obj.ref_calib_dst_.create(dim, recon_obj.ref_calib_.begin());
+
+            recon_bit.data_.data_.get_dimensions(dim);
+            recon_obj.data_dst_.create(dim, recon_bit.data_.data_.begin());
+
+            recon_obj.ref_coil_map_.get_dimensions(dim);
+            recon_obj.ref_coil_map_dst_.create(dim, recon_obj.ref_coil_map_.begin());
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::generate_downstream_dst_channel(...) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::compute_coil_map(const hoNDArray< std::complex<float> >& complexIm, hoNDArray< std::complex<float> >& coilMap)
+    {
+        try
+        {
+            typedef  std::complex<float> T;
+
+            size_t RO = complexIm.get_size(0);
+            size_t E1 = complexIm.get_size(1);
+            size_t E2 = complexIm.get_size(2);
+            size_t CHA = complexIm.get_size(3);
+
+            if (!complexIm.dimensions_equal(&coilMap))
+            {
+                coilMap = complexIm;
+            }
+
+            if (CHA <= 1)
+            {
+                GWARN_STREAM("coilMapMakerInati<T>::make_coil_map, CHA <= 1");
+                return;
+            }
+
+            size_t ks = 7;
+            size_t power = 3;
+            size_t num = complexIm.get_number_of_elements() / (RO*E1*E2*CHA);
+
+            long long n;
+
+            if (E2 > 1)
+            {
+                for (n = 0; n < (long long)num; n++)
+                {
+
+                    hoNDArray<T> im(RO, E1, E2, CHA, const_cast<T*>(complexIm.begin() + n*RO*E1*E2*CHA));
+                    hoNDArray<T> cmap(RO, E1, E2, CHA, coilMap.begin() + n*RO*E1*E2*CHA);
+
+                    Gadgetron::coil_map_3d_Inati(im, cmap, ks, power);
+                }
+            }
+            else
+            {
+#pragma omp parallel for default(none) private(n) shared(num, RO, E1, CHA, complexIm, coilMap, ks, power) if(num>8)
+                for (n = 0; n < (long long)num; n++)
+                {
+                    hoNDArray<T> im(RO, E1, CHA, const_cast<T*>(complexIm.begin()) + n*RO*E1*CHA);
+                    hoNDArray<T> cmap(RO, E1, CHA, coilMap.begin() + n*RO*E1*CHA);
+
+                    Gadgetron::coil_map_2d_Inati(im, cmap, ks, power);
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::compute_coil_map(...) ... ")
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::perform_coil_map_estimation(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t e)
+    {
+        try
+        {
+            // compute coil map from recon_obj.ref_coil_map_dst_
+
+            std::stringstream os;
+            os << "encoding_" << e;
+            std::string suffix = os.str();
+
+            // estimate coil map from full_kspace
+            size_t RO = recon_obj.ref_coil_map_dst_.get_size(0);
+            size_t E1 = recon_obj.ref_coil_map_dst_.get_size(1);
+            size_t E2 = recon_obj.ref_coil_map_dst_.get_size(2);
+            size_t dstCHA = recon_obj.ref_coil_map_dst_.get_size(3);
+            size_t N = recon_obj.ref_coil_map_dst_.get_size(4);
+            size_t S = recon_obj.ref_coil_map_dst_.get_size(5);
+            size_t SLC = recon_obj.ref_coil_map_dst_.get_size(6);
+
+            recon_obj.coil_map_.create(RO, E1, E2, dstCHA, N, S, SLC);
+            Gadgetron::clear(recon_obj.coil_map_);
+
+            // convert full_kspace to image domain
+            if (E2 > 1)
+            {
+                Gadgetron::hoNDFFT<float>::instance()->ifft3c(recon_obj.ref_coil_map_dst_, complex_im_recon_buf_);
+            }
+            else
+            {
+                Gadgetron::hoNDFFT<float>::instance()->ifft2c(recon_obj.ref_coil_map_dst_, complex_im_recon_buf_);
+            }
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "ref_coil_map_dst_complex_image_for_coil_map_estimation_" + suffix);
+            }
+
+            this->compute_coil_map(complex_im_recon_buf_, recon_obj.coil_map_);
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(recon_obj.coil_map_, debug_folder_full_path_ + "recon_obj_coil_map_" + suffix);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_coil_map_estimation(...) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::perform_calib(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t e)
+    {
+        try
+        {
+            typedef  std::complex<float> T;
+
+            // estimate grappa kernel between ref_preparer_[e]->ref_calib_ and recon_obj.ref_calib_dst_
+
+            if (acceFactorE1_[e] <= 1 && acceFactorE2_[e] <= 1)
+            {
+                return;
+            }
+
+            size_t RO = recon_bit.data_.data_.get_size(0);
+            size_t E1 = recon_bit.data_.data_.get_size(1);
+            size_t E2 = recon_bit.data_.data_.get_size(2);
+
+            hoNDArray<T>& src = recon_obj.ref_calib_;
+            hoNDArray<T>& dst = recon_obj.ref_calib_dst_;
+
+            size_t ref_RO = src.get_size(0);
+            size_t ref_E1 = src.get_size(1);
+            size_t ref_E2 = src.get_size(2);
+            size_t srcCHA = src.get_size(3);
+            size_t ref_N = src.get_size(4);
+            size_t ref_S = src.get_size(5);
+            size_t ref_SLC = src.get_size(6);
+
+            size_t dstCHA = dst.get_size(3);
+
+            // allocate buffer for kernels
+            size_t kRO = grappa_kSize_RO.value();
+            size_t kNE1 = grappa_kSize_E1.value();
+            size_t kNE2 = grappa_kSize_E2.value();
+
+            size_t convKRO, convKE1, convKE2;
+
+            if (E2 > 1)
+            {
+                std::vector<int> kE1, oE1;
+                std::vector<int> kE2, oE2;
+                bool fitItself = true;
+
+                grappa3d_kerPattern(kE1, oE1, kE2, oE2, convKRO, convKE1, convKE2, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], kRO, kNE1, kNE2, fitItself);
+
+                recon_obj.kernel_.create(convKRO, convKE1, convKE2, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+                recon_obj.unmixing_coeff_.create(RO, E1, E2, srcCHA, ref_N, ref_S, ref_SLC);
+                recon_obj.gfactor_.create(RO, E1, E2, 1, ref_N, ref_S, ref_SLC);
+            }
+            else
+            {
+                std::vector<int> kE1, oE1;
+                bool fitItself = true;
+
+                Gadgetron::grappa2d_kerPattern(kE1, oE1, convKRO, convKE1, (size_t)acceFactorE1_[e], kRO, kNE1, fitItself);
+
+                recon_obj.kernel_.create(convKRO, convKE1, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+                recon_obj.kernelIm_.create(RO, E1, 1, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+                recon_obj.unmixing_coeff_.create(RO, E1, 1, srcCHA, ref_N, ref_S, ref_SLC);
+                recon_obj.gfactor_.create(RO, E1, 1, 1, ref_N, ref_S, ref_SLC);
+            }
+
+            Gadgetron::clear(recon_obj.kernel_);
+            Gadgetron::clear(recon_obj.kernelIm_);
+            Gadgetron::clear(recon_obj.unmixing_coeff_);
+            Gadgetron::clear(recon_obj.gfactor_);
+
+            // estimate kernel
+
+            long long num = ref_N*ref_S*ref_SLC;
+
+            long long ii;
+
+#pragma omp parallel for default(none) private(ii) shared(src, dst, recon_obj, e, num, ref_N, ref_S, ref_RO, ref_E1, ref_E2, RO, E1, E2, dstCHA, srcCHA)
+            for (ii = 0; ii < num; ii++)
+            {
+                size_t slc = ii / (ref_N*ref_S);
+                size_t s = (ii - slc*ref_N*ref_S) / (ref_N);
+                size_t n = ii - slc*ref_N*ref_S - s*ref_N;
+
+                T* pSrc = &(src(0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> ref_src(ref_RO, ref_E1, ref_E2, srcCHA, pSrc);
+
+                T* pDst = &(dst(0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> ref_dst(ref_RO, ref_E1, ref_E2, dstCHA, pDst);
+
+                this->perform_calib_impl(n, s, slc, e, ref_src, ref_dst, recon_obj);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_calib(...) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::perform_calib_impl(size_t n, size_t s, size_t slc, size_t e, const hoNDArray< std::complex<float> >& src, const hoNDArray< std::complex<float> >& dst, ReconObjType& recon_obj)
+    {
+        try
+        {
+            typedef std::complex<float> T;
+
+            size_t RO = recon_obj.data_dst_.get_size(0);
+            size_t E1 = recon_obj.data_dst_.get_size(1);
+            size_t E2 = recon_obj.data_dst_.get_size(2);
+
+            size_t ref_RO = src.get_size(0);
+            size_t ref_E1 = src.get_size(1);
+            size_t ref_E2 = src.get_size(2);
+            size_t srcCHA = src.get_size(3);
+
+            size_t dstCHA = dst.get_size(3);
+
+            // allocate buffer for kernels
+            size_t kRO = grappa_kSize_RO.value();
+            size_t kNE1 = grappa_kSize_E1.value();
+            size_t kNE2 = grappa_kSize_E2.value();
+
+            size_t convKRO = recon_obj.kernel_.get_size(0);
+            size_t convKNE1 = recon_obj.kernel_.get_size(1);
+
+            Gadgetron::GadgetronTimer gt_timer_local;
+            gt_timer_local.set_timing_in_destruction(false);
+
+            bool performTiming = perform_timing.value();
+
+            std::stringstream os;
+            os << "n" << n << "_s" << s << "_slc" << slc << "_encoding_" << e;
+            std::string suffix = os.str();
+
+            if (E2 > 1)
+            {
+                size_t convKNE2 = recon_obj.kernel_.get_size(2);
+
+                hoNDArray<T> acsSrc(ref_RO, ref_E1, ref_E2, srcCHA, const_cast<T*>(src.begin()));
+                hoNDArray<T> acsDst(ref_RO, ref_E1, ref_E2, dstCHA, const_cast<T*>(dst.begin()));
+
+                T* pKernel = &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> ker(convKRO, convKNE1, convKNE2, srcCHA, dstCHA, pKernel);
+
+                T* pCoilMap = &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> coilMap(RO, E1, E2, dstCHA, pCoilMap);
+
+                T* pUnmixing = &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> unmixC(RO, E1, E2, srcCHA, pUnmixing);
+
+                float* pGFactor = &(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc));
+                hoNDArray<float> gFactor(RO, E1, E2, 1, pGFactor);
+
+                if (performTiming) { gt_timer_local.start("grappa3d_calib_convolution_kernel"); }
+                Gadgetron::grappa3d_calib_convolution_kernel(acsSrc, acsDst, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], grappa_reg_lamda.value(), grappa_calib_over_determine_ratio.value(), kRO, kNE1, kNE2, ker);
+                if (performTiming) { gt_timer_local.stop(); }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(ker, debug_folder_full_path_ + "convKer3D_" + suffix);
+                }
+
+                if (performTiming) { gt_timer_local.start("grappa3d_unmixing_coeff"); }
+                Gadgetron::grappa3d_unmixing_coeff(ker, coilMap, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], unmixC, gFactor);
+                if (performTiming) { gt_timer_local.stop(); }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_3D_" + suffix);
+                }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_3D_" + suffix);
+                }
+            }
+            else
+            {
+                // ------------------------------------------------------
+                // calibrate the combined imgae channels
+                // ------------------------------------------------------
+
+                hoNDArray<T> acsSrc(ref_RO, ref_E1, srcCHA, const_cast<T*>(src.begin()));
+                hoNDArray<T> acsDst(ref_RO, ref_E1, dstCHA, const_cast<T*>(dst.begin()));
+
+                T* pKernel = &(recon_obj.kernel_(0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> convKer(convKRO, convKNE1, srcCHA, dstCHA, pKernel);
+
+                T* pkIm = &(recon_obj.kernelIm_(0, 0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> kIm(RO, E1, srcCHA, dstCHA, pkIm);
+
+                T* pCoilMap = &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc)); // this handles uncombined channels
+                hoNDArray<T> coilMap(RO, E1, dstCHA, pCoilMap);
+
+                T* pUnmixing = &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc));
+                hoNDArray<T> unmixC(RO, E1, srcCHA, pUnmixing);
+
+                float* pGFactor = &(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc));
+                hoNDArray<float> gFactor;
+
+                if (performTiming) { gt_timer_local.start("grappa2d_calib_convolution_kernel ... "); }
+                Gadgetron::grappa2d_calib_convolution_kernel(acsSrc, acsDst, (size_t)acceFactorE1_[e], grappa_reg_lamda.value(), kRO, kNE1, convKer);
+                if (performTiming) { gt_timer_local.stop(); }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(convKer, debug_folder_full_path_ + "convKer_" + suffix);
+                }
+
+                if (performTiming) { gt_timer_local.start("grappa2d_image_domain_kernel ... "); }
+                Gadgetron::grappa2d_image_domain_kernel(convKer, RO, E1, kIm);
+                if (performTiming) { gt_timer_local.stop(); }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(kIm, debug_folder_full_path_ + "kIm_" + suffix);
+                }
+
+                if (performTiming) { gt_timer_local.start("grappa2d_unmixing_coeff ... "); }
+                Gadgetron::grappa2d_unmixing_coeff(kIm, coilMap, (size_t)acceFactorE1_[e], unmixC, gFactor);
+                if (performTiming) { gt_timer_local.stop(); }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_" + suffix);
+                }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_" + suffix);
+                }
+
+                memcpy(pGFactor, gFactor.begin(), gFactor.get_number_of_bytes());
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_calib_impl(n, s, slc) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::perform_unwrapping(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t e)
+    {
+        try
+        {
+            typedef std::complex<float> T;
+
+            size_t RO = recon_obj.data_dst_.get_size(0);
+            size_t E1 = recon_obj.data_dst_.get_size(1);
+            size_t E2 = recon_obj.data_dst_.get_size(2);
+            size_t dstCHA = recon_obj.data_dst_.get_size(3);
+            size_t N = recon_obj.data_dst_.get_size(4);
+            size_t S = recon_obj.data_dst_.get_size(5);
+            size_t SLC = recon_obj.data_dst_.get_size(6);
+
+            hoNDArray<T>& src = recon_obj.ref_calib_;
+            hoNDArray<T>& dst = recon_obj.ref_calib_dst_;
+
+            size_t ref_RO = src.get_size(0);
+            size_t ref_E1 = src.get_size(1);
+            size_t ref_E2 = src.get_size(2);
+            size_t srcCHA = src.get_size(3);
+            size_t ref_N = src.get_size(4);
+            size_t ref_S = src.get_size(5);
+            size_t ref_SLC = src.get_size(6);
+
+            size_t convkRO = recon_obj.kernel_.get_size(0);
+            size_t convkE1 = recon_obj.kernel_.get_size(1);
+            size_t convkE2 = recon_obj.kernel_.get_size(2);
+
+            recon_obj.recon_res_.data_.create(RO, E1, E2, 1, N, S, SLC);
+
+            // compute aliased images
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+                std::string suffix = os.str();
+                gt_exporter_.exportArrayComplex(recon_bit.data_.data_, debug_folder_full_path_ + "data_src_" + suffix);
+            }
+
+            if (perform_timing.value()) { gt_timer1_.start("perform_unwrapping, compute aliased images ... "); }
+
+            data_recon_buf_.create(RO, E1, E2, dstCHA, N, S, SLC);
+
+            if (E2>1)
+            {
+                Gadgetron::hoNDFFT<float>::instance()->ifft3c(recon_bit.data_.data_, complex_im_recon_buf_, data_recon_buf_);
+            }
+            else
+            {
+                Gadgetron::hoNDFFT<float>::instance()->ifft2c(recon_bit.data_.data_, complex_im_recon_buf_, data_recon_buf_);
+            }
+
+            if (perform_timing.value()) { gt_timer1_.stop(); }
+
+            // SNR unit scaling
+            float effectiveAcceFactor = acceFactorE1_[e] * acceFactorE2_[e];
+            if (effectiveAcceFactor > 1)
+            {
+                float fftCompensationRatio = (float)(1.0 / std::sqrt(effectiveAcceFactor));
+                Gadgetron::scal(fftCompensationRatio, complex_im_recon_buf_);
+            }
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+                std::string suffix = os.str();
+                gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "aliasedIm_" + suffix);
+            }
+
+            // unwrapping
+
+            long long num = N*S*SLC;
+
+            long long ii;
+
+            if (effectiveAcceFactor > 1)
+            {
+                if (perform_timing.value()) { gt_timer1_.start("perform_unwrapping, unwrapping ... "); }
+
+                if (E2 > 1)
+                {
+#pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, E2, srcCHA, convkRO, convkE1, convkE2, ref_N, ref_S, recon_obj, dstCHA, e)
+                    {
+#pragma omp for 
+                        for (ii = 0; ii < num; ii++)
+                        {
+                            size_t slc = ii / (N*S);
+                            size_t s = (ii - slc*N*S) / N;
+                            size_t n = ii - slc*N*S - s*N;
+
+                            // combined channels
+                            T* pIm = &(complex_im_recon_buf_(0, 0, 0, 0, n, s, slc));
+                            hoNDArray<T> aliasedIm(RO, E1, E2, srcCHA, 1, pIm);
+
+                            size_t usedN = n;
+                            if (n >= ref_N) usedN = ref_N - 1;
+
+                            size_t usedS = s;
+                            if (s >= ref_S) usedS = ref_S - 1;
+
+                            T* pKer = &(recon_obj.kernel_(0, 0, 0, 0, 0, usedN, usedS, slc));
+                            hoNDArray<T> ker(convkRO, convkE1, convkE2, srcCHA, dstCHA, pKer);
+
+                            T* pUnmix = &(recon_obj.unmixing_coeff_(0, 0, 0, 0, usedN, usedS, slc));
+                            hoNDArray<T> unmixing(RO, E1, E2, srcCHA, pUnmix);
+
+                            T* pRes = &(recon_obj.recon_res_.data_(0, 0, 0, 0, n, s, slc));
+                            hoNDArray<T> res(RO, E1, E2, 1, pRes);
+
+                            Gadgetron::apply_unmix_coeff_aliased_image_3D(aliasedIm, unmixing, res);
+                        }
+                    }
+                }
+                else
+                {
+#pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, E2, srcCHA, ref_N, ref_S, recon_obj, dstCHA, e)
+                    {
+#pragma omp for 
+                        for (ii = 0; ii < num; ii++)
+                        {
+                            size_t slc = ii / (N*S);
+                            size_t s = (ii - slc*N*S) / N;
+                            size_t n = ii - slc*N*S - s*N;
+
+                            // combined channels
+                            T* pIm = &(complex_im_recon_buf_(0, 0, 0, 0, n, s, slc));
+                            hoNDArray<T> aliasedIm(RO, E1, srcCHA, pIm);
+
+                            size_t usedN = n;
+                            if (n >= ref_N) usedN = ref_N - 1;
+
+                            size_t usedS = s;
+                            if (s >= ref_S) usedS = ref_S - 1;
+
+                            T* pUnmix = &(recon_obj.unmixing_coeff_(0, 0, 0, 0, usedN, usedS, slc));
+                            hoNDArray<T> unmixing(RO, E1, srcCHA, pUnmix);
+
+                            T* pRes = &(recon_obj.recon_res_.data_(0, 0, 0, 0, n, s, slc));
+                            hoNDArray<T> res(RO, E1, 1, pRes);
+
+                            Gadgetron::apply_unmix_coeff_aliased_image(aliasedIm, unmixing, res);
+                        }
+                    }
+                }
+
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+            }
+            else
+            {
+                if (perform_timing.value()) { gt_timer1_.start("perform_unwrapping, coil combination ... "); }
+                this->coil_combination(complex_im_recon_buf_, recon_obj.coil_map_, recon_obj.recon_res_.data_);
+                if (perform_timing.value()) { gt_timer1_.stop(); }
+            }
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+                std::string suffix = os.str();
+                gt_exporter_.exportArrayComplex(recon_obj.recon_res_.data_, debug_folder_full_path_ + "unwrappedIm_" + suffix);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_unwrapping(...) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::coil_combination(const hoNDArray< std::complex<float> >& complex_im, const hoNDArray< std::complex<float> >& coil_map, hoNDArray< std::complex<float> >& res)
+    {
+        try
+        {
+            size_t RO = complex_im.get_size(0);
+            size_t E1 = complex_im.get_size(1);
+            size_t E2 = complex_im.get_size(2);
+            size_t CHA = complex_im.get_size(3);
+            size_t N = complex_im.get_size(4);
+            size_t S = complex_im.get_size(5);
+            size_t SLC = complex_im.get_size(6);
+
+            size_t dstCHA = 1;
+
+            size_t coilCHA = coil_map.get_size(3);
+
+            size_t coil_N = coil_map.get_size(4);
+            size_t coil_S = coil_map.get_size(5);
+
+            typedef std::complex<float> T;
+
+            T* pIm = const_cast<T*>(complex_im.begin());
+            T* pCoilMap = const_cast<T*>(coil_map.begin());
+
+            res.create(RO, E1, E2, dstCHA, N, S, SLC);
+
+            long long num = SLC*S*N;
+
+            long long ii;
+
+#pragma omp parallel default(none) private(ii) shared(RO, E1, E2, CHA, N, S, SLC, coilCHA, dstCHA, num, coil_N, coil_S, pIm, pCoilMap, res) if(num>8)
+            {
+                hoNDArray<T> dataBuf;
+                dataBuf.create(RO, E1, E2, coilCHA);
+
+                hoNDArray<T> dataBufCombined;
+                dataBufCombined.create(RO, E1, E2, 1);
+
+#pragma omp for 
+                for (ii = 0; ii < num; ii++)
+                {
+                    size_t slc = ii / (N*S);
+                    size_t s = (ii - slc*N*S) / N;
+                    size_t n = ii - slc*N*S - s*N;
+
+                    size_t ns = s;
+                    if (ns >= coil_S) ns = coil_S - 1;
+
+                    size_t nn = n;
+                    if (nn >= coil_N) nn = coil_N - 1;
+
+                    hoNDArray<T> imCurr(RO, E1, E2, CHA, pIm + slc*RO*E1*E2*CHA*N*S + s*RO*E1*E2*CHA*N + n*RO*E1*E2*CHA);
+                    hoNDArray<T> coilMapCurr(RO, E1, E2, CHA, pCoilMap + slc*RO*E1*E2*CHA*coil_N*coil_S + ns*RO*E1*E2*CHA*coil_N + nn*RO*E1*E2*CHA);
+
+                    Gadgetron::multiplyConj(imCurr, coilMapCurr, dataBuf);
+                    Gadgetron::sum_over_dimension(dataBuf, dataBufCombined, 3);
+
+                    memcpy(res.begin() + slc*RO*E1*E2*dstCHA*N*S + s*RO*E1*E2*dstCHA*N + n*RO*E1*E2*dstCHA, dataBufCombined.begin(), sizeof(T)*RO*E1*E2);
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::coil_combination(complex_im) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::compute_image_header(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t e)
+    {
+        try
+        {
+            size_t RO = recon_obj.recon_res_.data_.get_size(0);
+            size_t E1 = recon_obj.recon_res_.data_.get_size(1);
+            size_t E2 = recon_obj.recon_res_.data_.get_size(2);
+            size_t CHA = recon_obj.recon_res_.data_.get_size(3);
+            size_t N = recon_obj.recon_res_.data_.get_size(4);
+            size_t S = recon_obj.recon_res_.data_.get_size(5);
+            size_t SLC = recon_obj.recon_res_.data_.get_size(6);
+
+            GADGET_CHECK_THROW(N == recon_bit.data_.headers_.get_size(2));
+            GADGET_CHECK_THROW(S == recon_bit.data_.headers_.get_size(3));
+
+            recon_obj.recon_res_.headers_.create(N, S, SLC);
+            recon_obj.recon_res_.meta_.resize(N*S*SLC);
+
+            size_t n, s, slc;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        size_t header_E1 = recon_bit.data_.headers_.get_size(0);
+                        size_t header_E2 = recon_bit.data_.headers_.get_size(1);
+
+                        // for every kspace, find the recorded header which is closest to the kspace center [E1/2 E2/2]
+                        ISMRMRD::AcquisitionHeader acq_header;
+
+                        long long bestE1 = E1 + 1;
+                        long long bestE2 = E2 + 1;
+
+                        size_t e1, e2;
+                        for (e2 = 0; e2 < header_E2; e2++)
+                        {
+                            for (e1 = 0; e1 < header_E1; e1++)
+                            {
+                                ISMRMRD::AcquisitionHeader& curr_header = recon_bit.data_.headers_(e1, e2, n, s, slc);
+
+                                if (curr_header.measurement_uid != 0) // a valid header
+                                {
+                                    if (E2 > 1)
+                                    {
+                                        if (std::abs((long long)curr_header.idx.kspace_encode_step_1 - (long long)(E1 / 2)) < bestE1
+                                            && std::abs((long long)curr_header.idx.kspace_encode_step_2 - (long long)(E2 / 2)) < bestE2)
+                                        {
+                                            bestE1 = std::abs((long long)curr_header.idx.kspace_encode_step_1 - (long long)E1 / 2);
+                                            bestE2 = std::abs((long long)curr_header.idx.kspace_encode_step_2 - (long long)E2 / 2);
+
+                                            acq_header = curr_header;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (std::abs((long long)curr_header.idx.kspace_encode_step_1 - (long long)(E1 / 2)) < bestE1)
+                                        {
+                                            bestE1 = std::abs((long long)curr_header.idx.kspace_encode_step_1 - (long long)E1 / 2);
+
+                                            acq_header = curr_header;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if (acq_header.measurement_uid == 0)
+                        {
+                            std::ostringstream ostr;
+                            ostr << "Cannot create valid image header : n = " << n << ", s = " << s << ", slc = " << slc;
+                            GADGET_THROW(ostr.str());
+                        }
+                        else
+                        {
+                            ISMRMRD::ImageHeader& im_header = recon_obj.recon_res_.headers_(n, s, slc);
+                            ISMRMRD::MetaContainer& meta = recon_obj.recon_res_.meta_[n + s*N + slc*N*S];
+
+                            im_header.version = acq_header.version;
+                            im_header.data_type = ISMRMRD::ISMRMRD_CXFLOAT;
+                            im_header.flags = acq_header.flags;
+                            im_header.measurement_uid = acq_header.measurement_uid;
+
+                            im_header.matrix_size[0] = (uint16_t)RO;
+                            im_header.matrix_size[1] = (uint16_t)E1;
+                            im_header.matrix_size[2] = (uint16_t)E2;
+
+                            im_header.field_of_view[0] = recon_bit.data_.sampling_.recon_FOV_[0];
+                            im_header.field_of_view[1] = recon_bit.data_.sampling_.recon_FOV_[1];
+                            im_header.field_of_view[2] = recon_bit.data_.sampling_.recon_FOV_[2];
+
+                            im_header.channels = (uint16_t)CHA;
+
+                            im_header.position[0] = acq_header.position[0];
+                            im_header.position[1] = acq_header.position[1];
+                            im_header.position[2] = acq_header.position[2];
+
+                            im_header.read_dir[0] = acq_header.read_dir[0];
+                            im_header.read_dir[1] = acq_header.read_dir[1];
+                            im_header.read_dir[2] = acq_header.read_dir[2];
+
+                            im_header.phase_dir[0] = acq_header.phase_dir[0];
+                            im_header.phase_dir[1] = acq_header.phase_dir[1];
+                            im_header.phase_dir[2] = acq_header.phase_dir[2];
+
+                            im_header.slice_dir[0] = acq_header.slice_dir[0];
+                            im_header.slice_dir[1] = acq_header.slice_dir[1];
+                            im_header.slice_dir[2] = acq_header.slice_dir[2];
+
+                            im_header.patient_table_position[0] = acq_header.patient_table_position[0];
+                            im_header.patient_table_position[1] = acq_header.patient_table_position[1];
+                            im_header.patient_table_position[2] = acq_header.patient_table_position[2];
+
+                            im_header.average = acq_header.idx.average;
+                            im_header.slice = acq_header.idx.slice;
+                            im_header.contrast = acq_header.idx.contrast;
+                            im_header.phase = acq_header.idx.phase;
+                            im_header.repetition = acq_header.idx.repetition;
+                            im_header.set = acq_header.idx.set;
+
+                            im_header.acquisition_time_stamp = acq_header.acquisition_time_stamp;
+
+                            im_header.physiology_time_stamp[0] = acq_header.physiology_time_stamp[0];
+                            im_header.physiology_time_stamp[1] = acq_header.physiology_time_stamp[1];
+                            im_header.physiology_time_stamp[2] = acq_header.physiology_time_stamp[2];
+
+                            im_header.image_type = ISMRMRD::ISMRMRD_IMTYPE_COMPLEX;
+                            im_header.image_index = (uint16_t)(n + s*N + slc*N*S);
+                            im_header.image_series_index = 0;
+
+                            memcpy(im_header.user_int, acq_header.user_int, sizeof(int32_t)*ISMRMRD::ISMRMRD_USER_INTS);
+                            memcpy(im_header.user_float, acq_header.user_float, sizeof(float)*ISMRMRD::ISMRMRD_USER_FLOATS);
+
+                            im_header.attribute_string_len = 0;
+
+                            meta.set("encoding", (long)e);
+
+                            meta.set("encoding_FOV", recon_bit.data_.sampling_.encoded_FOV_[0]);
+                            meta.append("encoding_FOV", recon_bit.data_.sampling_.encoded_FOV_[1]);
+                            meta.append("encoding_FOV", recon_bit.data_.sampling_.encoded_FOV_[2]);
+
+                            meta.set("recon_FOV", recon_bit.data_.sampling_.recon_FOV_[0]);
+                            meta.append("recon_FOV", recon_bit.data_.sampling_.recon_FOV_[1]);
+                            meta.append("recon_FOV", recon_bit.data_.sampling_.recon_FOV_[2]);
+
+                            meta.set("encoded_matrix", (long)recon_bit.data_.sampling_.encoded_matrix_[0]);
+                            meta.append("encoded_matrix", (long)recon_bit.data_.sampling_.encoded_matrix_[1]);
+                            meta.append("encoded_matrix", (long)recon_bit.data_.sampling_.encoded_matrix_[2]);
+
+                            meta.set("recon_matrix", (long)recon_bit.data_.sampling_.recon_matrix_[0]);
+                            meta.append("recon_matrix", (long)recon_bit.data_.sampling_.recon_matrix_[1]);
+                            meta.append("recon_matrix", (long)recon_bit.data_.sampling_.recon_matrix_[2]);
+
+                            meta.set("sampling_limits_RO", (long)recon_bit.data_.sampling_.sampling_limits_[0].min_);
+                            meta.append("sampling_limits_RO", (long)recon_bit.data_.sampling_.sampling_limits_[0].center_);
+                            meta.append("sampling_limits_RO", (long)recon_bit.data_.sampling_.sampling_limits_[0].max_);
+
+                            meta.set("sampling_limits_E1", (long)recon_bit.data_.sampling_.sampling_limits_[1].min_);
+                            meta.append("sampling_limits_E1", (long)recon_bit.data_.sampling_.sampling_limits_[1].center_);
+                            meta.append("sampling_limits_E1", (long)recon_bit.data_.sampling_.sampling_limits_[1].max_);
+
+                            meta.set("sampling_limits_E2", (long)recon_bit.data_.sampling_.sampling_limits_[2].min_);
+                            meta.append("sampling_limits_E2", (long)recon_bit.data_.sampling_.sampling_limits_[2].center_);
+                            meta.append("sampling_limits_E2", (long)recon_bit.data_.sampling_.sampling_limits_[2].max_);
+                        }
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::compute_image_header(...) ... ");
+        }
+    }
+
+    void GenericCartesianGrappaReconGadget::get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath)
+    {
+        char* v = std::getenv("GADGETRON_DEBUG_FOLDER");
+        if (v == NULL)
+        {
+#ifdef _WIN32
+            debugFolderPath = "c:/temp/gadgetron";
+#else
+            debugFolderPath = "/tmp/gadgetron";
+#endif // _WIN32
+        }
+        else
+        {
+            debugFolderPath = std::string(v);
+        }
+
+        debugFolderPath.append("/");
+        debugFolderPath.append(debugFolder);
+        debugFolderPath.append("/");
+    }
+
+    // ----------------------------------------------------------------------------------------
+
+    GADGET_FACTORY_DECLARE(GenericCartesianGrappaReconGadget)
+
+}

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
@@ -140,15 +140,15 @@ namespace Gadgetron {
 
         // ---------------------------------------------------------------------------------------------------------
 
-        if (!debug_folder.value().empty())
-        {
-            Gadgetron::get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
-            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
-        }
-        else
-        {
-            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is not set ... ");
-        }
+        //if (!debug_folder.value().empty())
+        //{
+        //    Gadgetron::get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
+        //    GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
+        //}
+        //else
+        //{
+        //    GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is not set ... ");
+        //}
 
         return GADGET_OK;
     }
@@ -170,35 +170,35 @@ namespace Gadgetron {
             std::stringstream os;
             os << "_encoding_" << e;
 
-            GDEBUG_CONDITION_STREAM(verbose.value(), "Encoding space : " << e);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Calling " << process_called_times_ << " , encoding space : " << e);
             GDEBUG_CONDITION_STREAM(verbose.value(), "======================================================================");
 
             // ---------------------------------------------------------------
             // export incoming data
 
-            if (!debug_folder_full_path_.empty())
-            {
-                gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data" + os.str());
-            }
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data" + os.str());
+            //}
 
-            if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
-            {
-                gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_traj" + os.str());
-            }
+            //if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+            //{
+            //    gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_traj" + os.str());
+            //}
 
             // ---------------------------------------------------------------
 
             if (recon_bit_->rbit_[e].ref_.data_.get_number_of_elements() > 0)
             {
-                if (!debug_folder_full_path_.empty())
-                {
-                    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref" + os.str());
-                }
+                //if (!debug_folder_full_path_.empty())
+                //{
+                //    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref" + os.str());
+                //}
 
-                if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].ref_.trajectory_.get_number_of_elements() > 0)
-                {
-                    gt_exporter_.exportArray(recon_bit_->rbit_[e].ref_.trajectory_, debug_folder_full_path_ + "ref_traj" + os.str());
-                }
+                //if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].ref_.trajectory_.get_number_of_elements() > 0)
+                //{
+                //    gt_exporter_.exportArray(recon_bit_->rbit_[e].ref_.trajectory_, debug_folder_full_path_ + "ref_traj" + os.str());
+                //}
 
                 // ---------------------------------------------------------------
 
@@ -210,15 +210,15 @@ namespace Gadgetron {
 
                 // ----------------------------------------------------------
                 // export prepared ref for calibration and coil map
-                if (!debug_folder_full_path_.empty())
-                {
-                    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_calib_, debug_folder_full_path_ + "ref_calib" + os.str());
-                }
+                //if (!debug_folder_full_path_.empty())
+                //{
+                //    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_calib_, debug_folder_full_path_ + "ref_calib" + os.str());
+                //}
 
-                if (!debug_folder_full_path_.empty())
-                {
-                    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_coil_map_, debug_folder_full_path_ + "ref_coil_map" + os.str());
-                }
+                //if (!debug_folder_full_path_.empty())
+                //{
+                //    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_coil_map_, debug_folder_full_path_ + "ref_coil_map" + os.str());
+                //}
 
                 // ---------------------------------------------------------------
 
@@ -243,15 +243,15 @@ namespace Gadgetron {
 
             if (recon_bit_->rbit_[e].data_.data_.get_number_of_elements() > 0)
             {
-                if (!debug_folder_full_path_.empty())
-                {
-                    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data_before_unwrapping" + os.str());
-                }
+                //if (!debug_folder_full_path_.empty())
+                //{
+                //    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data_before_unwrapping" + os.str());
+                //}
 
-                if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
-                {
-                    gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_before_unwrapping_traj" + os.str());
-                }
+                //if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+                //{
+                //    gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_before_unwrapping_traj" + os.str());
+                //}
 
                 // ---------------------------------------------------------------
 
@@ -471,13 +471,13 @@ namespace Gadgetron {
                 }
             }
 
-            if (!debug_folder_full_path_.empty())
-            {
-                std::stringstream os;
-                os << "encoding_" << encoding;
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    std::stringstream os;
+            //    os << "encoding_" << encoding;
 
-                gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_before_filtering_" + os.str());
-            }
+            //    gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_before_filtering_" + os.str());
+            //}
 
             // filter the ref_coil_map
             if (filter_RO_ref_coi_map_.get_size(0) != RO
@@ -488,15 +488,15 @@ namespace Gadgetron {
                     recon_bit.ref_.sampling_.sampling_limits_[0], recon_bit.ref_.sampling_.sampling_limits_[1], recon_bit.ref_.sampling_.sampling_limits_[2], 
                     filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
 
-                if (!debug_folder_full_path_.empty())
-                {
-                    std::stringstream os;
-                    os << "encoding_" << encoding;
+                //if (!debug_folder_full_path_.empty())
+                //{
+                //    std::stringstream os;
+                //    os << "encoding_" << encoding;
 
-                    gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_full_path_ + "filter_RO_ref_coi_map_" + os.str());
-                    gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_full_path_ + "filter_E1_ref_coi_map_" + os.str());
-                    gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_full_path_ + "filter_E2_ref_coi_map_" + os.str());
-                }
+                //    gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_full_path_ + "filter_RO_ref_coi_map_" + os.str());
+                //    gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_full_path_ + "filter_E1_ref_coi_map_" + os.str());
+                //    gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_full_path_ + "filter_E2_ref_coi_map_" + os.str());
+                //}
             }
 
             hoNDArray< std::complex<float> > ref_recon_buf;
@@ -510,13 +510,13 @@ namespace Gadgetron {
                 Gadgetron::apply_kspace_filter_ROE1(ref_coil_map, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_recon_buf);
             }
 
-            if (!debug_folder_full_path_.empty())
-            {
-                std::stringstream os;
-                os << "encoding_" << encoding;
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    std::stringstream os;
+            //    os << "encoding_" << encoding;
 
-                gt_exporter_.exportArrayComplex(ref_recon_buf, debug_folder_full_path_ + "ref_coil_map_after_filtering_" + os.str());
-            }
+            //    gt_exporter_.exportArrayComplex(ref_recon_buf, debug_folder_full_path_ + "ref_coil_map_after_filtering_" + os.str());
+            //}
 
             // pad the ref_coil_map into the data array
             Gadgetron::pad(recon_RO, recon_E1, recon_E2, &ref_recon_buf, &ref_coil_map);
@@ -525,14 +525,14 @@ namespace Gadgetron {
             ref.get_dimensions(dim);
             ref_calib.create(dim, ref.begin());
 
-            if (!debug_folder_full_path_.empty())
-            {
-                std::stringstream os;
-                os << "encoding_" << encoding;
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    std::stringstream os;
+            //    os << "encoding_" << encoding;
 
-                gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_" + os.str());
-                gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_" + os.str());
-            }
+            //    gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_" + os.str());
+            //    gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_" + os.str());
+            //}
         }
         catch (...)
         {
@@ -557,13 +557,13 @@ namespace Gadgetron {
                 Gadgetron::hoNDFFT<float>::instance()->ifft2c(recon_obj.ref_coil_map_, complex_im_recon_buf_);
             }
 
-            if (!debug_folder_full_path_.empty())
-            {
-                std::stringstream os;
-                os << "encoding_" << e;
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    std::stringstream os;
+            //    os << "encoding_" << e;
 
-                gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "complex_im_for_coil_map_" + os.str());
-            }
+            //    gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "complex_im_for_coil_map_" + os.str());
+            //}
 
             size_t ks = 7;
             size_t kz = 5;
@@ -571,13 +571,13 @@ namespace Gadgetron {
 
             Gadgetron::coil_map_Inati(complex_im_recon_buf_, recon_obj.coil_map_, ks, kz, power);
 
-            if (!debug_folder_full_path_.empty())
-            {
-                std::stringstream os;
-                os << "encoding_" << e;
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    std::stringstream os;
+            //    os << "encoding_" << e;
 
-                gt_exporter_.exportArrayComplex(recon_obj.coil_map_, debug_folder_full_path_ + "coil_map_" + os.str());
-            }
+            //    gt_exporter_.exportArrayComplex(recon_obj.coil_map_, debug_folder_full_path_ + "coil_map_" + os.str());
+            //}
         }
         catch (...)
         {
@@ -589,8 +589,6 @@ namespace Gadgetron {
     {
         try
         {
-            typedef  std::complex<float> T;
-
             size_t RO = recon_bit.data_.data_.get_size(0);
             size_t E1 = recon_bit.data_.data_.get_size(1);
             size_t E2 = recon_bit.data_.data_.get_size(2);
@@ -662,10 +660,10 @@ namespace Gadgetron {
                     os << "n" << n << "_s" << s << "_slc" << slc << "_encoding_" << e;
                     std::string suffix = os.str();
 
-                    T* pSrc = &(src(0, 0, 0, 0, n, s, slc));
+                    std::complex<float>* pSrc = &(src(0, 0, 0, 0, n, s, slc));
                     hoNDArray< std::complex<float> > ref_src(ref_RO, ref_E1, ref_E2, srcCHA, pSrc);
 
-                    T* pDst = &(dst(0, 0, 0, 0, n, s, slc));
+                    std::complex<float>* pDst = &(dst(0, 0, 0, 0, n, s, slc));
                     hoNDArray< std::complex<float> > ref_dst(ref_RO, ref_E1, ref_E2, dstCHA, pDst);
 
                     // -----------------------------------
@@ -675,30 +673,30 @@ namespace Gadgetron {
                         hoNDArray< std::complex<float> > ker(convKRO, convKE1, convKE2, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc)));
                         Gadgetron::grappa3d_calib_convolution_kernel(ref_src, ref_dst, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], grappa_reg_lamda.value(), grappa_calib_over_determine_ratio.value(), kRO, kNE1, kNE2, ker);
 
-                        if (!debug_folder_full_path_.empty())
-                        {
-                            gt_exporter_.exportArrayComplex(ker, debug_folder_full_path_ + "convKer3D_" + suffix);
-                        }
+                        //if (!debug_folder_full_path_.empty())
+                        //{
+                        //    gt_exporter_.exportArrayComplex(ker, debug_folder_full_path_ + "convKer3D_" + suffix);
+                        //}
 
                         hoNDArray< std::complex<float> > coilMap(RO, E1, E2, dstCHA, &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc)));
                         hoNDArray< std::complex<float> > unmixC(RO, E1, E2, srcCHA, &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc)));
                         hoNDArray<float> gFactor(RO, E1, E2, 1, &(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc)));
                         Gadgetron::grappa3d_unmixing_coeff(ker, coilMap, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], unmixC, gFactor);
 
-                        if (!debug_folder_full_path_.empty())
-                        {
-                            gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_3D_" + suffix);
-                        }
+                        //if (!debug_folder_full_path_.empty())
+                        //{
+                        //    gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_3D_" + suffix);
+                        //}
 
-                        if (!debug_folder_full_path_.empty())
-                        {
-                            gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_3D_" + suffix);
-                        }
+                        //if (!debug_folder_full_path_.empty())
+                        //{
+                        //    gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_3D_" + suffix);
+                        //}
                     }
                     else
                     {
-                        hoNDArray< std::complex<float> > acsSrc(ref_RO, ref_E1, srcCHA, const_cast<T*>(ref_src.begin()));
-                        hoNDArray< std::complex<float> > acsDst(ref_RO, ref_E1, dstCHA, const_cast<T*>(ref_dst.begin()));
+                        hoNDArray< std::complex<float> > acsSrc(ref_RO, ref_E1, srcCHA, const_cast< std::complex<float>*>(ref_src.begin()));
+                        hoNDArray< std::complex<float> > acsDst(ref_RO, ref_E1, dstCHA, const_cast< std::complex<float>*>(ref_dst.begin()));
 
                         hoNDArray< std::complex<float> > convKer(convKRO, convKE1, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc)));
                         hoNDArray< std::complex<float> > kIm(RO, E1, srcCHA, dstCHA, &(recon_obj.kernelIm_(0, 0, 0, 0, 0, n, s, slc)));
@@ -706,15 +704,15 @@ namespace Gadgetron {
                         Gadgetron::grappa2d_calib_convolution_kernel(acsSrc, acsDst, (size_t)acceFactorE1_[e], grappa_reg_lamda.value(), kRO, kNE1, convKer);
                         Gadgetron::grappa2d_image_domain_kernel(convKer, RO, E1, kIm);
 
-                        if (!debug_folder_full_path_.empty())
-                        {
-                            gt_exporter_.exportArrayComplex(convKer, debug_folder_full_path_ + "convKer_" + suffix);
-                        }
+                        //if (!debug_folder_full_path_.empty())
+                        //{
+                        //    gt_exporter_.exportArrayComplex(convKer, debug_folder_full_path_ + "convKer_" + suffix);
+                        //}
 
-                        if (!debug_folder_full_path_.empty())
-                        {
-                            gt_exporter_.exportArrayComplex(kIm, debug_folder_full_path_ + "kIm_" + suffix);
-                        }
+                        //if (!debug_folder_full_path_.empty())
+                        //{
+                        //    gt_exporter_.exportArrayComplex(kIm, debug_folder_full_path_ + "kIm_" + suffix);
+                        //}
 
                         hoNDArray< std::complex<float> > coilMap(RO, E1, dstCHA, &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc)));
                         hoNDArray< std::complex<float> > unmixC(RO, E1, srcCHA, &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc)));
@@ -723,15 +721,15 @@ namespace Gadgetron {
                         Gadgetron::grappa2d_unmixing_coeff(kIm, coilMap, (size_t)acceFactorE1_[e], unmixC, gFactor);
                         memcpy(&(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc)), gFactor.begin(), gFactor.get_number_of_bytes());
 
-                        if (!debug_folder_full_path_.empty())
-                        {
-                            gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_" + suffix);
-                        }
+                        //if (!debug_folder_full_path_.empty())
+                        //{
+                        //    gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_" + suffix);
+                        //}
 
-                        if (!debug_folder_full_path_.empty())
-                        {
-                            gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_" + suffix);
-                        }
+                        //if (!debug_folder_full_path_.empty())
+                        //{
+                        //    gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_" + suffix);
+                        //}
                     }
 
                     // -----------------------------------
@@ -775,13 +773,13 @@ namespace Gadgetron {
 
             recon_obj.recon_res_.data_.create(RO, E1, E2, 1, N, S, SLC);
 
-            if (!debug_folder_full_path_.empty())
-            {
-                std::stringstream os;
-                os << "encoding_" << e;
-                std::string suffix = os.str();
-                gt_exporter_.exportArrayComplex(recon_bit.data_.data_, debug_folder_full_path_ + "data_src_" + suffix);
-            }
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    std::stringstream os;
+            //    os << "encoding_" << e;
+            //    std::string suffix = os.str();
+            //    gt_exporter_.exportArrayComplex(recon_bit.data_.data_, debug_folder_full_path_ + "data_src_" + suffix);
+            //}
 
             // compute aliased images
             data_recon_buf_.create(RO, E1, E2, dstCHA, N, S, SLC);
@@ -803,13 +801,13 @@ namespace Gadgetron {
                 Gadgetron::scal(fftCompensationRatio, complex_im_recon_buf_);
             }
 
-            if (!debug_folder_full_path_.empty())
-            {
-                std::stringstream os;
-                os << "encoding_" << e;
-                std::string suffix = os.str();
-                gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "aliasedIm_" + suffix);
-            }
+            //if (!debug_folder_full_path_.empty())
+            //{
+            //    std::stringstream os;
+            //    os << "encoding_" << e;
+            //    std::string suffix = os.str();
+            //    gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "aliasedIm_" + suffix);
+            //}
 
             // unwrapping
 
@@ -849,13 +847,13 @@ namespace Gadgetron {
                 }
             }
 
-            if (!debug_folder_full_path_.empty())
+            /*if (!debug_folder_full_path_.empty())
             {
                 std::stringstream os;
                 os << "encoding_" << e;
                 std::string suffix = os.str();
                 gt_exporter_.exportArrayComplex(recon_obj.recon_res_.data_, debug_folder_full_path_ + "unwrappedIm_" + suffix);
-            }
+            }*/
         }
         catch (...)
         {

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
@@ -25,23 +25,10 @@ namespace Gadgetron {
     {
         gt_timer_.set_timing_in_destruction(false);
         gt_timer_local_.set_timing_in_destruction(false);
-
-        std::string procTime;
-        Gadgetron::get_current_moment(procTime);
-
-        GDEBUG_STREAM("* ======================================================================================================= *");
-        GDEBUG_STREAM("---> GenericCartesianGrappaReconGadget, constructor(), Currnt processing time : " << procTime << " <---");
-        GDEBUG_STREAM("* ======================================================================================================= *");
     }
 
     GenericCartesianGrappaReconGadget::~GenericCartesianGrappaReconGadget()
     {
-        std::string procTime;
-        Gadgetron::get_current_moment(procTime);
-
-        GDEBUG_STREAM("* ======================================================================================================= *");
-        GDEBUG_STREAM("---> GenericCartesianGrappaReconGadget, destructor(), Currnt processing time : " << procTime << " <---");
-        GDEBUG_STREAM("* ======================================================================================================= *");
     }
 
     int GenericCartesianGrappaReconGadget::process_config(ACE_Message_Block* mb)
@@ -480,13 +467,9 @@ namespace Gadgetron {
             //}
 
             // filter the ref_coil_map
-            if (filter_RO_ref_coi_map_.get_size(0) != RO
-                || filter_E1_ref_coi_map_.get_size(0) != E1
-                || ((E2 > 1) && (filter_E2_ref_coi_map_.get_size(0) != E2)))
+            if (filter_RO_ref_coi_map_.get_size(0) != RO)
             {
-                Gadgetron::generate_ref_filter_for_coil_map(ref_coil_map,
-                    recon_bit.ref_.sampling_.sampling_limits_[0], recon_bit.ref_.sampling_.sampling_limits_[1], recon_bit.ref_.sampling_.sampling_limits_[2], 
-                    filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
+                Gadgetron::generate_symmetric_filter_ref(ref_coil_map.get_size(0), recon_bit.ref_.sampling_.sampling_limits_[0].min_, recon_bit.ref_.sampling_.sampling_limits_[0].max_, filter_RO_ref_coi_map_);
 
                 //if (!debug_folder_full_path_.empty())
                 //{
@@ -494,7 +477,31 @@ namespace Gadgetron {
                 //    os << "encoding_" << encoding;
 
                 //    gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_full_path_ + "filter_RO_ref_coi_map_" + os.str());
+                //}
+            }
+
+            if (filter_E1_ref_coi_map_.get_size(0) != E1)
+            {
+                Gadgetron::generate_symmetric_filter_ref(ref_coil_map.get_size(1), recon_bit.ref_.sampling_.sampling_limits_[1].min_, recon_bit.ref_.sampling_.sampling_limits_[1].max_, filter_E1_ref_coi_map_);
+
+                //if (!debug_folder_full_path_.empty())
+                //{
+                //    std::stringstream os;
+                //    os << "encoding_" << encoding;
+
                 //    gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_full_path_ + "filter_E1_ref_coi_map_" + os.str());
+                //}
+            }
+
+            if ( (E2 > 1) && (filter_E2_ref_coi_map_.get_size(0) != E2) )
+            {
+                Gadgetron::generate_symmetric_filter_ref(ref_coil_map.get_size(2), recon_bit.ref_.sampling_.sampling_limits_[2].min_, recon_bit.ref_.sampling_.sampling_limits_[2].max_, filter_E2_ref_coi_map_);
+
+                //if (!debug_folder_full_path_.empty())
+                //{
+                //    std::stringstream os;
+                //    os << "encoding_" << encoding;
+
                 //    gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_full_path_ + "filter_E2_ref_coi_map_" + os.str());
                 //}
             }

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
@@ -9,14 +9,39 @@
 #include "mri_core_grappa.h"
 #include "mri_core_utility.h"
 
+/*
+    The input is IsmrmrdReconData and output is single 2D or 3D ISMRMRD images
+
+    If required, the gfactor map can be sent out
+
+    If the  number of required destination channel is 1, the GrappaONE recon will be performed
+
+    The image number computation logic is implemented in compute_image_number function, which can be overloaded
+*/
+
 namespace Gadgetron {
 
     GenericCartesianGrappaReconGadget::GenericCartesianGrappaReconGadget() : num_encoding_spaces_(1), process_called_times_(0)
     {
+        gt_timer_.set_timing_in_destruction(false);
+        gt_timer_local_.set_timing_in_destruction(false);
+
+        std::string procTime;
+        Gadgetron::get_current_moment(procTime);
+
+        GDEBUG_STREAM("* ======================================================================================================= *");
+        GDEBUG_STREAM("---> GenericCartesianGrappaReconGadget, constructor(), Currnt processing time : " << procTime << " <---");
+        GDEBUG_STREAM("* ======================================================================================================= *");
     }
 
     GenericCartesianGrappaReconGadget::~GenericCartesianGrappaReconGadget()
     {
+        std::string procTime;
+        Gadgetron::get_current_moment(procTime);
+
+        GDEBUG_STREAM("* ======================================================================================================= *");
+        GDEBUG_STREAM("---> GenericCartesianGrappaReconGadget, destructor(), Currnt processing time : " << procTime << " <---");
+        GDEBUG_STREAM("* ======================================================================================================= *");
     }
 
     int GenericCartesianGrappaReconGadget::process_config(ACE_Message_Block* mb)
@@ -113,6 +138,18 @@ namespace Gadgetron {
             }
         }
 
+        // ---------------------------------------------------------------------------------------------------------
+
+        if (!debug_folder.value().empty())
+        {
+            Gadgetron::get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
+        }
+        else
+        {
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is not set ... ");
+        }
+
         return GADGET_OK;
     }
 
@@ -130,35 +167,75 @@ namespace Gadgetron {
         size_t e;
         for (e = 0; e < recon_bit_->rbit_.size(); e++)
         {
-            this->ensure_recon_size(recon_bit_->rbit_[e], recon_obj_[e], e);
+            std::stringstream os;
+            os << "_encoding_" << e;
 
-            if (calib_mode_[e] == Gadgetron::ISMRMRD_noacceleration && recon_bit_->rbit_[e].ref_.data_.get_number_of_elements()==0)
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Encoding space : " << e);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "======================================================================");
+
+            // ---------------------------------------------------------------
+            // export incoming data
+
+            if (!debug_folder_full_path_.empty())
             {
-                std::vector<size_t> dim;
-                recon_bit_->rbit_[e].data_.data_.get_dimensions(dim);
-                recon_bit_->rbit_[e].ref_.data_.create(dim, recon_bit_->rbit_[e].data_.data_.begin());
-
-                if (recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
-                {
-                    recon_bit_->rbit_[e].data_.trajectory_.get_dimensions(dim);
-                    recon_bit_->rbit_[e].ref_.trajectory_.create(dim, recon_bit_->rbit_[e].data_.trajectory_.begin());
-                }
-
-                recon_bit_->rbit_[e].ref_.headers_ = recon_bit_->rbit_[e].data_.headers_;
-                recon_bit_->rbit_[e].ref_.sampling_ = recon_bit_->rbit_[e].data_.sampling_;
+                gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data" + os.str());
             }
+
+            if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+            {
+                gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_traj" + os.str());
+            }
+
+            // ---------------------------------------------------------------
 
             if (recon_bit_->rbit_[e].ref_.data_.get_number_of_elements() > 0)
             {
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref" + os.str());
+                }
+
+                if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].ref_.trajectory_.get_number_of_elements() > 0)
+                {
+                    gt_exporter_.exportArray(recon_bit_->rbit_[e].ref_.trajectory_, debug_folder_full_path_ + "ref_traj" + os.str());
+                }
+
+                // ---------------------------------------------------------------
+
                 // after this step, the recon_obj_[e].ref_calib_ and recon_obj_[e].ref_coil_map_ are set
-                this->prepare_ref(recon_bit_->rbit_[e], recon_obj_[e], e);
+
+                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::make_ref_coil_map"); }
+                this->make_ref_coil_map(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ----------------------------------------------------------
+                // export prepared ref for calibration and coil map
+                if (!debug_folder_full_path_.empty())
+                {
+                    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_calib_, debug_folder_full_path_ + "ref_calib" + os.str());
+                }
+
+                if (!debug_folder_full_path_.empty())
+                {
+                    this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_coil_map_, debug_folder_full_path_ + "ref_coil_map" + os.str());
+                }
+
+                // ---------------------------------------------------------------
 
                 // after this step, coil map is computed and stored in recon_obj_[e].coil_map_
+                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::make_ref_coil_map"); }
                 this->perform_coil_map_estimation(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ---------------------------------------------------------------
 
                 // after this step, recon_obj_[e].kernel_, recon_obj_[e].kernelIm_, recon_obj_[e].unmixing_coeff_ are filled
                 // gfactor is computed too
+                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::perform_calib"); }
                 this->perform_calib(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ---------------------------------------------------------------
 
                 recon_bit_->rbit_[e].ref_.data_.clear();
                 recon_bit_->rbit_[e].ref_.trajectory_.clear();
@@ -166,10 +243,33 @@ namespace Gadgetron {
 
             if (recon_bit_->rbit_[e].data_.data_.get_number_of_elements() > 0)
             {
-                this->perform_unwrapping(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (!debug_folder_full_path_.empty())
+                {
+                    gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data_before_unwrapping" + os.str());
+                }
 
+                if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+                {
+                    gt_exporter_.exportArray(recon_bit_->rbit_[e].data_.trajectory_, debug_folder_full_path_ + "data_before_unwrapping_traj" + os.str());
+                }
+
+                // ---------------------------------------------------------------
+
+                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::perform_unwrapping"); }
+                this->perform_unwrapping(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ---------------------------------------------------------------
+
+                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::compute_image_header"); }
                 this->compute_image_header(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ---------------------------------------------------------------
+
+                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::send_out_image_array"); }
                 this->send_out_image_array(recon_bit_->rbit_[e], recon_obj_[e].recon_res_, e, image_series.value() + ((int)e + 1), GADGETRON_IMAGE_REGULAR);
+                if (perform_timing.value()) { gt_timer_.stop(); }
 
                 if (send_out_gfactor.value() && recon_obj_[e].gfactor_.get_number_of_elements()>0)
                 {
@@ -178,7 +278,9 @@ namespace Gadgetron {
                     res.headers_ = recon_obj_[e].recon_res_.headers_;
                     res.meta_ = recon_obj_[e].recon_res_.meta_;
 
+                    if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::send_out_image_array"); }
                     this->send_out_image_array(recon_bit_->rbit_[e], res, e, image_series.value() + 10 * ((int)e + 1), GADGETRON_IMAGE_GFACTOR);
+                    if (perform_timing.value()) { gt_timer_.stop(); }
                 }
             }
 
@@ -294,98 +396,7 @@ namespace Gadgetron {
 
     // ----------------------------------------------------------------------------------------
 
-    void GenericCartesianGrappaReconGadget::ensure_recon_size(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding)
-    {
-        try
-        {
-            size_t RO = recon_bit.data_.data_.get_size(0);
-            size_t E1 = recon_bit.data_.data_.get_size(1);
-            size_t E2 = recon_bit.data_.data_.get_size(2);
-
-            size_t N = recon_bit.data_.data_.get_size(4);
-            size_t S = recon_bit.data_.data_.get_size(5);
-            size_t SLC = recon_bit.data_.data_.get_size(6);
-
-            // compensate for sampling limits under acceleration
-            if (E1-1 - recon_bit.data_.sampling_.sampling_limits_[1].max_ < acceFactorE1_[encoding])
-            {
-                recon_bit.data_.sampling_.sampling_limits_[1].max_ = (uint16_t)E1 - 1;
-            }
-
-            if ( (E2>1) && (E2-1 - recon_bit.data_.sampling_.sampling_limits_[2].max_ < acceFactorE2_[encoding]))
-            {
-                recon_bit.data_.sampling_.sampling_limits_[2].max_ = (uint16_t)E2 - 1;
-            }
-
-            float spacingE1 = recon_bit.data_.sampling_.recon_FOV_[1] / recon_bit.data_.sampling_.recon_matrix_[1];
-            size_t encodingE1 = (size_t)std::floor(recon_bit.data_.sampling_.encoded_FOV_[1] / spacingE1 + 0.5);
-
-            if (encodingE1 > E1)
-            {
-                GDEBUG_STREAM("recon_squared_pixel is true; change encoding E1 to be " << encodingE1);
-
-                // pad the data
-                hoNDArray< std::complex<float> > dataPadded;
-                Gadgetron::pad(RO, encodingE1, &recon_bit.data_.data_, &dataPadded);
-                recon_bit.data_.data_ = dataPadded;
-
-                // update the sampling_limits
-                uint16_t offsetE1 = (uint16_t)(encodingE1 / 2 - E1 / 2);
-
-                recon_bit.data_.sampling_.sampling_limits_[1].min_ += offsetE1;
-                recon_bit.data_.sampling_.sampling_limits_[1].max_ += offsetE1;
-
-                // update image headers
-                size_t headerE1 = recon_bit.data_.headers_.get_size(0);
-                size_t headerE2 = recon_bit.data_.headers_.get_size(1);
-
-                size_t n, s, slc, e1, e2;
-
-                for (slc = 0; slc < SLC; slc++)
-                {
-                    for (s = 0; s < S; s++)
-                    {
-                        for (n = 0; n < N; n++)
-                        {
-                            for (e2 = 0; e2 < headerE2; e2++)
-                            {
-                                for (e1 = 0; e1 < headerE1; e1++)
-                                {
-                                    if (recon_bit.data_.headers_(e1, e2, n, s, slc).measurement_uid != 0)
-                                    {
-                                        recon_bit.data_.headers_(e1, e2, n, s, slc).idx.kspace_encode_step_1 += offsetE1;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // if calib_mode is embedded, pad the ref
-                if (calib_mode_[encoding] == Gadgetron::ISMRMRD_embedded)
-                {
-                    if (recon_bit.ref_.data_.get_size(0) == RO && recon_bit.ref_.data_.get_size(1) == E1)
-                    {
-                        Gadgetron::pad(RO, encodingE1, &recon_bit.ref_.data_, &dataPadded);
-                        recon_bit.ref_.data_ = dataPadded;
-
-                        recon_bit.ref_.sampling_.sampling_limits_[1].min_ += offsetE1;
-                        recon_bit.ref_.sampling_.sampling_limits_[1].max_ += offsetE1;
-                    }
-                }
-            }
-            else
-            {
-                GDEBUG_STREAM("it is not required to change encoding E1 ... ");
-            }
-        }
-        catch (...)
-        {
-            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::ensure_recon_size(...) ... ");
-        }
-    }
-
-    void GenericCartesianGrappaReconGadget::prepare_ref(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding)
+    void GenericCartesianGrappaReconGadget::make_ref_coil_map(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding)
     {
         try
         {
@@ -394,132 +405,138 @@ namespace Gadgetron {
             hoNDArray< std::complex<float> >& ref_coil_map = recon_obj.ref_coil_map_;
 
             // sampling limits
-            SamplingLimit sampling_limits[3];
-            sampling_limits[0] = recon_bit.ref_.sampling_.sampling_limits_[0];
-            sampling_limits[1] = recon_bit.ref_.sampling_.sampling_limits_[1];
-            sampling_limits[2] = recon_bit.ref_.sampling_.sampling_limits_[2];
+            size_t sRO = recon_bit.ref_.sampling_.sampling_limits_[0].min_;
+            size_t eRO = recon_bit.ref_.sampling_.sampling_limits_[0].max_;
+            size_t cRO = recon_bit.ref_.sampling_.sampling_limits_[0].center_;
+
+            size_t sE1 = recon_bit.ref_.sampling_.sampling_limits_[1].min_;
+            size_t eE1 = recon_bit.ref_.sampling_.sampling_limits_[1].max_;
+            size_t cE1 = recon_bit.ref_.sampling_.sampling_limits_[1].center_;
+
+            size_t sE2 = recon_bit.ref_.sampling_.sampling_limits_[2].min_;
+            size_t eE2 = recon_bit.ref_.sampling_.sampling_limits_[2].max_;
+            size_t cE2 = recon_bit.ref_.sampling_.sampling_limits_[2].center_;
 
             // recon size
             size_t recon_RO = recon_bit.data_.data_.get_size(0);
             size_t recon_E1 = recon_bit.data_.data_.get_size(1);
             size_t recon_E2 = recon_bit.data_.data_.get_size(2);
 
-            // filter ref coil map
-            bool filter_ref_coil_map = true;
-
             // ref array size
-            size_t RO = ref.get_size(0);
-            size_t E1 = ref.get_size(1);
-            size_t E2 = ref.get_size(2);
             size_t CHA = ref.get_size(3);
             size_t N = ref.get_size(4);
             size_t S = ref.get_size(5);
             size_t SLC = ref.get_size(6);
 
-            if (calib_mode_[encoding] == ISMRMRD_separate || calib_mode_[encoding] == ISMRMRD_external || calib_mode_[encoding] == ISMRMRD_other)
+            // determine the ref_coil_map size
+            size_t RO = 2 * cRO;
+            if (sRO>0 || eRO<RO - 1)
             {
-                if (average_all_ref_N.value())
+                RO = 2 * std::max(cRO - sRO, eRO - cRO);
+            }
+
+            size_t E1 = eE1 - sE1 + 1;
+            size_t E2 = eE2 - sE2 + 1;
+
+            if ((calib_mode_[encoding] == Gadgetron::ISMRMRD_interleaved) || (calib_mode_[encoding] == Gadgetron::ISMRMRD_noacceleration))
+            {
+                E1 = 2 * std::max(cE1 - sE1, eE1 - cE1);
+                if (E2>1 ) E2 = 2 * std::max(cE2 - sE2, eE2 - cE2);
+            }
+
+            ref_coil_map.create(RO, E1, E2, CHA, N, S, SLC);
+            Gadgetron::clear(ref_coil_map);
+
+            size_t slc, s, n, cha, e2, e1;
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
                 {
-                    if (N > 1)
+                    for (n = 0; n < N; n++)
                     {
-                        Gadgetron::sum_over_dimension(ref, ref_calib, (size_t)4);
-                        Gadgetron::scal((float)(1.0 / N), ref_calib);
-                    }
-                    else
-                    {
-                        ref_calib = ref;
-                    }
-                }
-                else
-                {
-                    ref_calib = ref;
-                }
+                        for (cha = 0; cha < CHA; cha++)
+                        {
+                            for (e2 = sE2; e2 <= eE2; e2++)
+                            {
+                                for (e1 = sE1; e1 <= eE1; e1++)
+                                {
+                                    std::complex<float>* pSrc = &(ref(0, e1-sE1, e2-sE2, cha, n, s, slc));
+                                    std::complex<float>* pDst = &(ref_coil_map(0, e1, e2, cha, n, s, slc));
 
-                if (average_all_ref_S.value())
-                {
-                    if (S > 1)
-                    {
-                        hoNDArray< std::complex<float> > ref_recon_buf;
-                        Gadgetron::sum_over_dimension(ref_calib, ref_recon_buf, 5);
-                        Gadgetron::scal((float)(1.0 / S), ref_recon_buf);
-                        ref_calib = ref_recon_buf;
-                    }
-                }
-
-                hoNDArray< std::complex<float> > ref_recon_buf;
-
-                // detect sampled region in ref
-                size_t start_E1(0), end_E1(0);
-                Gadgetron::detect_sampled_region_E1(ref, start_E1, end_E1);
-
-                size_t start_E2(0), end_E2(0);
-                if (E2 > 1)
-                {
-                    Gadgetron::detect_sampled_region_E2(ref, start_E2, end_E2);
-                }
-
-                // crop the ref_calib_, along E1 and E2
-                vector_td<size_t, 3> crop_offset;
-                crop_offset[0] = sampling_limits[0].min_;
-                crop_offset[1] = start_E1;
-                crop_offset[2] = start_E2;
-
-                vector_td<size_t, 3> crop_size;
-                crop_size[0] = sampling_limits[0].max_ - sampling_limits[0].min_ + 1;
-                crop_size[1] = end_E1 - start_E1 + 1;
-                crop_size[2] = end_E2 - start_E2 + 1;
-
-                Gadgetron::crop(crop_offset, crop_size, &ref_calib, &ref_recon_buf);
-                ref_calib = ref_recon_buf;
-
-                // create filter if needed
-                if (filter_ref_coil_map)
-                {
-                    if (filter_RO_ref_coi_map_.get_size(0) != RO
-                        || filter_E1_ref_coi_map_.get_size(0) != ref_calib.get_size(1)
-                        || ((E2 > 1) && (filter_E2_ref_coi_map_.get_size(0) != ref_calib.get_size(2))))
-                    {
-                        SamplingLimit sE1;
-                        sE1.min_ = 0;
-                        sE1.max_ = (uint16_t)ref_calib.get_size(1) - 1;
-
-                        SamplingLimit sE2;
-                        sE2.min_ = 0;
-                        sE2.max_ = (uint16_t)ref_calib.get_size(2) - 1;
-
-                        Gadgetron::generate_ref_filter_for_coil_map(ref_calib, sampling_limits[0], sE1, sE2, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
+                                    memcpy(pDst + sRO, pSrc, sizeof(std::complex<float>)*(eRO - sRO + 1));
+                                }
+                            }
+                        }
                     }
                 }
+            }
 
-                // filter the ref_coil_map_
-                ref_coil_map = ref_calib;
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << encoding;
 
-                if (filter_ref_coil_map)
+                gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_before_filtering_" + os.str());
+            }
+
+            // filter the ref_coil_map
+            if (filter_RO_ref_coi_map_.get_size(0) != RO
+                || filter_E1_ref_coi_map_.get_size(0) != E1
+                || ((E2 > 1) && (filter_E2_ref_coi_map_.get_size(0) != E2)))
+            {
+                Gadgetron::generate_ref_filter_for_coil_map(ref_coil_map,
+                    recon_bit.ref_.sampling_.sampling_limits_[0], recon_bit.ref_.sampling_.sampling_limits_[1], recon_bit.ref_.sampling_.sampling_limits_[2], 
+                    filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_);
+
+                if (!debug_folder_full_path_.empty())
                 {
-                    if (E2 > 1)
-                    {
-                        Gadgetron::apply_kspace_filter_ROE1E2(ref_coil_map, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_, ref_recon_buf);
-                    }
-                    else
-                    {
-                        Gadgetron::apply_kspace_filter_ROE1(ref_coil_map, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_recon_buf);
-                    }
+                    std::stringstream os;
+                    os << "encoding_" << encoding;
 
-                    ref_coil_map = ref_recon_buf;
+                    gt_exporter_.exportArrayComplex(filter_RO_ref_coi_map_, debug_folder_full_path_ + "filter_RO_ref_coi_map_" + os.str());
+                    gt_exporter_.exportArrayComplex(filter_E1_ref_coi_map_, debug_folder_full_path_ + "filter_E1_ref_coi_map_" + os.str());
+                    gt_exporter_.exportArrayComplex(filter_E2_ref_coi_map_, debug_folder_full_path_ + "filter_E2_ref_coi_map_" + os.str());
                 }
+            }
 
-                // pad the ref_coil_map into the data array
-                Gadgetron::pad(recon_RO, recon_E1, recon_E2, &ref_coil_map, &ref_recon_buf);
-                ref_coil_map = ref_recon_buf;
+            hoNDArray< std::complex<float> > ref_recon_buf;
+
+            if (E2 > 1)
+            {
+                Gadgetron::apply_kspace_filter_ROE1E2(ref_coil_map, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, filter_E2_ref_coi_map_, ref_recon_buf);
             }
             else
             {
-                GADGET_THROW("To be implemented ... ");
+                Gadgetron::apply_kspace_filter_ROE1(ref_coil_map, filter_RO_ref_coi_map_, filter_E1_ref_coi_map_, ref_recon_buf);
+            }
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << encoding;
+
+                gt_exporter_.exportArrayComplex(ref_recon_buf, debug_folder_full_path_ + "ref_coil_map_after_filtering_" + os.str());
+            }
+
+            // pad the ref_coil_map into the data array
+            Gadgetron::pad(recon_RO, recon_E1, recon_E2, &ref_recon_buf, &ref_coil_map);
+
+            std::vector<size_t> dim;
+            ref.get_dimensions(dim);
+            ref_calib.create(dim, ref.begin());
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << encoding;
+
+                gt_exporter_.exportArrayComplex(ref_coil_map, debug_folder_full_path_ + "ref_coil_map_" + os.str());
+                gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_" + os.str());
             }
         }
         catch (...)
         {
-            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::prepare_ref(...) ... ");
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::make_ref_coil_map(...) ... ");
         }
     }
 
@@ -540,7 +557,27 @@ namespace Gadgetron {
                 Gadgetron::hoNDFFT<float>::instance()->ifft2c(recon_obj.ref_coil_map_, complex_im_recon_buf_);
             }
 
-            this->compute_coil_map(complex_im_recon_buf_, recon_obj.coil_map_);
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+
+                gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "complex_im_for_coil_map_" + os.str());
+            }
+
+            size_t ks = 7;
+            size_t kz = 5;
+            size_t power = 3;
+
+            Gadgetron::coil_map_Inati(complex_im_recon_buf_, recon_obj.coil_map_, ks, kz, power);
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+
+                gt_exporter_.exportArrayComplex(recon_obj.coil_map_, debug_folder_full_path_ + "coil_map_" + os.str());
+            }
         }
         catch (...)
         {
@@ -554,14 +591,12 @@ namespace Gadgetron {
         {
             typedef  std::complex<float> T;
 
-            if (acceFactorE1_[e] <= 1 && acceFactorE2_[e] <= 1) return;
-
             size_t RO = recon_bit.data_.data_.get_size(0);
             size_t E1 = recon_bit.data_.data_.get_size(1);
             size_t E2 = recon_bit.data_.data_.get_size(2);
 
-            hoNDArray<T>& src = recon_obj.ref_calib_;
-            hoNDArray<T>& dst = recon_obj.ref_calib_;
+            hoNDArray< std::complex<float> >& src = recon_obj.ref_calib_;
+            hoNDArray< std::complex<float> >& dst = recon_obj.ref_calib_;
 
             size_t ref_RO = src.get_size(0);
             size_t ref_E1 = src.get_size(1);
@@ -573,131 +608,139 @@ namespace Gadgetron {
 
             size_t dstCHA = dst.get_size(3);
 
-            // allocate buffer for kernels
-            size_t kRO = grappa_kSize_RO.value();
-            size_t kNE1 = grappa_kSize_E1.value();
-            size_t kNE2 = grappa_kSize_E2.value();
+            recon_obj.unmixing_coeff_.create(RO, E1, E2, srcCHA, ref_N, ref_S, ref_SLC);
+            recon_obj.gfactor_.create(RO, E1, E2, 1, ref_N, ref_S, ref_SLC);
 
-            size_t convKRO, convKE1, convKE2;
-
-            if (E2 > 1)
-            {
-                std::vector<int> kE1, oE1;
-                std::vector<int> kE2, oE2;
-                bool fitItself = true;
-
-                grappa3d_kerPattern(kE1, oE1, kE2, oE2, convKRO, convKE1, convKE2, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], kRO, kNE1, kNE2, fitItself);
-
-                recon_obj.kernel_.create(convKRO, convKE1, convKE2, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
-                recon_obj.unmixing_coeff_.create(RO, E1, E2, srcCHA, ref_N, ref_S, ref_SLC);
-                recon_obj.gfactor_.create(RO, E1, E2, 1, ref_N, ref_S, ref_SLC);
-            }
-            else
-            {
-                std::vector<int> kE1, oE1;
-                bool fitItself = true;
-
-                Gadgetron::grappa2d_kerPattern(kE1, oE1, convKRO, convKE1, (size_t)acceFactorE1_[e], kRO, kNE1, fitItself);
-
-                recon_obj.kernel_.create(convKRO, convKE1, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
-                recon_obj.kernelIm_.create(RO, E1, 1, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
-                recon_obj.unmixing_coeff_.create(RO, E1, 1, srcCHA, ref_N, ref_S, ref_SLC);
-                recon_obj.gfactor_.create(RO, E1, 1, 1, ref_N, ref_S, ref_SLC);
-            }
-
-            Gadgetron::clear(recon_obj.kernel_);
-            Gadgetron::clear(recon_obj.kernelIm_);
             Gadgetron::clear(recon_obj.unmixing_coeff_);
             Gadgetron::clear(recon_obj.gfactor_);
 
-            // estimate kernel
-
-            long long num = ref_N*ref_S*ref_SLC;
-
-            long long ii;
-
-#pragma omp parallel for default(none) private(ii) shared(src, dst, recon_obj, e, num, ref_N, ref_S, ref_RO, ref_E1, ref_E2, RO, E1, E2, dstCHA, srcCHA)
-            for (ii = 0; ii < num; ii++)
+            if (acceFactorE1_[e] <= 1 && acceFactorE2_[e] <= 1)
             {
-                size_t slc = ii / (ref_N*ref_S);
-                size_t s = (ii - slc*ref_N*ref_S) / (ref_N);
-                size_t n = ii - slc*ref_N*ref_S - s*ref_N;
+                Gadgetron::conjugate(recon_obj.ref_coil_map_, recon_obj.unmixing_coeff_);
+            }
+            else
+            {
+                // allocate buffer for kernels
+                size_t kRO = grappa_kSize_RO.value();
+                size_t kNE1 = grappa_kSize_E1.value();
+                size_t kNE2 = grappa_kSize_E2.value();
 
-                T* pSrc = &(src(0, 0, 0, 0, n, s, slc));
-                hoNDArray<T> ref_src(ref_RO, ref_E1, ref_E2, srcCHA, pSrc);
+                size_t convKRO(1), convKE1(1), convKE2(1);
 
-                T* pDst = &(dst(0, 0, 0, 0, n, s, slc));
-                hoNDArray<T> ref_dst(ref_RO, ref_E1, ref_E2, dstCHA, pDst);
+                if (E2 > 1)
+                {
+                    std::vector<int> kE1, oE1;
+                    std::vector<int> kE2, oE2;
+                    bool fitItself = true;
+                    grappa3d_kerPattern(kE1, oE1, kE2, oE2, convKRO, convKE1, convKE2, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], kRO, kNE1, kNE2, fitItself);
+                }
+                else
+                {
+                    std::vector<int> kE1, oE1;
+                    bool fitItself = true;
+                    Gadgetron::grappa2d_kerPattern(kE1, oE1, convKRO, convKE1, (size_t)acceFactorE1_[e], kRO, kNE1, fitItself);
+                    recon_obj.kernelIm_.create(RO, E1, 1, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+                }
 
-                this->perform_calib_impl(n, s, slc, e, ref_src, ref_dst, recon_obj);
+                recon_obj.kernel_.create(convKRO, convKE1, convKE2, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+
+                Gadgetron::clear(recon_obj.kernel_);
+                Gadgetron::clear(recon_obj.kernelIm_);
+
+                long long num = ref_N*ref_S*ref_SLC;
+
+                long long ii;
+
+#pragma omp parallel for default(none) private(ii) shared(src, dst, recon_obj, e, num, ref_N, ref_S, ref_RO, ref_E1, ref_E2, RO, E1, E2, dstCHA, srcCHA, convKRO, convKE1, convKE2, kRO, kNE1, kNE2)
+                for (ii = 0; ii < num; ii++)
+                {
+                    size_t slc = ii / (ref_N*ref_S);
+                    size_t s = (ii - slc*ref_N*ref_S) / (ref_N);
+                    size_t n = ii - slc*ref_N*ref_S - s*ref_N;
+
+                    std::stringstream os;
+                    os << "n" << n << "_s" << s << "_slc" << slc << "_encoding_" << e;
+                    std::string suffix = os.str();
+
+                    T* pSrc = &(src(0, 0, 0, 0, n, s, slc));
+                    hoNDArray< std::complex<float> > ref_src(ref_RO, ref_E1, ref_E2, srcCHA, pSrc);
+
+                    T* pDst = &(dst(0, 0, 0, 0, n, s, slc));
+                    hoNDArray< std::complex<float> > ref_dst(ref_RO, ref_E1, ref_E2, dstCHA, pDst);
+
+                    // -----------------------------------
+
+                    if (E2 > 1)
+                    {
+                        hoNDArray< std::complex<float> > ker(convKRO, convKE1, convKE2, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc)));
+                        Gadgetron::grappa3d_calib_convolution_kernel(ref_src, ref_dst, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], grappa_reg_lamda.value(), grappa_calib_over_determine_ratio.value(), kRO, kNE1, kNE2, ker);
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArrayComplex(ker, debug_folder_full_path_ + "convKer3D_" + suffix);
+                        }
+
+                        hoNDArray< std::complex<float> > coilMap(RO, E1, E2, dstCHA, &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc)));
+                        hoNDArray< std::complex<float> > unmixC(RO, E1, E2, srcCHA, &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc)));
+                        hoNDArray<float> gFactor(RO, E1, E2, 1, &(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc)));
+                        Gadgetron::grappa3d_unmixing_coeff(ker, coilMap, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], unmixC, gFactor);
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_3D_" + suffix);
+                        }
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_3D_" + suffix);
+                        }
+                    }
+                    else
+                    {
+                        hoNDArray< std::complex<float> > acsSrc(ref_RO, ref_E1, srcCHA, const_cast<T*>(ref_src.begin()));
+                        hoNDArray< std::complex<float> > acsDst(ref_RO, ref_E1, dstCHA, const_cast<T*>(ref_dst.begin()));
+
+                        hoNDArray< std::complex<float> > convKer(convKRO, convKE1, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc)));
+                        hoNDArray< std::complex<float> > kIm(RO, E1, srcCHA, dstCHA, &(recon_obj.kernelIm_(0, 0, 0, 0, 0, n, s, slc)));
+
+                        Gadgetron::grappa2d_calib_convolution_kernel(acsSrc, acsDst, (size_t)acceFactorE1_[e], grappa_reg_lamda.value(), kRO, kNE1, convKer);
+                        Gadgetron::grappa2d_image_domain_kernel(convKer, RO, E1, kIm);
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArrayComplex(convKer, debug_folder_full_path_ + "convKer_" + suffix);
+                        }
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArrayComplex(kIm, debug_folder_full_path_ + "kIm_" + suffix);
+                        }
+
+                        hoNDArray< std::complex<float> > coilMap(RO, E1, dstCHA, &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc)));
+                        hoNDArray< std::complex<float> > unmixC(RO, E1, srcCHA, &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc)));
+                        hoNDArray<float> gFactor;
+
+                        Gadgetron::grappa2d_unmixing_coeff(kIm, coilMap, (size_t)acceFactorE1_[e], unmixC, gFactor);
+                        memcpy(&(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc)), gFactor.begin(), gFactor.get_number_of_bytes());
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArrayComplex(unmixC, debug_folder_full_path_ + "unmixC_" + suffix);
+                        }
+
+                        if (!debug_folder_full_path_.empty())
+                        {
+                            gt_exporter_.exportArray(gFactor, debug_folder_full_path_ + "gFactor_" + suffix);
+                        }
+                    }
+
+                    // -----------------------------------
+                }
             }
         }
         catch (...)
         {
             GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_calib(...) ... ");
-        }
-    }
-
-    void GenericCartesianGrappaReconGadget::perform_calib_impl(size_t n, size_t s, size_t slc, size_t e, const hoNDArray< std::complex<float> >& src, const hoNDArray< std::complex<float> >& dst, ReconObjType& recon_obj)
-    {
-        try
-        {
-            typedef std::complex<float> T;
-
-            size_t RO = recon_obj.ref_coil_map_.get_size(0);
-            size_t E1 = recon_obj.ref_coil_map_.get_size(1);
-            size_t E2 = recon_obj.ref_coil_map_.get_size(2);
-
-            size_t ref_RO = src.get_size(0);
-            size_t ref_E1 = src.get_size(1);
-            size_t ref_E2 = src.get_size(2);
-            size_t srcCHA = src.get_size(3);
-
-            size_t dstCHA = dst.get_size(3);
-
-            // allocate buffer for kernels
-            size_t kRO = grappa_kSize_RO.value();
-            size_t kNE1 = grappa_kSize_E1.value();
-            size_t kNE2 = grappa_kSize_E2.value();
-
-            size_t convKRO = recon_obj.kernel_.get_size(0);
-            size_t convKNE1 = recon_obj.kernel_.get_size(1);
-
-            if (E2 > 1)
-            {
-                size_t convKNE2 = recon_obj.kernel_.get_size(2);
-
-                hoNDArray<T> ker(convKRO, convKNE1, convKNE2, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc)));
-                hoNDArray<T> coilMap(RO, E1, E2, dstCHA, &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc)));
-
-                hoNDArray<T> unmixC(RO, E1, E2, srcCHA, &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc)));
-                hoNDArray<float> gFactor(RO, E1, E2, 1, &(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc)));
-
-                Gadgetron::grappa3d_calib_convolution_kernel(src, dst, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], grappa_reg_lamda.value(), grappa_calib_over_determine_ratio.value(), kRO, kNE1, kNE2, ker);
-                Gadgetron::grappa3d_unmixing_coeff(ker, coilMap, (size_t)acceFactorE1_[e], (size_t)acceFactorE2_[e], unmixC, gFactor);
-            }
-            else
-            {
-                hoNDArray<T> acsSrc(ref_RO, ref_E1, srcCHA, const_cast<T*>(src.begin()));
-                hoNDArray<T> acsDst(ref_RO, ref_E1, dstCHA, const_cast<T*>(dst.begin()));
-
-                hoNDArray<T> convKer(convKRO, convKNE1, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, n, s, slc)));
-                hoNDArray<T> kIm(RO, E1, srcCHA, dstCHA, &(recon_obj.kernelIm_(0, 0, 0, 0, 0, n, s, slc)));
-                hoNDArray<T> coilMap(RO, E1, dstCHA, &(recon_obj.coil_map_(0, 0, 0, 0, n, s, slc)));
-                hoNDArray<T> unmixC(RO, E1, srcCHA, &(recon_obj.unmixing_coeff_(0, 0, 0, 0, n, s, slc)));
-
-                Gadgetron::grappa2d_calib_convolution_kernel(acsSrc, acsDst, (size_t)acceFactorE1_[e], grappa_reg_lamda.value(), kRO, kNE1, convKer);
-                Gadgetron::grappa2d_image_domain_kernel(convKer, RO, E1, kIm);
-
-                hoNDArray<float> gFactor;
-                Gadgetron::grappa2d_unmixing_coeff(kIm, coilMap, (size_t)acceFactorE1_[e], unmixC, gFactor);
-
-                memcpy(&(recon_obj.gfactor_(0, 0, 0, 0, n, s, slc)), gFactor.begin(), gFactor.get_number_of_bytes());
-            }
-        }
-        catch (...)
-        {
-            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_calib_impl(n, s, slc) ... ");
         }
     }
 
@@ -715,8 +758,8 @@ namespace Gadgetron {
             size_t S = recon_bit.data_.data_.get_size(5);
             size_t SLC = recon_bit.data_.data_.get_size(6);
 
-            hoNDArray<T>& src = recon_obj.ref_calib_;
-            hoNDArray<T>& dst = recon_obj.ref_calib_;
+            hoNDArray< std::complex<float> >& src = recon_obj.ref_calib_;
+            hoNDArray< std::complex<float> >& dst = recon_obj.ref_calib_;
 
             size_t ref_RO = src.get_size(0);
             size_t ref_E1 = src.get_size(1);
@@ -731,6 +774,14 @@ namespace Gadgetron {
             size_t convkE2 = recon_obj.kernel_.get_size(2);
 
             recon_obj.recon_res_.data_.create(RO, E1, E2, 1, N, S, SLC);
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+                std::string suffix = os.str();
+                gt_exporter_.exportArrayComplex(recon_bit.data_.data_, debug_folder_full_path_ + "data_src_" + suffix);
+            }
 
             // compute aliased images
             data_recon_buf_.create(RO, E1, E2, dstCHA, N, S, SLC);
@@ -752,186 +803,22 @@ namespace Gadgetron {
                 Gadgetron::scal(fftCompensationRatio, complex_im_recon_buf_);
             }
 
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+                std::string suffix = os.str();
+                gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "aliasedIm_" + suffix);
+            }
+
             // unwrapping
 
             long long num = N*S*SLC;
 
             long long ii;
 
-            if (effectiveAcceFactor > 1)
-            {
-                if (E2 > 1)
-                {
 #pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, E2, srcCHA, convkRO, convkE1, convkE2, ref_N, ref_S, recon_obj, dstCHA, e)
-                    {
-#pragma omp for 
-                        for (ii = 0; ii < num; ii++)
-                        {
-                            size_t slc = ii / (N*S);
-                            size_t s = (ii - slc*N*S) / N;
-                            size_t n = ii - slc*N*S - s*N;
-
-                            // combined channels
-                            T* pIm = &(complex_im_recon_buf_(0, 0, 0, 0, n, s, slc));
-                            hoNDArray<T> aliasedIm(RO, E1, E2, srcCHA, 1, pIm);
-
-                            size_t usedN = n;
-                            if (n >= ref_N) usedN = ref_N - 1;
-
-                            size_t usedS = s;
-                            if (s >= ref_S) usedS = ref_S - 1;
-
-                            T* pKer = &(recon_obj.kernel_(0, 0, 0, 0, 0, usedN, usedS, slc));
-                            hoNDArray<T> ker(convkRO, convkE1, convkE2, srcCHA, dstCHA, pKer);
-
-                            T* pUnmix = &(recon_obj.unmixing_coeff_(0, 0, 0, 0, usedN, usedS, slc));
-                            hoNDArray<T> unmixing(RO, E1, E2, srcCHA, pUnmix);
-
-                            T* pRes = &(recon_obj.recon_res_.data_(0, 0, 0, 0, n, s, slc));
-                            hoNDArray<T> res(RO, E1, E2, 1, pRes);
-
-                            Gadgetron::apply_unmix_coeff_aliased_image_3D(aliasedIm, unmixing, res);
-                        }
-                    }
-                }
-                else
-                {
-#pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, E2, srcCHA, ref_N, ref_S, recon_obj, dstCHA, e)
-                    {
-#pragma omp for 
-                        for (ii = 0; ii < num; ii++)
-                        {
-                            size_t slc = ii / (N*S);
-                            size_t s = (ii - slc*N*S) / N;
-                            size_t n = ii - slc*N*S - s*N;
-
-                            // combined channels
-                            T* pIm = &(complex_im_recon_buf_(0, 0, 0, 0, n, s, slc));
-                            hoNDArray<T> aliasedIm(RO, E1, srcCHA, pIm);
-
-                            size_t usedN = n;
-                            if (n >= ref_N) usedN = ref_N - 1;
-
-                            size_t usedS = s;
-                            if (s >= ref_S) usedS = ref_S - 1;
-
-                            T* pUnmix = &(recon_obj.unmixing_coeff_(0, 0, 0, 0, usedN, usedS, slc));
-                            hoNDArray<T> unmixing(RO, E1, srcCHA, pUnmix);
-
-                            T* pRes = &(recon_obj.recon_res_.data_(0, 0, 0, 0, n, s, slc));
-                            hoNDArray<T> res(RO, E1, 1, pRes);
-
-                            Gadgetron::apply_unmix_coeff_aliased_image(aliasedIm, unmixing, res);
-                        }
-                    }
-                }
-            }
-            else
             {
-                this->coil_combination(complex_im_recon_buf_, recon_obj.coil_map_, recon_obj.recon_res_.data_);
-            }
-        }
-        catch (...)
-        {
-            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_unwrapping(...) ... ");
-        }
-    }
-
-    void GenericCartesianGrappaReconGadget::compute_coil_map(const hoNDArray< std::complex<float> >& complexIm, hoNDArray< std::complex<float> >& coilMap)
-    {
-        try
-        {
-            typedef  std::complex<float> T;
-
-            size_t RO = complexIm.get_size(0);
-            size_t E1 = complexIm.get_size(1);
-            size_t E2 = complexIm.get_size(2);
-            size_t CHA = complexIm.get_size(3);
-
-            if (!complexIm.dimensions_equal(&coilMap))
-            {
-                coilMap = complexIm;
-            }
-
-            if (CHA <= 1)
-            {
-                GWARN_STREAM("coilMapMakerInati<T>::make_coil_map, CHA <= 1");
-                return;
-            }
-
-            size_t ks = 7;
-            size_t power = 3;
-            size_t num = complexIm.get_number_of_elements() / (RO*E1*E2*CHA);
-
-            long long n;
-
-            if (E2 > 1)
-            {
-                for (n = 0; n < (long long)num; n++)
-                {
-
-                    hoNDArray<T> im(RO, E1, E2, CHA, const_cast<T*>(complexIm.begin() + n*RO*E1*E2*CHA));
-                    hoNDArray<T> cmap(RO, E1, E2, CHA, coilMap.begin() + n*RO*E1*E2*CHA);
-
-                    Gadgetron::coil_map_3d_Inati(im, cmap, ks, power);
-                }
-            }
-            else
-            {
-#pragma omp parallel for default(none) private(n) shared(num, RO, E1, CHA, complexIm, coilMap, ks, power) if(num>8)
-                for (n = 0; n < (long long)num; n++)
-                {
-                    hoNDArray<T> im(RO, E1, CHA, const_cast<T*>(complexIm.begin()) + n*RO*E1*CHA);
-                    hoNDArray<T> cmap(RO, E1, CHA, coilMap.begin() + n*RO*E1*CHA);
-
-                    Gadgetron::coil_map_2d_Inati(im, cmap, ks, power);
-                }
-            }
-        }
-        catch (...)
-        {
-            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::compute_coil_map(...) ... ")
-        }
-    }
-
-    void GenericCartesianGrappaReconGadget::coil_combination(const hoNDArray< std::complex<float> >& complex_im, const hoNDArray< std::complex<float> >& coil_map, hoNDArray< std::complex<float> >& res)
-    {
-        try
-        {
-            size_t RO = complex_im.get_size(0);
-            size_t E1 = complex_im.get_size(1);
-            size_t E2 = complex_im.get_size(2);
-            size_t CHA = complex_im.get_size(3);
-            size_t N = complex_im.get_size(4);
-            size_t S = complex_im.get_size(5);
-            size_t SLC = complex_im.get_size(6);
-
-            size_t dstCHA = 1;
-
-            size_t coilCHA = coil_map.get_size(3);
-
-            size_t coil_N = coil_map.get_size(4);
-            size_t coil_S = coil_map.get_size(5);
-
-            typedef std::complex<float> T;
-
-            T* pIm = const_cast<T*>(complex_im.begin());
-            T* pCoilMap = const_cast<T*>(coil_map.begin());
-
-            res.create(RO, E1, E2, dstCHA, N, S, SLC);
-
-            long long num = SLC*S*N;
-
-            long long ii;
-
-#pragma omp parallel default(none) private(ii) shared(RO, E1, E2, CHA, N, S, SLC, coilCHA, dstCHA, num, coil_N, coil_S, pIm, pCoilMap, res) if(num>8)
-            {
-                hoNDArray<T> dataBuf;
-                dataBuf.create(RO, E1, E2, coilCHA);
-
-                hoNDArray<T> dataBufCombined;
-                dataBufCombined.create(RO, E1, E2, 1);
-
 #pragma omp for 
                 for (ii = 0; ii < num; ii++)
                 {
@@ -939,25 +826,40 @@ namespace Gadgetron {
                     size_t s = (ii - slc*N*S) / N;
                     size_t n = ii - slc*N*S - s*N;
 
-                    size_t ns = s;
-                    if (ns >= coil_S) ns = coil_S - 1;
+                    // combined channels
+                    T* pIm = &(complex_im_recon_buf_(0, 0, 0, 0, n, s, slc));
+                    hoNDArray< std::complex<float> > aliasedIm(RO, E1, E2, srcCHA, 1, pIm);
 
-                    size_t nn = n;
-                    if (nn >= coil_N) nn = coil_N - 1;
+                    size_t usedN = n;
+                    if (n >= ref_N) usedN = ref_N - 1;
 
-                    hoNDArray<T> imCurr(RO, E1, E2, CHA, pIm + slc*RO*E1*E2*CHA*N*S + s*RO*E1*E2*CHA*N + n*RO*E1*E2*CHA);
-                    hoNDArray<T> coilMapCurr(RO, E1, E2, CHA, pCoilMap + slc*RO*E1*E2*CHA*coil_N*coil_S + ns*RO*E1*E2*CHA*coil_N + nn*RO*E1*E2*CHA);
+                    size_t usedS = s;
+                    if (s >= ref_S) usedS = ref_S - 1;
 
-                    Gadgetron::multiplyConj(imCurr, coilMapCurr, dataBuf);
-                    Gadgetron::sum_over_dimension(dataBuf, dataBufCombined, 3);
+                    T* pKer = &(recon_obj.kernel_(0, 0, 0, 0, 0, usedN, usedS, slc));
+                    hoNDArray< std::complex<float> > ker(convkRO, convkE1, convkE2, srcCHA, dstCHA, pKer);
 
-                    memcpy(res.begin() + slc*RO*E1*E2*dstCHA*N*S + s*RO*E1*E2*dstCHA*N + n*RO*E1*E2*dstCHA, dataBufCombined.begin(), sizeof(T)*RO*E1*E2);
+                    T* pUnmix = &(recon_obj.unmixing_coeff_(0, 0, 0, 0, usedN, usedS, slc));
+                    hoNDArray< std::complex<float> > unmixing(RO, E1, E2, srcCHA, pUnmix);
+
+                    T* pRes = &(recon_obj.recon_res_.data_(0, 0, 0, 0, n, s, slc));
+                    hoNDArray< std::complex<float> > res(RO, E1, E2, 1, pRes);
+
+                    Gadgetron::apply_unmix_coeff_aliased_image_3D(aliasedIm, unmixing, res);
                 }
+            }
+
+            if (!debug_folder_full_path_.empty())
+            {
+                std::stringstream os;
+                os << "encoding_" << e;
+                std::string suffix = os.str();
+                gt_exporter_.exportArrayComplex(recon_obj.recon_res_.data_, debug_folder_full_path_ + "unwrappedIm_" + suffix);
             }
         }
         catch (...)
         {
-            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::coil_combination(complex_im) ... ");
+            GADGET_THROW("Errors happened in GenericCartesianGrappaReconGadget::perform_unwrapping(...) ... ");
         }
     }
 

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
@@ -55,11 +55,8 @@ namespace Gadgetron {
     {
     public:
 
-        GenericCartesianGrappaReconObj();
-        GenericCartesianGrappaReconObj(const GenericCartesianGrappaReconObj<T>& v);
-        virtual ~GenericCartesianGrappaReconObj();
-
-        GenericCartesianGrappaReconObj<T>& operator=(const GenericCartesianGrappaReconObj<T>& v);
+        GenericCartesianGrappaReconObj() {}
+        virtual ~GenericCartesianGrappaReconObj() {}
 
         // ------------------------------------
         /// recon outputs
@@ -79,15 +76,6 @@ namespace Gadgetron {
         /// reference data ready for coil map estimation
         /// [RO E1 E2 CHA Nor1 Sor1 SLC]
         hoNDArray<T> ref_coil_map_;
-
-        /// ref calibration array in dst channels
-        hoNDArray<T> ref_calib_dst_;
-
-        /// kspace data in dst channel
-        hoNDArray<T> data_dst_;
-
-        /// ref coil map array in dst channel
-        hoNDArray<T> ref_coil_map_dst_;
 
         /// for combined imgae channel
         /// convolution kernel, [RO E1 E2 srcCHA - uncombinedCHA dstCHA - uncombinedCHA Nor1 Sor1 SLC]
@@ -201,9 +189,6 @@ namespace Gadgetron {
         virtual int process_config(ACE_Message_Block* mb);
         virtual int process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1);
 
-        // close call
-        int close(unsigned long flags);
-
         // --------------------------------------------------
         // recon step functions
         // --------------------------------------------------
@@ -217,9 +202,6 @@ namespace Gadgetron {
         // this may be the most complicated part of the whole recon
         // for every calibration mode, the ref is prepared accordingly
         virtual void prepare_ref(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
-
-        // generate the destination channel
-        virtual void generate_downstream_dst_channel(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
 
         // estimate coil map
         virtual void perform_coil_map_estimation(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
@@ -1,0 +1,281 @@
+/** \file   GenericCartesianGrappaReconGadget.h
+    \brief  This is the class gadget for both 2DT and 3DT cartesian grappa and grappaone reconstruction, working on the IsmrmrdReconData.
+
+            This class implements a general cartesian recon chain: 
+
+            Kspace -------------------------------------------------------> (padding for squared pixel recon)
+            Ref                                                                           |
+            |-> (padding for squared pixel recon)                                         |
+                  |-> ref preparation for embedded/separate/interleaved modes             |
+                        |-> coil compression                                              |
+                              |-> calibration ---------------------------------------------> coil combination -> PF handling (GenericReconPartialFourierHandlingGadget)
+                                                                                                                  |-> kspace filter (GenericReconKSpaceFilteringGadget)
+                                                                                                                        |-> FOV adjustment and image resizing (GenericReconFieldOfViewAdjustmentGadget)
+                                                                                                                             |-> Image array scaling (ImageArrayScalingGadget)
+
+            The input is IsmrmrdReconData and output is single 2D or 3D ISMRMRD images
+
+            If required, the gfactor map can be sent out
+
+            If the  number of required destination channel is 1, the GrappaONE recon will be performed
+
+            The image number computation logic is implemented in compute_image_number function, which can be overloaded
+
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include <complex>
+#include "gadgetron_mricore_export.h"
+#include "Gadget.h"
+#include "hoNDArray.h"
+#include "ismrmrd/ismrmrd.h"
+#include "ismrmrd/xml.h"
+#include "ismrmrd/meta.h"
+#include "GadgetronTimer.h"
+
+#include "hoNDArray_utils.h"
+
+#include "gtPlusIOAnalyze.h"
+
+#include "GadgetStreamController.h"
+
+#include "hoNDArray_utils.h"
+#include "hoNDArray_elemwise.h"
+#include "hoNDFFT.h"
+
+#include "mri_core_data.h"
+#include "mri_core_utility.h"
+#include "mri_core_coil_map_estimation.h"
+
+namespace Gadgetron {
+
+    /// define the recon status of GenericCartesianGrappaRecon
+    template <typename T>
+    class EXPORTGADGETSMRICORE GenericCartesianGrappaReconObj
+    {
+    public:
+
+        GenericCartesianGrappaReconObj();
+        GenericCartesianGrappaReconObj(const GenericCartesianGrappaReconObj<T>& v);
+        virtual ~GenericCartesianGrappaReconObj();
+
+        GenericCartesianGrappaReconObj<T>& operator=(const GenericCartesianGrappaReconObj<T>& v);
+
+        // ------------------------------------
+        /// recon outputs
+        // ------------------------------------
+        /// reconstructed images, headers and meta attributes
+        IsmrmrdImageArray recon_res_;
+
+        /// gfactor, [RO E1 E2 uncombinedCHA+1 N S SLC]
+        hoNDArray<typename realType<T>::Type> gfactor_;
+
+        // ------------------------------------
+        /// buffers used in the recon
+        // ------------------------------------
+        /// [RO E1 E2 CHA Nor1 Sor1 SLC]
+        hoNDArray<T> ref_calib_;
+
+        /// reference data ready for coil map estimation
+        /// [RO E1 E2 CHA Nor1 Sor1 SLC]
+        hoNDArray<T> ref_coil_map_;
+
+        /// ref calibration array in dst channels
+        hoNDArray<T> ref_calib_dst_;
+
+        /// kspace data in dst channel
+        hoNDArray<T> data_dst_;
+
+        /// ref coil map array in dst channel
+        hoNDArray<T> ref_coil_map_dst_;
+
+        /// for combined imgae channel
+        /// convolution kernel, [RO E1 E2 srcCHA - uncombinedCHA dstCHA - uncombinedCHA Nor1 Sor1 SLC]
+        hoNDArray<T> kernel_;
+        /// image domain kernel, [RO E1 E2 srcCHA - uncombinedCHA dstCHA - uncombinedCHA Nor1 Sor1 SLC]
+        hoNDArray<T> kernelIm_;
+        /// image domain unmixing coefficients, [RO E1 E2 srcCHA - uncombinedCHA Nor1 Sor1 SLC]
+        hoNDArray<T> unmixing_coeff_;
+
+        /// coil sensitivity map, [RO E1 E2 dstCHA - uncombinedCHA Nor1 Sor1 SLC]
+        hoNDArray<T> coil_map_;
+    };
+}
+
+namespace Gadgetron {
+
+    class EXPORTGADGETSMRICORE GenericCartesianGrappaReconGadget : public Gadget1<IsmrmrdReconData>
+    {
+    public:
+        GADGET_DECLARE(GenericCartesianGrappaReconGadget);
+
+        typedef Gadget1<IsmrmrdReconData> BaseClass;
+        typedef Gadgetron::GenericCartesianGrappaReconObj< std::complex<float> > ReconObjType;
+
+        GenericCartesianGrappaReconGadget();
+        ~GenericCartesianGrappaReconGadget();
+
+        /// ------------------------------------------------------------------------------------
+        /// parameters to control the reconstruction
+        /// ------------------------------------------------------------------------------------
+
+        /// image series
+        GADGET_PROPERTY(image_series, int, "Image series number", 0);
+
+        /// ------------------------------------------------------------------------------------
+        /// debug and timing
+        GADGET_PROPERTY(verbose, bool, "Whether to print more information", false);
+        GADGET_PROPERTY(debug_folder, std::string, "If set, the debug output will be written out", "");
+        GADGET_PROPERTY(perform_timing, bool, "Whether to perform timing on some computational steps", false);
+
+        /// ------------------------------------------------------------------------------------
+        /// image sending
+        GADGET_PROPERTY(send_out_gfactor, bool, "Whether to send out gfactor map", false);
+        GADGET_PROPERTY(send_out_snr_map, bool, "Whether to send out SNR map", false);
+
+        /// ------------------------------------------------------------------------------------
+        /// ref preparation
+        /// whether to average all N for ref generation
+        GADGET_PROPERTY(average_all_ref_N, bool, "Whether to average all N for ref generation", true);
+        /// whether to average all S for ref generation
+        GADGET_PROPERTY(average_all_ref_S, bool, "Whether to average all S for ref generation", false);
+
+        /// ------------------------------------------------------------------------------------
+        /// Grappa parameters
+        GADGET_PROPERTY(grappa_kSize_RO, int, "Grappa kernel size RO", 5);
+        GADGET_PROPERTY(grappa_kSize_E1, int, "Grappa kernel size E1", 4);
+        GADGET_PROPERTY(grappa_kSize_E2, int, "Grappa kernel size E2", 4);
+        GADGET_PROPERTY(grappa_reg_lamda, double, "Grappa regularization threshold", 0.0005);
+        GADGET_PROPERTY(grappa_calib_over_determine_ratio, double, "Grappa calibration overdermination ratio", 45);
+
+    protected:
+
+        // --------------------------------------------------
+        // variables for protocol
+        // --------------------------------------------------
+
+        // number of encoding spaces in the protocol
+        size_t num_encoding_spaces_;
+
+        // for every encoding space
+
+        // acceleration factor for E1 and E2
+        std::vector<double> acceFactorE1_;
+        std::vector<double> acceFactorE2_;
+
+        // calibration mode
+        std::vector<Gadgetron::ismrmrdCALIBMODE> calib_mode_;
+
+        // encoding space limits
+        std::vector<ISMRMRD::EncodingCounters> meas_max_idx_;
+
+        // --------------------------------------------------
+        // variable for recon
+        // --------------------------------------------------
+        // record the recon kernel, coil maps etc. for every encoding space
+        std::vector< ReconObjType > recon_obj_;
+
+        // number of times the process function is called
+        size_t process_called_times_;
+
+        /// buffers used during recon
+        hoNDArray< std::complex<float> > complex_im_recon_buf_;
+        hoNDArray< std::complex<float> > data_recon_buf_;
+
+        // filter used for ref coil map 
+        hoNDArray< std::complex<float> > filter_RO_ref_coi_map_;
+        hoNDArray< std::complex<float> > filter_E1_ref_coi_map_;
+        hoNDArray< std::complex<float> > filter_E2_ref_coi_map_;
+
+        // --------------------------------------------------
+        // variables for debug and timing
+        // --------------------------------------------------
+
+        // debug folder
+        std::string debug_folder_full_path_;
+
+        // clock for timing
+        Gadgetron::GadgetronTimer gt_timer1_;
+        Gadgetron::GadgetronTimer gt_timer2_;
+        Gadgetron::GadgetronTimer gt_timer3_;
+
+        // exporter
+        Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
+
+        // in verbose mode, more info is printed out
+        bool verbose_;
+
+        // --------------------------------------------------
+        // gadget functions
+        // --------------------------------------------------
+        // default interface function
+        virtual int process_config(ACE_Message_Block* mb);
+        virtual int process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1);
+
+        // close call
+        int close(unsigned long flags);
+
+        // --------------------------------------------------
+        // recon step functions
+        // --------------------------------------------------
+
+        // recon chain
+        // prepare recon
+        // if the squared pixel recon if prescribed, the new recon image size to ensure squared pixel will be computed
+        // if needed, the incoming data matrix will be padded and ref_preparer_ recon size will be updated
+        // then all recon components will be set with updated parameters
+        // finally, the consistency of this recon will be checked; if necessary, changes will be made to ensure the parameter consistency
+        virtual void prepare_recon(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // prepare the ref data
+        // this may be the most complicated part of the whole recon
+        // for every calibration mode, the ref is prepared accordingly
+        virtual void prepare_ref(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // generate the destination channel
+        virtual void generate_downstream_dst_channel(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // estimate coil map
+        virtual void perform_coil_map_estimation(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        /// complexIm: [RO E1 E2 CHA ...]
+        /// if E2 == 1, the 2D coil map estimation will be assumed
+        virtual void compute_coil_map(const hoNDArray< std::complex<float> >& complexIm, hoNDArray< std::complex<float> >& coilMap);
+
+        // calibration, if only one dst channel is prescribed, the GrappaOne is used
+        virtual void perform_calib(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // unwrapping or coil combination
+        virtual void perform_unwrapping(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // compute image header
+        virtual void compute_image_header(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // send out the recon results
+        virtual int send_out_image_array(IsmrmrdReconBit& recon_bit, IsmrmrdImageArray& res, size_t encoding, int series_num, const std::string& data_role);
+
+        // --------------------------------------------------
+        // implementation functions
+        // --------------------------------------------------
+
+        // perform one calibration
+        virtual void perform_calib_impl(size_t n, size_t s, size_t slc, size_t e, const hoNDArray< std::complex<float> >& src, const hoNDArray< std::complex<float> >& dst, ReconObjType& recon_obj);
+
+        // perform coil combination with uncombined channels
+        // complex_im: [RO E1 E2 CHA N S SLC]
+        // coil_map: [RO E1 E2 CHA-unCHA Nor1 Sor1 SLC]
+        // res: [RO E1 E2 unCHA+1 N S SLC]
+        void coil_combination(const hoNDArray< std::complex<float> >& complex_im, const hoNDArray< std::complex<float> >& coil_map, hoNDArray< std::complex<float> >& res);
+
+        // --------------------------------------------------
+        // utility functions
+        // --------------------------------------------------
+        void get_current_moment(std::string& procTime);
+        void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath);
+
+        // compute image number
+        virtual size_t compute_image_number(ISMRMRD::ImageHeader& imheader, size_t encoding = 0, size_t CHA = 1, size_t cha = 0, size_t E2 = 1);
+    };
+}

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
@@ -37,8 +37,6 @@
 
 #include "hoNDArray_utils.h"
 
-#include "gtPlusIOAnalyze.h"
-
 #include "GadgetStreamController.h"
 
 #include "hoNDArray_utils.h"
@@ -193,17 +191,6 @@ namespace Gadgetron {
         // variables for debug and timing
         // --------------------------------------------------
 
-        // debug folder
-        std::string debug_folder_full_path_;
-
-        // clock for timing
-        Gadgetron::GadgetronTimer gt_timer1_;
-        Gadgetron::GadgetronTimer gt_timer2_;
-        Gadgetron::GadgetronTimer gt_timer3_;
-
-        // exporter
-        Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
-
         // in verbose mode, more info is printed out
         bool verbose_;
 
@@ -221,13 +208,10 @@ namespace Gadgetron {
         // recon step functions
         // --------------------------------------------------
 
-        // recon chain
-        // prepare recon
-        // if the squared pixel recon if prescribed, the new recon image size to ensure squared pixel will be computed
-        // if needed, the incoming data matrix will be padded and ref_preparer_ recon size will be updated
-        // then all recon components will be set with updated parameters
-        // finally, the consistency of this recon will be checked; if necessary, changes will be made to ensure the parameter consistency
-        virtual void prepare_recon(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+        // ensure the recon image to have squared pixel, therefore zero-=padding resizing is not needed for E1
+        // TODO: consider extend this to E2 as well
+        // if needed, the incoming data matrix will be padded
+        virtual void ensure_recon_size(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
 
         // prepare the ref data
         // this may be the most complicated part of the whole recon
@@ -239,10 +223,6 @@ namespace Gadgetron {
 
         // estimate coil map
         virtual void perform_coil_map_estimation(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
-
-        /// complexIm: [RO E1 E2 CHA ...]
-        /// if E2 == 1, the 2D coil map estimation will be assumed
-        virtual void compute_coil_map(const hoNDArray< std::complex<float> >& complexIm, hoNDArray< std::complex<float> >& coilMap);
 
         // calibration, if only one dst channel is prescribed, the GrappaOne is used
         virtual void perform_calib(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
@@ -260,6 +240,10 @@ namespace Gadgetron {
         // implementation functions
         // --------------------------------------------------
 
+        /// complexIm: [RO E1 E2 CHA ...]
+        /// if E2 == 1, the 2D coil map estimation will be assumed
+        virtual void compute_coil_map(const hoNDArray< std::complex<float> >& complexIm, hoNDArray< std::complex<float> >& coilMap);
+
         // perform one calibration
         virtual void perform_calib_impl(size_t n, size_t s, size_t slc, size_t e, const hoNDArray< std::complex<float> >& src, const hoNDArray< std::complex<float> >& dst, ReconObjType& recon_obj);
 
@@ -272,9 +256,6 @@ namespace Gadgetron {
         // --------------------------------------------------
         // utility functions
         // --------------------------------------------------
-        void get_current_moment(std::string& procTime);
-        void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath);
-
         // compute image number
         virtual size_t compute_image_number(ISMRMRD::ImageHeader& imheader, size_t encoding = 0, size_t CHA = 1, size_t cha = 0, size_t E2 = 1);
     };

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.h
@@ -16,7 +16,7 @@
 
 #include "hoNDArray_utils.h"
 
-#include "gtPlusIOAnalyze.h"
+// #include "gtPlusIOAnalyze.h"
 
 #include "GadgetStreamController.h"
 
@@ -163,15 +163,15 @@ namespace Gadgetron {
         // in verbose mode, more info is printed out
         bool verbose_;
 
-        // debug folder
-        std::string debug_folder_full_path_;
+        //// debug folder
+        //std::string debug_folder_full_path_;
 
         // clock for timing
         Gadgetron::GadgetronTimer gt_timer_local_;
         Gadgetron::GadgetronTimer gt_timer_;
 
-        // exporter
-        Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
+        //// exporter
+        //Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
 
         // --------------------------------------------------
         // gadget functions

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
@@ -1,0 +1,301 @@
+
+#include "GenericCartesianReconReferencePrepGadget.h"
+#include <iomanip>
+
+#include "hoNDArray_reductions.h"
+#include "mri_core_def.h"
+
+namespace Gadgetron {
+
+    GenericCartesianReconReferencePrepGadget::GenericCartesianReconReferencePrepGadget() : num_encoding_spaces_(1), process_called_times_(0)
+    {
+        gt_timer_.set_timing_in_destruction(false);
+        gt_timer_local_.set_timing_in_destruction(false);
+    }
+
+    GenericCartesianReconReferencePrepGadget::~GenericCartesianReconReferencePrepGadget()
+    {
+    }
+
+    int GenericCartesianReconReferencePrepGadget::process_config(ACE_Message_Block* mb)
+    {
+        ISMRMRD::IsmrmrdHeader h;
+        try
+        {
+            deserialize(mb->rd_ptr(), h);
+        }
+        catch (...)
+        {
+            GDEBUG("Error parsing ISMRMRD Header");
+        }
+
+        if (!h.acquisitionSystemInformation)
+        {
+            GDEBUG("acquisitionSystemInformation not found in header. Bailing out");
+            return GADGET_FAIL;
+        }
+
+        // -------------------------------------------------
+
+        size_t NE = h.encoding.size();
+        num_encoding_spaces_ = NE;
+        GDEBUG_CONDITION_STREAM(verbose.value(), "Number of encoding spaces: " << NE);
+
+        calib_mode_.resize(NE, ISMRMRD_noacceleration);
+
+        size_t e;
+        for (e = 0; e < h.encoding.size(); e++)
+        {
+            ISMRMRD::EncodingSpace e_space = h.encoding[e].encodedSpace;
+            ISMRMRD::EncodingSpace r_space = h.encoding[e].reconSpace;
+            ISMRMRD::EncodingLimits e_limits = h.encoding[e].encodingLimits;
+
+            GDEBUG_CONDITION_STREAM(verbose.value(), "---> Encoding space : " << e << " <---");
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Encoding matrix size: " << e_space.matrixSize.x << " " << e_space.matrixSize.y << " " << e_space.matrixSize.z);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Encoding field_of_view : " << e_space.fieldOfView_mm.x << " " << e_space.fieldOfView_mm.y << " " << e_space.fieldOfView_mm.z);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Recon matrix size : " << r_space.matrixSize.x << " " << r_space.matrixSize.y << " " << r_space.matrixSize.z);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Recon field_of_view :  " << r_space.fieldOfView_mm.x << " " << r_space.fieldOfView_mm.y << " " << r_space.fieldOfView_mm.z);
+
+            if (!h.encoding[e].parallelImaging)
+            {
+                GDEBUG("Parallel Imaging section not found in header");
+                return GADGET_FAIL;
+            }
+
+            ISMRMRD::ParallelImaging p_imaging = *h.encoding[0].parallelImaging;
+            GDEBUG_CONDITION_STREAM(verbose.value(), "acceFactorE1 is " << p_imaging.accelerationFactor.kspace_encoding_step_1);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "acceFactorE2 is " << p_imaging.accelerationFactor.kspace_encoding_step_2);
+
+            std::string calib = *p_imaging.calibrationMode;
+
+            bool separate = (calib.compare("separate") == 0);
+            bool embedded = (calib.compare("embedded") == 0);
+            bool external = (calib.compare("external") == 0);
+            bool interleaved = (calib.compare("interleaved") == 0);
+            bool other = (calib.compare("other") == 0);
+
+            calib_mode_[e] = Gadgetron::ISMRMRD_noacceleration;
+            if (p_imaging.accelerationFactor.kspace_encoding_step_1 > 1 || p_imaging.accelerationFactor.kspace_encoding_step_2 > 1)
+            {
+                if (interleaved)
+                    calib_mode_[e] = Gadgetron::ISMRMRD_interleaved;
+                else if (embedded)
+                    calib_mode_[e] = Gadgetron::ISMRMRD_embedded;
+                else if (separate)
+                    calib_mode_[e] = Gadgetron::ISMRMRD_separate;
+                else if (external)
+                    calib_mode_[e] = Gadgetron::ISMRMRD_external;
+                else if (other)
+                    calib_mode_[e] = Gadgetron::ISMRMRD_other;
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+
+        if (!debug_folder.value().empty())
+        {
+            Gadgetron::get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
+        }
+        else
+        {
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is not set ... ");
+        }
+
+        return GADGET_OK;
+    }
+
+    int GenericCartesianReconReferencePrepGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1)
+    {
+        process_called_times_++;
+
+        IsmrmrdReconData* recon_bit_ = m1->getObjectPtr();
+        if (recon_bit_->rbit_.size() > num_encoding_spaces_)
+        {
+            GWARN_STREAM("Incoming recon_bit has more encoding spaces than the protocol : " << recon_bit_->rbit_.size() << " instead of " << num_encoding_spaces_);
+        }
+
+        // for every encoding space, prepare the recon_bit_->rbit_[e].ref_
+        size_t e;
+        for (e = 0; e < recon_bit_->rbit_.size(); e++)
+        {
+            std::stringstream os;
+            os << "_encoding_" << e;
+
+            // -----------------------------------------
+            // no acceleration mode
+            // check the availability of ref data
+            // -----------------------------------------
+            if (calib_mode_[e] == Gadgetron::ISMRMRD_noacceleration)
+            {
+                // if no ref data is set, make the ref point to the  data
+                if (recon_bit_->rbit_[e].ref_.data_.get_number_of_elements() == 0)
+                {
+                    std::vector<size_t> dim;
+                    recon_bit_->rbit_[e].data_.data_.get_dimensions(dim);
+                    recon_bit_->rbit_[e].ref_.data_.create(dim, recon_bit_->rbit_[e].data_.data_.begin());
+
+                    if (recon_bit_->rbit_[e].data_.trajectory_.get_number_of_elements() > 0)
+                    {
+                        recon_bit_->rbit_[e].data_.trajectory_.get_dimensions(dim);
+                        recon_bit_->rbit_[e].ref_.trajectory_.create(dim, recon_bit_->rbit_[e].data_.trajectory_.begin());
+                    }
+
+                    recon_bit_->rbit_[e].ref_.headers_ = recon_bit_->rbit_[e].data_.headers_;
+                    recon_bit_->rbit_[e].ref_.sampling_ = recon_bit_->rbit_[e].data_.sampling_;
+                }
+            }
+
+            if (recon_bit_->rbit_[e].ref_.data_.get_number_of_elements() == 0)
+            {
+                continue;
+            }
+
+            // useful variables
+            hoNDArray< std::complex<float> >& ref = recon_bit_->rbit_[e].ref_.data_;
+
+            SamplingLimit sampling_limits[3];
+            sampling_limits[0] = recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[0];
+            sampling_limits[1] = recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[1];
+            sampling_limits[2] = recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[2];
+
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+            size_t N = ref.get_size(4);
+            size_t S = ref.get_size(5);
+
+            // stored the ref data ready for calibration
+            hoNDArray< std::complex<float> > ref_calib;
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref" + os.str());
+            }
+
+            if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].ref_.trajectory_.get_number_of_elements() > 0)
+            {
+                gt_exporter_.exportArray(recon_bit_->rbit_[e].ref_.trajectory_, debug_folder_full_path_ + "ref_traj" + os.str());
+            }
+
+            // -----------------------------------------
+            // 1) average the ref according to the input parameters; 
+            //    TODO: if interleaved mode, need to detect sampling times for every E1/E2 location
+            // 2) detect the sampled region and crop the ref data if needed
+            // 3) update the sampling_limits
+            // -----------------------------------------
+
+            hoNDArray< std::complex<float> > ref_recon_buf;
+
+            // step 1
+            if (average_all_ref_N.value())
+            {
+                if (N > 1)
+                {
+                    Gadgetron::sum_over_dimension(ref, ref_calib, (size_t)4);
+                    Gadgetron::scal((float)(1.0 / N), ref_calib);
+                }
+                else
+                {
+                    ref_calib = ref;
+                }
+            }
+            else
+            {
+                ref_calib = ref;
+            }
+
+            if (average_all_ref_S.value())
+            {
+                if (S > 1)
+                {
+                    Gadgetron::sum_over_dimension(ref_calib, ref_recon_buf, 5);
+                    Gadgetron::scal((float)(1.0 / S), ref_recon_buf);
+                    ref_calib = ref_recon_buf;
+                }
+            }
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_after_averaging" + os.str());
+            }
+
+            // step 2, detect sampled region in ref, along E1 and E2
+            size_t start_E1(0), end_E1(0);
+            Gadgetron::detect_sampled_region_E1(ref, start_E1, end_E1);
+
+            size_t start_E2(0), end_E2(0);
+            if (E2 > 1)
+            {
+                Gadgetron::detect_sampled_region_E2(ref, start_E2, end_E2);
+            }
+
+            // crop the ref_calib, along RO, E1 and E2
+            vector_td<size_t, 3> crop_offset;
+            crop_offset[0] = sampling_limits[0].min_;
+            crop_offset[1] = start_E1;
+            crop_offset[2] = start_E2;
+
+            vector_td<size_t, 3> crop_size;
+            crop_size[0] = sampling_limits[0].max_ - sampling_limits[0].min_ + 1;
+            crop_size[1] = end_E1 - start_E1 + 1;
+            crop_size[2] = end_E2 - start_E2 + 1;
+
+            Gadgetron::crop(crop_offset, crop_size, &ref_calib, &ref_recon_buf);
+            ref_calib = ref_recon_buf;
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_after_cropping" + os.str());
+            }
+
+            // step 3, update the sampling limits
+            sampling_limits[0].center_ = RO/2;
+
+            if ( (calib_mode_[e] == Gadgetron::ISMRMRD_interleaved) || (calib_mode_[e] == Gadgetron::ISMRMRD_noacceleration) )
+            {
+                // need to keep the ref kspace center information
+                sampling_limits[1].min_ = start_E1;
+                sampling_limits[1].max_ = end_E1;
+
+                sampling_limits[2].min_ = start_E2;
+                sampling_limits[2].max_ = end_E2;
+
+                sampling_limits[1].center_ = E1 / 2;
+                sampling_limits[2].center_ = E2 / 2;
+            }
+            else
+            {
+                // sepearate, embedded mode, the ref center is the kspace center
+                sampling_limits[1].min_ = 0;
+                sampling_limits[1].max_ = end_E1 - start_E1;
+
+                sampling_limits[2].min_ = 0;
+                sampling_limits[2].max_ = end_E2 - start_E2;
+
+                sampling_limits[1].center_ = (sampling_limits[1].max_ + 1) / 2;
+                sampling_limits[2].center_ = (sampling_limits[2].max_ + 1) / 2;
+            }
+
+            ref = ref_calib;
+            recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[0] = sampling_limits[0];
+            recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[1] = sampling_limits[1];
+            recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[2] = sampling_limits[2];
+
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref_after_prep" + os.str());
+            }
+        }
+
+        if (this->next()->putq(m1) < 0)
+        {
+            GERROR_STREAM("Put IsmrmrdReconData to Q failed ... ");
+            return GADGET_FAIL;
+        }
+
+        return GADGET_OK;
+    }
+
+    GADGET_FACTORY_DECLARE(GenericCartesianReconReferencePrepGadget)
+}

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
@@ -222,12 +222,16 @@ namespace Gadgetron {
 
             // step 2, detect sampled region in ref, along E1 and E2
             size_t start_E1(0), end_E1(0);
-            Gadgetron::detect_sampled_region_E1(ref, start_E1, end_E1);
+            auto t = Gadgetron::detect_sampled_region_E1(ref);
+            start_E1 = std::get<0>(t);
+            end_E1 = std::get<1>(t);
 
             size_t start_E2(0), end_E2(0);
             if (E2 > 1)
             {
-                Gadgetron::detect_sampled_region_E2(ref, start_E2, end_E2);
+                auto t = Gadgetron::detect_sampled_region_E2(ref);
+                start_E2 = std::get<0>(t);
+                end_E2 = std::get<1>(t);
             }
 
             // crop the ref_calib, along RO, E1 and E2
@@ -250,28 +254,28 @@ namespace Gadgetron {
             }*/
 
             // step 3, update the sampling limits
-            sampling_limits[0].center_ = RO/2;
+            sampling_limits[0].center_ = (uint16_t)(RO/2);
 
             if ( (calib_mode_[e] == Gadgetron::ISMRMRD_interleaved) || (calib_mode_[e] == Gadgetron::ISMRMRD_noacceleration) )
             {
                 // need to keep the ref kspace center information
-                sampling_limits[1].min_ = start_E1;
-                sampling_limits[1].max_ = end_E1;
+                sampling_limits[1].min_ = (uint16_t)(start_E1);
+                sampling_limits[1].max_ = (uint16_t)(end_E1);
 
-                sampling_limits[2].min_ = start_E2;
-                sampling_limits[2].max_ = end_E2;
+                sampling_limits[2].min_ = (uint16_t)(start_E2);
+                sampling_limits[2].max_ = (uint16_t)(end_E2);
 
-                sampling_limits[1].center_ = E1 / 2;
-                sampling_limits[2].center_ = E2 / 2;
+                sampling_limits[1].center_ = (uint16_t)(E1 / 2);
+                sampling_limits[2].center_ = (uint16_t)(E2 / 2);
             }
             else
             {
                 // sepearate, embedded mode, the ref center is the kspace center
                 sampling_limits[1].min_ = 0;
-                sampling_limits[1].max_ = end_E1 - start_E1;
+                sampling_limits[1].max_ = (uint16_t)(end_E1 - start_E1);
 
                 sampling_limits[2].min_ = 0;
-                sampling_limits[2].max_ = end_E2 - start_E2;
+                sampling_limits[2].max_ = (uint16_t)(end_E2 - start_E2);
 
                 sampling_limits[1].center_ = (sampling_limits[1].max_ + 1) / 2;
                 sampling_limits[2].center_ = (sampling_limits[2].max_ + 1) / 2;

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
@@ -92,7 +92,7 @@ namespace Gadgetron {
 
         // ---------------------------------------------------------------------------------------------------------
 
-        if (!debug_folder.value().empty())
+        /*if (!debug_folder.value().empty())
         {
             Gadgetron::get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
             GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
@@ -100,7 +100,7 @@ namespace Gadgetron {
         else
         {
             GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is not set ... ");
-        }
+        }*/
 
         return GADGET_OK;
     }
@@ -168,7 +168,7 @@ namespace Gadgetron {
             // stored the ref data ready for calibration
             hoNDArray< std::complex<float> > ref_calib;
 
-            if (!debug_folder_full_path_.empty())
+            /*if (!debug_folder_full_path_.empty())
             {
                 gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref" + os.str());
             }
@@ -176,7 +176,7 @@ namespace Gadgetron {
             if (!debug_folder_full_path_.empty() && recon_bit_->rbit_[e].ref_.trajectory_.get_number_of_elements() > 0)
             {
                 gt_exporter_.exportArray(recon_bit_->rbit_[e].ref_.trajectory_, debug_folder_full_path_ + "ref_traj" + os.str());
-            }
+            }*/
 
             // -----------------------------------------
             // 1) average the ref according to the input parameters; 
@@ -215,10 +215,10 @@ namespace Gadgetron {
                 }
             }
 
-            if (!debug_folder_full_path_.empty())
+            /*if (!debug_folder_full_path_.empty())
             {
                 gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_after_averaging" + os.str());
-            }
+            }*/
 
             // step 2, detect sampled region in ref, along E1 and E2
             size_t start_E1(0), end_E1(0);
@@ -244,10 +244,10 @@ namespace Gadgetron {
             Gadgetron::crop(crop_offset, crop_size, &ref_calib, &ref_recon_buf);
             ref_calib = ref_recon_buf;
 
-            if (!debug_folder_full_path_.empty())
+            /*if (!debug_folder_full_path_.empty())
             {
                 gt_exporter_.exportArrayComplex(ref_calib, debug_folder_full_path_ + "ref_calib_after_cropping" + os.str());
-            }
+            }*/
 
             // step 3, update the sampling limits
             sampling_limits[0].center_ = RO/2;
@@ -282,10 +282,10 @@ namespace Gadgetron {
             recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[1] = sampling_limits[1];
             recon_bit_->rbit_[e].ref_.sampling_.sampling_limits_[2] = sampling_limits[2];
 
-            if (!debug_folder_full_path_.empty())
+            /*if (!debug_folder_full_path_.empty())
             {
                 gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_.data_, debug_folder_full_path_ + "ref_after_prep" + os.str());
-            }
+            }*/
         }
 
         if (this->next()->putq(m1) < 0)

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
@@ -16,7 +16,7 @@
 
 #include "hoNDArray_utils.h"
 
-#include "gtPlusIOAnalyze.h"
+// #include "gtPlusIOAnalyze.h"
 
 #include "GadgetStreamController.h"
 
@@ -81,15 +81,15 @@ namespace Gadgetron {
         // in verbose mode, more info is printed out
         bool verbose_;
 
-        // debug folder
-        std::string debug_folder_full_path_;
+        //// debug folder
+        //std::string debug_folder_full_path_;
 
         // clock for timing
         Gadgetron::GadgetronTimer gt_timer_local_;
         Gadgetron::GadgetronTimer gt_timer_;
 
-        // exporter
-        Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
+        //// exporter
+        //Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
 
         // --------------------------------------------------
         // gadget functions

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
@@ -1,0 +1,101 @@
+/** \file   GenericCartesianReconReferencePrepGadget.h
+    \brief  This is the class gadget for both 2DT and 3DT cartesian reconstruction to prepare the reference data, working on the IsmrmrdReconData.
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include <complex>
+#include "gadgetron_mricore_export.h"
+#include "Gadget.h"
+#include "hoNDArray.h"
+#include "ismrmrd/ismrmrd.h"
+#include "ismrmrd/xml.h"
+#include "ismrmrd/meta.h"
+#include "GadgetronTimer.h"
+
+#include "hoNDArray_utils.h"
+
+#include "gtPlusIOAnalyze.h"
+
+#include "GadgetStreamController.h"
+
+#include "hoNDArray_utils.h"
+#include "hoNDArray_elemwise.h"
+
+#include "mri_core_data.h"
+#include "mri_core_utility.h"
+
+namespace Gadgetron {
+
+    class EXPORTGADGETSMRICORE GenericCartesianReconReferencePrepGadget : public Gadget1<IsmrmrdReconData>
+    {
+    public:
+        GADGET_DECLARE(GenericCartesianReconReferencePrepGadget);
+
+        typedef Gadget1<IsmrmrdReconData> BaseClass;
+
+        GenericCartesianReconReferencePrepGadget();
+        ~GenericCartesianReconReferencePrepGadget();
+
+        /// ------------------------------------------------------------------------------------
+        /// parameters to control the reconstruction
+        /// ------------------------------------------------------------------------------------
+
+        /// ------------------------------------------------------------------------------------
+        /// debug and timing
+        GADGET_PROPERTY(verbose, bool, "Whether to print more information", false);
+        GADGET_PROPERTY(debug_folder, std::string, "If set, the debug output will be written out", "");
+        GADGET_PROPERTY(perform_timing, bool, "Whether to perform timing on some computational steps", false);
+
+        /// ref preparation
+        /// whether to average all N for ref generation
+        GADGET_PROPERTY(average_all_ref_N, bool, "Whether to average all N for ref generation", true);
+        /// whether to average all S for ref generation
+        GADGET_PROPERTY(average_all_ref_S, bool, "Whether to average all S for ref generation", false);
+
+    protected:
+
+        // --------------------------------------------------
+        // variables for protocol
+        // --------------------------------------------------
+
+        // number of encoding spaces in the protocol
+        size_t num_encoding_spaces_;
+
+        // for every encoding space
+        // calibration mode
+        std::vector<Gadgetron::ismrmrdCALIBMODE> calib_mode_;
+
+        // --------------------------------------------------
+        // variable for recon
+        // --------------------------------------------------
+
+        // number of times the process function is called
+        size_t process_called_times_;
+
+        // --------------------------------------------------
+        // variables for debug and timing
+        // --------------------------------------------------
+
+        // in verbose mode, more info is printed out
+        bool verbose_;
+
+        // debug folder
+        std::string debug_folder_full_path_;
+
+        // clock for timing
+        Gadgetron::GadgetronTimer gt_timer_local_;
+        Gadgetron::GadgetronTimer gt_timer_;
+
+        // exporter
+        Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;
+
+        // --------------------------------------------------
+        // gadget functions
+        // --------------------------------------------------
+        // default interface function
+        virtual int process_config(ACE_Message_Block* mb);
+        virtual int process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1);
+    };
+}

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!--
+        Gadgetron generic recon chain for 2D and 3D cartesian sampling
+
+        T2W imaging
+        Triggered by repetition
+        Recon N is repetition and S is set
+
+        Author: Hui Xue
+        Magnetic Resonance Technology Program, National Heart, Lung and Blood Institute, National Institutes of Health
+        10 Center Drive, Bethesda, MD 20814, USA
+        Email: hui.xue@nih.gov
+    -->
+
+    <!-- reader -->
+    <reader><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageReader</classname></reader>
+
+    <!-- writer -->
+    <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
+
+    <!-- Noise prewhitening -->
+    <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
+
+    <!-- RO asymmetric echo handling -->
+    <gadget><name>AsymmetricEcho</name><dll>gadgetron_mricore</dll><classname>AsymmetricEchoAdjustROGadget</classname></gadget>
+
+    <!-- RO oversampling removal -->
+    <gadget><name>RemoveROOversampling</name><dll>gadgetron_mricore</dll><classname>RemoveROOversamplingGadget</classname></gadget>
+
+    <!-- Data accumulation and trigger gadget -->
+    <gadget>
+        <name>AccTrig</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value>repetition</value></property>
+        <property><name>sorting_dimension</name><value>slice</value></property>
+    </gadget>
+
+    <gadget>
+        <name>Buff</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>BucketToBufferGadget</classname>
+        <property><name>N_dimension</name><value>repetition</value></property>
+        <property><name>S_dimension</name><value>set</value></property>
+        <property><name>split_slices</name><value>true</value></property>
+        <property><name>ignore_segment</name><value>true</value></property>
+    </gadget>
+
+    <!-- Recon -->
+    <gadget>
+        <name>Recon</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericCartesianGrappaReconGadget</classname>
+
+        <!-- image series -->
+        <property><name>image_series</name><value>0</value></property>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value>DebugFolder</value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- whether to send out gfactor -->
+        <property><name>send_out_gfactor</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>false</value></property>
+    </gadget>
+
+    <!-- ImageArray to images -->
+    <gadget>
+        <name>ImageArraySplit</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageArraySplitGadget</classname>
+    </gadget>
+
+    <!-- after recon processing -->
+    <gadget>
+        <name>ComplexToFloatAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ComplexToFloatGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>ImageFinish</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
@@ -50,6 +50,24 @@
         <property><name>ignore_segment</name><value>true</value></property>
     </gadget>
 
+    <!-- Prep ref -->
+    <gadget>
+        <name>PrepRef</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericCartesianReconReferencePrepGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value>DebugFolder</value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>false</value></property>
+    </gadget>
+
     <!-- Recon -->
     <gadget>
         <name>Recon</name>
@@ -66,12 +84,6 @@
 
         <!-- whether to send out gfactor -->
         <property><name>send_out_gfactor</name><value>true</value></property>
-
-        <!-- averaging across repetition -->
-        <property><name>average_all_ref_N</name><value>true</value></property>
-
-        <!-- every set has its own kernels -->
-        <property><name>average_all_ref_S</name><value>false</value></property>
     </gadget>
 
     <!-- ImageArray to images -->

--- a/gadgets/mri_core/RemoveROOversamplingGadget.cpp
+++ b/gadgets/mri_core/RemoveROOversamplingGadget.cpp
@@ -124,6 +124,8 @@ namespace Gadgetron{
         m1->cont(m3);
         m1->getObjectPtr()->number_of_samples = data_out_dims[0];
         m1->getObjectPtr()->center_sample = (uint16_t)(m1->getObjectPtr()->center_sample/ratioFOV);
+        m1->getObjectPtr()->discard_pre = (uint16_t)(m1->getObjectPtr()->discard_pre / ratioFOV);
+        m1->getObjectPtr()->discard_post = (uint16_t)(m1->getObjectPtr()->discard_post / ratioFOV);
 
       } // end if (dowork_)
 

--- a/toolboxes/gtplus/workflow/gtPlusISMRMRDReconUtil.h
+++ b/toolboxes/gtplus/workflow/gtPlusISMRMRDReconUtil.h
@@ -125,15 +125,7 @@ namespace Gadgetron {
     };
 
     // define the calibration mode of ISMRMRD
-    enum ISMRMRDCALIBMODE
-    {
-        ISMRMRD_embedded = 256,
-        ISMRMRD_interleaved,
-        ISMRMRD_separate,
-        ISMRMRD_external,
-        ISMRMRD_other,
-        ISMRMRD_noacceleration
-    };
+    typedef Gadgetron::ismrmrdCALIBMODE ISMRMRDCALIBMODE;
 
     // define the interpolation method
     enum ISMRMRDINTERP

--- a/toolboxes/mri_core/mri_core_data.h
+++ b/toolboxes/mri_core/mri_core_data.h
@@ -38,6 +38,19 @@ namespace Gadgetron
 	NONE
       };
 
+    // --------------------------------------------------------------------------
+    /// define the calibration mode of ISMRMRD
+    // --------------------------------------------------------------------------
+    enum ismrmrdCALIBMODE
+    {
+        ISMRMRD_embedded,
+        ISMRMRD_interleaved,
+        ISMRMRD_separate,
+        ISMRMRD_external,
+        ISMRMRD_other,
+        ISMRMRD_noacceleration
+    };
+
   class SamplingLimit
   {
   public:

--- a/toolboxes/mri_core/mri_core_utility.cpp
+++ b/toolboxes/mri_core/mri_core_utility.cpp
@@ -12,7 +12,7 @@
 namespace Gadgetron
 {
     template <typename T>
-    std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray<T>& data)
+    hoNDArray<bool> detect_readout_sampling_status(const hoNDArray<T>& data)
     {
         try
         {
@@ -64,7 +64,7 @@ namespace Gadgetron
                 }
             }
 
-            return std::make_tuple(std::move(sampled));
+            return sampled;
         }
         catch (...)
         {
@@ -72,10 +72,10 @@ namespace Gadgetron
         }
     }
 
-    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< float >& data);
-    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< double >& data);
-    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< std::complex<float> >& data);
-    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< std::complex<double> >& data);
+    template EXPORTMRICORE hoNDArray<bool> detect_readout_sampling_status(const hoNDArray< float >& data);
+    template EXPORTMRICORE hoNDArray<bool> detect_readout_sampling_status(const hoNDArray< double >& data);
+    template EXPORTMRICORE hoNDArray<bool> detect_readout_sampling_status(const hoNDArray< std::complex<float> >& data);
+    template EXPORTMRICORE hoNDArray<bool> detect_readout_sampling_status(const hoNDArray< std::complex<double> >& data);
 
     // ------------------------------------------------------------------------
 
@@ -84,8 +84,7 @@ namespace Gadgetron
     {
         try
         {
-            hoNDArray<bool> sampled;
-            sampled = std::get<0>(Gadgetron::detect_readout_sampling_status(data));
+            hoNDArray<bool> sampled = Gadgetron::detect_readout_sampling_status(data);
 
             size_t RO = data.get_size(0);
             size_t E1 = data.get_size(1);
@@ -142,8 +141,7 @@ namespace Gadgetron
     {
         try
         {
-            hoNDArray<bool> sampled;
-            sampled = std::get<0>(Gadgetron::detect_readout_sampling_status(data));
+            hoNDArray<bool> sampled = Gadgetron::detect_readout_sampling_status(data);
 
             size_t RO = data.get_size(0);
             size_t E1 = data.get_size(1);

--- a/toolboxes/mri_core/mri_core_utility.cpp
+++ b/toolboxes/mri_core/mri_core_utility.cpp
@@ -6,8 +6,209 @@
 
 #include "mri_core_utility.h"
 #include "hoNDArray_elemwise.h"
+#include "mri_core_kspace_filter.h"
 
 namespace Gadgetron
 {
+    template <typename T>
+    void detect_readout_sampling_status(const hoNDArray<T>& data, hoNDArray<float>& sampled)
+    {
+        try
+        {
+            typedef typename realType<T>::Type value_type;
 
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            sampled.create(E1, E2, N, S, SLC);
+            Gadgetron::clear(sampled);
+
+            size_t slc, s, n, e2, e1;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                value_type v = 0;
+                                const T* pData = &(data(0, e1, e2, 0, n, s, slc));
+
+                                size_t ro;
+                                for (ro = 0; ro < RO; ro++)
+                                {
+                                    v += std::abs(pData[ro]);
+                                }
+
+                                if (v > 0)
+                                {
+                                    sampled(e1, e2, n, s, slc) = 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in detect_readout_sampling_status(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< float >& data, hoNDArray<float>& sampled);
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< double >& data, hoNDArray<float>& sampled);
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< std::complex<float> >& data, hoNDArray<float>& sampled);
+    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< std::complex<double> >& data, hoNDArray<float>& sampled);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void detect_sampled_region_E1(const hoNDArray<T>& data, size_t& start_E1, size_t& end_E1)
+    {
+        try
+        {
+            hoNDArray<float> sampled;
+            Gadgetron::detect_readout_sampling_status(data, sampled);
+
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            start_E1 = E1;
+            end_E1 = 0;
+
+            size_t e1, e2, n, s, slc;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                if (sampled(e1, e2, n, s, slc)>0)
+                                {
+                                    if (e1 < start_E1) start_E1 = e1;
+                                    if (e1 > end_E1) end_E1 = e1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in detect_sampled_region_E1(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<float>& data, size_t& start_E1, size_t& end_E1);
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<double>& data, size_t& start_E1, size_t& end_E1);
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray< std::complex<float> >& data, size_t& start_E1, size_t& end_E1);
+    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray< std::complex<double> >& data, size_t& start_E1, size_t& end_E1);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void detect_sampled_region_E2(const hoNDArray<T>& data, size_t& start_E2, size_t& end_E2)
+    {
+        try
+        {
+            hoNDArray<float> sampled;
+            Gadgetron::detect_readout_sampling_status(data, sampled);
+
+            size_t RO = data.get_size(0);
+            size_t E1 = data.get_size(1);
+            size_t E2 = data.get_size(2);
+            size_t CHA = data.get_size(3);
+            size_t N = data.get_size(4);
+            size_t S = data.get_size(5);
+            size_t SLC = data.get_size(6);
+
+            start_E2 = E2;
+            end_E2 = 0;
+
+            size_t e1, e2, n, s, slc;
+
+            for (slc = 0; slc < SLC; slc++)
+            {
+                for (s = 0; s < S; s++)
+                {
+                    for (n = 0; n < N; n++)
+                    {
+                        for (e2 = 0; e2 < E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                if (sampled(e1, e2, n, s, slc)>0)
+                                {
+                                    if (e2 < start_E2) start_E2 = e2;
+                                    if (e2 > end_E2) end_E2 = e2;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in detect_sampled_region_E2(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<float>& data, size_t& start_E2, size_t& end_E2);
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<double>& data, size_t& start_E2, size_t& end_E2);
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray< std::complex<float> >& data, size_t& start_E2, size_t& end_E2);
+    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray< std::complex<double> >& data, size_t& start_E2, size_t& end_E2);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T>
+    void generate_ref_filter_for_coil_map(const hoNDArray<T>& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray<T>& filter_RO, hoNDArray<T>& filter_E1, hoNDArray<T>& filter_E2)
+    {
+        try
+        {
+            size_t RO = ref.get_size(0);
+            size_t E1 = ref.get_size(1);
+            size_t E2 = ref.get_size(2);
+
+            Gadgetron::generate_symmetric_filter_ref(RO, lim_RO.min_, lim_RO.max_, filter_RO);
+            Gadgetron::generate_symmetric_filter_ref(E1, lim_E1.min_, lim_E1.max_, filter_E1);
+
+            if (E2 > 1)
+            {
+                Gadgetron::generate_symmetric_filter_ref(E2, lim_E2.min_, lim_E2.max_, filter_E2);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in generate_ref_filter_for_coil_map(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<float> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<float> >& filter_RO, hoNDArray< std::complex<float> >& filter_E1, hoNDArray< std::complex<float> >& filter_E2);
+    template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<double> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<double> >& filter_RO, hoNDArray< std::complex<double> >& filter_E1, hoNDArray< std::complex<double> >& filter_E2);
+
+    // ------------------------------------------------------------------------
 }

--- a/toolboxes/mri_core/mri_core_utility.cpp
+++ b/toolboxes/mri_core/mri_core_utility.cpp
@@ -12,7 +12,7 @@
 namespace Gadgetron
 {
     template <typename T>
-    void detect_readout_sampling_status(const hoNDArray<T>& data, hoNDArray<float>& sampled)
+    std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray<T>& data)
     {
         try
         {
@@ -26,8 +26,8 @@ namespace Gadgetron
             size_t S = data.get_size(5);
             size_t SLC = data.get_size(6);
 
+            hoNDArray<bool> sampled;
             sampled.create(E1, E2, N, S, SLC);
-            Gadgetron::clear(sampled);
 
             size_t slc, s, n, e2, e1;
 
@@ -52,13 +52,19 @@ namespace Gadgetron
 
                                 if (v > 0)
                                 {
-                                    sampled(e1, e2, n, s, slc) = 1;
+                                    sampled(e1, e2, n, s, slc) = true;
+                                }
+                                else
+                                {
+                                    sampled(e1, e2, n, s, slc) =false;
                                 }
                             }
                         }
                     }
                 }
             }
+
+            return std::make_tuple(std::move(sampled));
         }
         catch (...)
         {
@@ -66,20 +72,20 @@ namespace Gadgetron
         }
     }
 
-    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< float >& data, hoNDArray<float>& sampled);
-    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< double >& data, hoNDArray<float>& sampled);
-    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< std::complex<float> >& data, hoNDArray<float>& sampled);
-    template EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray< std::complex<double> >& data, hoNDArray<float>& sampled);
+    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< float >& data);
+    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< double >& data);
+    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< std::complex<float> >& data);
+    template EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray< std::complex<double> >& data);
 
     // ------------------------------------------------------------------------
 
     template <typename T>
-    void detect_sampled_region_E1(const hoNDArray<T>& data, size_t& start_E1, size_t& end_E1)
+    std::tuple<size_t, size_t> detect_sampled_region_E1(const hoNDArray<T>& data)
     {
         try
         {
-            hoNDArray<float> sampled;
-            Gadgetron::detect_readout_sampling_status(data, sampled);
+            hoNDArray<bool> sampled;
+            sampled = std::get<0>(Gadgetron::detect_readout_sampling_status(data));
 
             size_t RO = data.get_size(0);
             size_t E1 = data.get_size(1);
@@ -89,6 +95,7 @@ namespace Gadgetron
             size_t S = data.get_size(5);
             size_t SLC = data.get_size(6);
 
+            size_t start_E1, end_E1;
             start_E1 = E1;
             end_E1 = 0;
 
@@ -104,7 +111,7 @@ namespace Gadgetron
                         {
                             for (e1 = 0; e1 < E1; e1++)
                             {
-                                if (sampled(e1, e2, n, s, slc)>0)
+                                if (sampled(e1, e2, n, s, slc)==true)
                                 {
                                     if (e1 < start_E1) start_E1 = e1;
                                     if (e1 > end_E1) end_E1 = e1;
@@ -115,6 +122,7 @@ namespace Gadgetron
                 }
             }
 
+            return std::make_tuple(start_E1, end_E1);
         }
         catch (...)
         {
@@ -122,20 +130,20 @@ namespace Gadgetron
         }
     }
 
-    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<float>& data, size_t& start_E1, size_t& end_E1);
-    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<double>& data, size_t& start_E1, size_t& end_E1);
-    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray< std::complex<float> >& data, size_t& start_E1, size_t& end_E1);
-    template EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray< std::complex<double> >& data, size_t& start_E1, size_t& end_E1);
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E1(const hoNDArray<float>& data);
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E1(const hoNDArray<double>& data);
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E1(const hoNDArray< std::complex<float> >& data);
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E1(const hoNDArray< std::complex<double> >& data);
 
     // ------------------------------------------------------------------------
 
     template <typename T>
-    void detect_sampled_region_E2(const hoNDArray<T>& data, size_t& start_E2, size_t& end_E2)
+    std::tuple<size_t, size_t> detect_sampled_region_E2(const hoNDArray<T>& data)
     {
         try
         {
-            hoNDArray<float> sampled;
-            Gadgetron::detect_readout_sampling_status(data, sampled);
+            hoNDArray<bool> sampled;
+            sampled = std::get<0>(Gadgetron::detect_readout_sampling_status(data));
 
             size_t RO = data.get_size(0);
             size_t E1 = data.get_size(1);
@@ -145,6 +153,7 @@ namespace Gadgetron
             size_t S = data.get_size(5);
             size_t SLC = data.get_size(6);
 
+            size_t start_E2, end_E2;
             start_E2 = E2;
             end_E2 = 0;
 
@@ -160,7 +169,7 @@ namespace Gadgetron
                         {
                             for (e1 = 0; e1 < E1; e1++)
                             {
-                                if (sampled(e1, e2, n, s, slc)>0)
+                                if (sampled(e1, e2, n, s, slc)==true)
                                 {
                                     if (e2 < start_E2) start_E2 = e2;
                                     if (e2 > end_E2) end_E2 = e2;
@@ -171,6 +180,7 @@ namespace Gadgetron
                 }
             }
 
+            return std::make_tuple(start_E2, end_E2);
         }
         catch (...)
         {
@@ -178,74 +188,10 @@ namespace Gadgetron
         }
     }
 
-    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<float>& data, size_t& start_E2, size_t& end_E2);
-    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<double>& data, size_t& start_E2, size_t& end_E2);
-    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray< std::complex<float> >& data, size_t& start_E2, size_t& end_E2);
-    template EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray< std::complex<double> >& data, size_t& start_E2, size_t& end_E2);
-
-    // ------------------------------------------------------------------------
-
-    template <typename T>
-    void generate_ref_filter_for_coil_map(const hoNDArray<T>& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray<T>& filter_RO, hoNDArray<T>& filter_E1, hoNDArray<T>& filter_E2)
-    {
-        try
-        {
-            size_t RO = ref.get_size(0);
-            size_t E1 = ref.get_size(1);
-            size_t E2 = ref.get_size(2);
-
-            Gadgetron::generate_symmetric_filter_ref(RO, lim_RO.min_, lim_RO.max_, filter_RO);
-            Gadgetron::generate_symmetric_filter_ref(E1, lim_E1.min_, lim_E1.max_, filter_E1);
-
-            if (E2 > 1)
-            {
-                Gadgetron::generate_symmetric_filter_ref(E2, lim_E2.min_, lim_E2.max_, filter_E2);
-            }
-        }
-        catch (...)
-        {
-            GADGET_THROW("Errors in generate_ref_filter_for_coil_map(...) ... ");
-        }
-    }
-
-    template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<float> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<float> >& filter_RO, hoNDArray< std::complex<float> >& filter_E1, hoNDArray< std::complex<float> >& filter_E2);
-    template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<double> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<double> >& filter_RO, hoNDArray< std::complex<double> >& filter_E1, hoNDArray< std::complex<double> >& filter_E2);
-
-    // ------------------------------------------------------------------------
-
-    void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath)
-    {
-        char* v = std::getenv("GADGETRON_DEBUG_FOLDER");
-        if (v == NULL)
-        {
-#ifdef _WIN32
-            debugFolderPath = "c:/temp/gadgetron";
-#else
-            debugFolderPath = "/tmp/gadgetron";
-#endif // _WIN32
-        }
-        else
-        {
-            debugFolderPath = std::string(v);
-        }
-
-        debugFolderPath.append("/");
-        debugFolderPath.append(debugFolder);
-        debugFolderPath.append("/");
-    }
-
-    // ------------------------------------------------------------------------
-
-    void get_current_moment(std::string& procTime)
-    {
-        char timestamp[100];
-        time_t mytime;
-        struct tm *mytm;
-        mytime = time(NULL);
-        mytm = localtime(&mytime);
-        strftime(timestamp, sizeof(timestamp), "%a, %b %d %Y, %H:%M:%S", mytm);
-        procTime = timestamp;
-    }
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E2(const hoNDArray<float>& data);
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E2(const hoNDArray<double>& data);
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E2(const hoNDArray< std::complex<float> >& data);
+    template EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E2(const hoNDArray< std::complex<double> >& data);
 
     // ------------------------------------------------------------------------
 }

--- a/toolboxes/mri_core/mri_core_utility.cpp
+++ b/toolboxes/mri_core/mri_core_utility.cpp
@@ -7,6 +7,7 @@
 #include "mri_core_utility.h"
 #include "hoNDArray_elemwise.h"
 #include "mri_core_kspace_filter.h"
+#include <ctime>
 
 namespace Gadgetron
 {
@@ -209,6 +210,42 @@ namespace Gadgetron
 
     template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<float> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<float> >& filter_RO, hoNDArray< std::complex<float> >& filter_E1, hoNDArray< std::complex<float> >& filter_E2);
     template EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray< std::complex<double> >& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray< std::complex<double> >& filter_RO, hoNDArray< std::complex<double> >& filter_E1, hoNDArray< std::complex<double> >& filter_E2);
+
+    // ------------------------------------------------------------------------
+
+    void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath)
+    {
+        char* v = std::getenv("GADGETRON_DEBUG_FOLDER");
+        if (v == NULL)
+        {
+#ifdef _WIN32
+            debugFolderPath = "c:/temp/gadgetron";
+#else
+            debugFolderPath = "/tmp/gadgetron";
+#endif // _WIN32
+        }
+        else
+        {
+            debugFolderPath = std::string(v);
+        }
+
+        debugFolderPath.append("/");
+        debugFolderPath.append(debugFolder);
+        debugFolderPath.append("/");
+    }
+
+    // ------------------------------------------------------------------------
+
+    void get_current_moment(std::string& procTime)
+    {
+        char timestamp[100];
+        time_t mytime;
+        struct tm *mytm;
+        mytime = time(NULL);
+        mytm = localtime(&mytime);
+        strftime(timestamp, sizeof(timestamp), "%a, %b %d %Y, %H:%M:%S", mytm);
+        procTime = timestamp;
+    }
 
     // ------------------------------------------------------------------------
 }

--- a/toolboxes/mri_core/mri_core_utility.h
+++ b/toolboxes/mri_core/mri_core_utility.h
@@ -29,4 +29,10 @@ namespace Gadgetron
     /// set up the kspace filter for ref used for coil map estimation
     template <typename T> EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray<T>& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray<T>& filter_RO, hoNDArray<T>& filter_E1, hoNDArray<T>& filter_E2);
 
+    /// get the path of debug folder
+    /// environmental variable GADGETRON_DEBUG_FOLDER is used 
+    EXPORTMRICORE void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath);
+
+    /// get current time into string
+    EXPORTMRICORE void get_current_moment(std::string& procTime);
 }

--- a/toolboxes/mri_core/mri_core_utility.h
+++ b/toolboxes/mri_core/mri_core_utility.h
@@ -18,7 +18,7 @@ namespace Gadgetron
     /// data: [RO E1 E2 CHA N S SLC]
 
     /// sampled: [E1 E2 N S SLC], if a readout is sampled, corresponding sampled location is 1; otherwise, 0
-    template <typename T> EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray<T>& data);
+    template <typename T> EXPORTMRICORE hoNDArray<bool> detect_readout_sampling_status(const hoNDArray<T>& data);
 
     /// detect sampled region along E1
     template <typename T> EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E1(const hoNDArray<T>& data);

--- a/toolboxes/mri_core/mri_core_utility.h
+++ b/toolboxes/mri_core/mri_core_utility.h
@@ -8,7 +8,25 @@
 
 #include "mri_core_export.h"
 #include "hoNDArray.h"
+#include "mri_core_data.h"
 
 namespace Gadgetron
 {
+    // --------------------------------------------------------------------------
+    /// detect whether a readout has been sampled or not
+    // --------------------------------------------------------------------------
+    /// data: [RO E1 E2 CHA N S SLC]
+
+    /// sampled: [E1 E2 N S SLC], if a readout is sampled, corresponding sampled location is 1; otherwise, 0
+    template <typename T> EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray<T>& data, hoNDArray<float>& sampled);
+
+    /// detect sampled region along E1
+    template <typename T> EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<T>& data, size_t& start_E1, size_t& end_E1);
+
+    /// detect sampled region along E2
+    template <typename T> EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<T>& data, size_t& start_E2, size_t& end_E2);
+
+    /// set up the kspace filter for ref used for coil map estimation
+    template <typename T> EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray<T>& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray<T>& filter_RO, hoNDArray<T>& filter_E1, hoNDArray<T>& filter_E2);
+
 }

--- a/toolboxes/mri_core/mri_core_utility.h
+++ b/toolboxes/mri_core/mri_core_utility.h
@@ -18,21 +18,11 @@ namespace Gadgetron
     /// data: [RO E1 E2 CHA N S SLC]
 
     /// sampled: [E1 E2 N S SLC], if a readout is sampled, corresponding sampled location is 1; otherwise, 0
-    template <typename T> EXPORTMRICORE void detect_readout_sampling_status(const hoNDArray<T>& data, hoNDArray<float>& sampled);
+    template <typename T> EXPORTMRICORE std::tuple<hoNDArray<bool> > detect_readout_sampling_status(const hoNDArray<T>& data);
 
     /// detect sampled region along E1
-    template <typename T> EXPORTMRICORE void detect_sampled_region_E1(const hoNDArray<T>& data, size_t& start_E1, size_t& end_E1);
+    template <typename T> EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E1(const hoNDArray<T>& data);
 
     /// detect sampled region along E2
-    template <typename T> EXPORTMRICORE void detect_sampled_region_E2(const hoNDArray<T>& data, size_t& start_E2, size_t& end_E2);
-
-    /// set up the kspace filter for ref used for coil map estimation
-    template <typename T> EXPORTMRICORE void generate_ref_filter_for_coil_map(const hoNDArray<T>& ref, const SamplingLimit& lim_RO, const SamplingLimit& lim_E1, const SamplingLimit& lim_E2, hoNDArray<T>& filter_RO, hoNDArray<T>& filter_E1, hoNDArray<T>& filter_E2);
-
-    /// get the path of debug folder
-    /// environmental variable GADGETRON_DEBUG_FOLDER is used 
-    EXPORTMRICORE void get_debug_folder_path(const std::string& debugFolder, std::string& debugFolderPath);
-
-    /// get current time into string
-    EXPORTMRICORE void get_current_moment(std::string& procTime);
+    template <typename T> EXPORTMRICORE std::tuple<size_t, size_t> detect_sampled_region_E2(const hoNDArray<T>& data);
 }


### PR DESCRIPTION

A single recon gadget for grappa is added.

An example is given for T2W data, Generic_Cartesian_Grappa_T2W.xml, which works with integration test data meas_MID00057_T2w.dat

The changes on BucketToBufferGadget are still needed to make sure kspace is buffered in the correct location. This PR includes the changes in PR #204.

Please focus on the main gadget GenericCartesianGrappaReconGadget

The recon kernel and other status is stored in GenericCartesianGrappaReconObj for every encoding space. Therefore, the incoming reconbit without ref data can be processed with buffered kernel and coil maps.

The recon chain consists of 

        a) ensure the recon image to have squared pixel, therefore zero-padding resizing is not needed for E1. This avoids ringing in the final images. 
       b) prepare the ref data. Gadget can control to whether averaging all N or all S for ref data.
       c) estimate coil map
       d) calibration
       e) unwrapping or coil combination
       f) compute image header
       g) send out the recon results, gfactor can be sent out

A few utilities functions are added into mri_core to detect sampled kspace region.

After combining comments, i will put in the integration test cases
