### PR TITLE
add ref preparation for interleaved mode to count the sampling times …

### DIFF
--- a/gadgets/mri_core/BucketToBufferGadget.cpp
+++ b/gadgets/mri_core/BucketToBufferGadget.cpp
@@ -602,7 +602,14 @@ namespace Gadgetron{
     uint16_t npts_to_copy = acqhdr.number_of_samples - acqhdr.discard_pre - acqhdr.discard_post;
     long long offset;
     if (encoding.trajectory.compare("cartesian") == 0) {
-        offset  = (long long) dataBuffer.sampling_.sampling_limits_[0].center_ - (long long) acqhdr.center_sample;
+        if ((acqhdr.number_of_samples == dataBuffer.data_.get_size(0)) && (acqhdr.center_sample == acqhdr.number_of_samples/2)) // acq has been corrected for center , e.g. by asymmetric handling
+        {
+            offset = acqhdr.discard_pre;
+        }
+        else
+        {
+            offset = (long long)dataBuffer.sampling_.sampling_limits_[0].center_ - (long long)acqhdr.center_sample;
+        }
     } else {
         //TODO what about EPI with asymmetric readouts?
         //TODO any other sort of trajectory?

--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -137,6 +137,7 @@ set( gadgetron_mricore_config_files
     isalive.xml
     gtquery.xml
     Generic_Cartesian_Grappa_T2W.xml
+    Generic_Cartesian_Grappa_RealTimeCine.xml
 )
 
 add_library(gadgetron_mricore SHARED 

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
@@ -656,7 +656,7 @@ namespace Gadgetron {
 
                 long long ii;
 
-#pragma omp parallel for default(none) private(ii) shared(src, dst, recon_obj, e, num, ref_N, ref_S, ref_RO, ref_E1, ref_E2, RO, E1, E2, dstCHA, srcCHA, convKRO, convKE1, convKE2, kRO, kNE1, kNE2)
+#pragma omp parallel for default(none) private(ii) shared(src, dst, recon_obj, e, num, ref_N, ref_S, ref_RO, ref_E1, ref_E2, RO, E1, E2, dstCHA, srcCHA, convKRO, convKE1, convKE2, kRO, kNE1, kNE2) if(num>1)
                 for (ii = 0; ii < num; ii++)
                 {
                     size_t slc = ii / (ref_N*ref_S);
@@ -822,7 +822,7 @@ namespace Gadgetron {
 
             long long ii;
 
-#pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, E2, srcCHA, convkRO, convkE1, convkE2, ref_N, ref_S, recon_obj, dstCHA, e)
+#pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, E2, srcCHA, convkRO, convkE1, convkE2, ref_N, ref_S, recon_obj, dstCHA, e) if(num>1)
             {
 #pragma omp for 
                 for (ii = 0; ii < num; ii++)

--- a/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianGrappaReconGadget.cpp
@@ -210,7 +210,7 @@ namespace Gadgetron {
                 // ---------------------------------------------------------------
 
                 // after this step, coil map is computed and stored in recon_obj_[e].coil_map_
-                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::make_ref_coil_map"); }
+                if (perform_timing.value()) { gt_timer_.start("GenericCartesianGrappaReconGadget::perform_coil_map_estimation"); }
                 this->perform_coil_map_estimation(recon_bit_->rbit_[e], recon_obj_[e], e);
                 if (perform_timing.value()) { gt_timer_.stop(); }
 
@@ -419,7 +419,7 @@ namespace Gadgetron {
             size_t RO = 2 * cRO;
             if (sRO>0 || eRO<RO - 1)
             {
-                RO = 2 * std::max(cRO - sRO, eRO - cRO);
+                RO = 2 * std::max(cRO - sRO, eRO - cRO+1);
             }
 
             size_t E1 = eE1 - sE1 + 1;
@@ -427,8 +427,8 @@ namespace Gadgetron {
 
             if ((calib_mode_[encoding] == Gadgetron::ISMRMRD_interleaved) || (calib_mode_[encoding] == Gadgetron::ISMRMRD_noacceleration))
             {
-                E1 = 2 * std::max(cE1 - sE1, eE1 - cE1);
-                if (E2>1 ) E2 = 2 * std::max(cE2 - sE2, eE2 - cE2);
+                E1 = 2 * std::max(cE1 - sE1, eE1 - cE1+1);
+                if (E2>1 ) E2 = 2 * std::max(cE2 - sE2, eE2 - cE2+1);
             }
 
             ref_coil_map.create(RO, E1, E2, CHA, N, S, SLC);

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
@@ -162,8 +162,10 @@ namespace Gadgetron {
             size_t RO = ref.get_size(0);
             size_t E1 = ref.get_size(1);
             size_t E2 = ref.get_size(2);
+            size_t CHA = ref.get_size(3);
             size_t N = ref.get_size(4);
             size_t S = ref.get_size(5);
+            size_t SLC = ref.get_size(6);
 
             // stored the ref data ready for calibration
             hoNDArray< std::complex<float> > ref_calib;
@@ -180,7 +182,8 @@ namespace Gadgetron {
 
             // -----------------------------------------
             // 1) average the ref according to the input parameters; 
-            //    TODO: if interleaved mode, need to detect sampling times for every E1/E2 location
+            //    if interleaved mode, sampling times for every E1/E2 location is detected and line by line averaging is performed 
+            //    this is required when irregular cartesian sampling is used or number of frames cannot be divided in full by acceleration factor
             // 2) detect the sampled region and crop the ref data if needed
             // 3) update the sampling_limits
             // -----------------------------------------
@@ -192,8 +195,51 @@ namespace Gadgetron {
             {
                 if (N > 1)
                 {
-                    Gadgetron::sum_over_dimension(ref, ref_calib, (size_t)4);
-                    Gadgetron::scal((float)(1.0 / N), ref_calib);
+                    if (calib_mode_[e] == ISMRMRD_interleaved)
+                    {
+                        hoNDArray<bool> sampled = Gadgetron::detect_readout_sampling_status(ref);
+
+                        Gadgetron::sum_over_dimension(ref, ref_calib, 4);
+
+                        size_t ro, e1, e2, cha, n, s, slc;
+
+                        for (slc = 0; slc < SLC; slc++)
+                        {
+                            for (s = 0; s < S; s++)
+                            {
+                                for (cha = 0; cha < CHA; cha++)
+                                {
+                                    for (e2 = 0; e2 < E2; e2++)
+                                    {
+                                        for (e1 = 0; e1 < E1; e1++)
+                                        {
+                                            float freq = 0;
+                                            for (n = 0; n < N; n++)
+                                            {
+                                                if (sampled(e1, e2, n, s, slc)) freq = freq + 1;
+                                            }
+
+                                            if (freq > 1)
+                                            {
+                                                float freq_reciprocal = (float)(1.0 / freq);
+
+                                                std::complex<float>* pAve = &(ref_calib(0, e1, e2, cha, 0, s, slc));
+                                                for (ro = 0; ro < RO; ro++)
+                                                {
+                                                    pAve[ro] *= freq_reciprocal;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Gadgetron::sum_over_dimension(ref, ref_calib, (size_t)4);
+                        Gadgetron::scal((float)(1.0 / N), ref_calib);
+                    }
                 }
                 else
                 {
@@ -209,8 +255,52 @@ namespace Gadgetron {
             {
                 if (S > 1)
                 {
-                    Gadgetron::sum_over_dimension(ref_calib, ref_recon_buf, 5);
-                    Gadgetron::scal((float)(1.0 / S), ref_recon_buf);
+                    if (calib_mode_[e] == ISMRMRD_interleaved)
+                    {
+                        hoNDArray<bool> sampled = Gadgetron::detect_readout_sampling_status(ref_calib);
+
+                        Gadgetron::sum_over_dimension(ref_calib, ref_recon_buf, 5);
+
+                        size_t ro, e1, e2, cha, n, s, slc;
+
+                        for (slc = 0; slc < SLC; slc++)
+                        {
+                            for (n = 0; n < ref_calib.get_size(4); n++)
+                            {
+                                for (cha = 0; cha < CHA; cha++)
+                                {
+                                    for (e2 = 0; e2 < E2; e2++)
+                                    {
+                                        for (e1 = 0; e1 < E1; e1++)
+                                        {
+                                            float freq = 0;
+                                            for (s = 0; s < S; s++)
+                                            {
+                                                if (sampled(e1, e2, n, s, slc)) freq = freq + 1;
+                                            }
+
+                                            if (freq > 1)
+                                            {
+                                                float freq_reciprocal = (float)(1.0 / freq);
+
+                                                std::complex<float>* pAve = &(ref_recon_buf(0, e1, e2, cha, n, 0, slc));
+                                                for (ro = 0; ro < RO; ro++)
+                                                {
+                                                    pAve[ro] *= freq_reciprocal;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Gadgetron::sum_over_dimension(ref_calib, ref_recon_buf, 5);
+                        Gadgetron::scal((float)(1.0 / S), ref_recon_buf);
+                    }
+
                     ref_calib = ref_recon_buf;
                 }
             }

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.cpp
@@ -197,7 +197,39 @@ namespace Gadgetron {
                 {
                     if (calib_mode_[e] == ISMRMRD_interleaved)
                     {
-                        GADGET_CHECK_EXCEPTION_RETURN(this->averaging_with_sampling_times(ref, ref_calib), GADGET_FAIL);
+                        hoNDArray<bool> sampled = Gadgetron::detect_readout_sampling_status(ref);
+                        Gadgetron::sum_over_dimension(ref, ref_calib, 4);
+
+                        // for every E1/E2 location, count how many times it is sampled for all N
+                        size_t ro, e1, e2, cha, n, s, slc;
+                        for (slc = 0; slc < SLC; slc++)
+                        {
+                            for (cha = 0; cha < CHA; cha++)
+                            {
+                                for (e2 = 0; e2 < E2; e2++)
+                                {
+                                    for (e1 = 0; e1 < E1; e1++)
+                                    {
+                                        float freq = 0;
+
+                                        for (s = 0; s < S; s++)
+                                        {
+                                            for (n = 0; n < N; n++)
+                                            {
+                                                if (sampled(e1, e2, n, s, slc)) freq += 1;
+                                            }
+
+                                            if (freq > 1)
+                                            {
+                                                float freq_reciprocal = (float)(1.0 / freq);
+                                                std::complex<float>* pAve = &(ref_calib(0, e1, e2, cha, 0, s, slc));
+                                                for (ro = 0; ro < RO; ro++) pAve[ro] *= freq_reciprocal;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                     else
                     {
@@ -309,61 +341,6 @@ namespace Gadgetron {
         }
 
         return GADGET_OK;
-    }
-
-    void GenericCartesianReconReferencePrepGadget::averaging_with_sampling_times(const hoNDArray< std::complex<float> >& input, hoNDArray< std::complex<float> >& res)
-    {
-        try
-        {
-            hoNDArray<bool> sampled = Gadgetron::detect_readout_sampling_status(input);
-
-            // sum over N
-            Gadgetron::sum_over_dimension(input, res, 4);
-
-            size_t RO = input.get_size(0);
-            size_t E1 = input.get_size(1);
-            size_t E2 = input.get_size(2);
-            size_t CHA = input.get_size(3);
-            size_t N = input.get_size(4);
-            size_t S = input.get_size(5);
-            size_t SLC = input.get_size(6);
-
-            if (N == 1) return;
-
-            size_t ro, e1, e2, cha, n, s, slc;
-            for (slc = 0; slc < SLC; slc++)
-            {
-                for (cha = 0; cha < CHA; cha++)
-                {
-                    for (e2 = 0; e2 < E2; e2++)
-                    {
-                        for (e1 = 0; e1 < E1; e1++)
-                        {
-                            float freq = 0;
-
-                            for (s = 0; s < S; s++)
-                            {
-                                for (n = 0; n < N; n++)
-                                {
-                                    if (sampled(e1, e2, n, s, slc)) freq += 1;
-                                }
-
-                                if (freq > 1)
-                                {
-                                    float freq_reciprocal = (float)(1.0 / freq);
-                                    std::complex<float>* pAve = &(res(0, e1, e2, cha, 0, s, slc));
-                                    for (ro = 0; ro < RO; ro++) pAve[ro] *= freq_reciprocal;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        catch (...)
-        {
-            GERROR_STREAM("Exceptions happened in GenericCartesianReconReferencePrepGadget::averaging_with_sampling_times(...) ... ");
-        }
     }
 
     GADGET_FACTORY_DECLARE(GenericCartesianReconReferencePrepGadget)

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
@@ -99,13 +99,5 @@ namespace Gadgetron {
         // default interface function
         virtual int process_config(ACE_Message_Block* mb);
         virtual int process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1);
-
-        // --------------------------------------------------
-        // implementation functions
-        // --------------------------------------------------
-        /// averaging input by counting the time of sampling along N for a E1/E2 location
-        /// input: [RO E1 E2 CHA N S SLC]
-        /// res: [RO E1 E2 CHA 1 S SLC]
-        void averaging_with_sampling_times(const hoNDArray< std::complex<float> >& input, hoNDArray< std::complex<float> >& res);
     };
 }

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
@@ -50,6 +50,8 @@ namespace Gadgetron {
 
         /// ref preparation
         /// whether to average all N for ref generation
+        /// for the interleaved mode, the sampling times will be counted and used for averaging
+        /// it is recommended to set N as the interleaved dimension
         GADGET_PROPERTY(average_all_ref_N, bool, "Whether to average all N for ref generation", true);
         /// whether to average all S for ref generation
         GADGET_PROPERTY(average_all_ref_S, bool, "Whether to average all S for ref generation", false);
@@ -101,9 +103,9 @@ namespace Gadgetron {
         // --------------------------------------------------
         // implementation functions
         // --------------------------------------------------
-        /// averaging input by counting the time of sampling for a E1/E2 location
+        /// averaging input by counting the time of sampling along N for a E1/E2 location
         /// input: [RO E1 E2 CHA N S SLC]
-        /// if alongN==false, the averaging is performed along S dimension
-        void averaging_with_sampling_times(const hoNDArray< std::complex<float> >& input, hoNDArray< std::complex<float> >& res, bool alongN);
+        /// res: [RO E1 E2 CHA 1 S SLC]
+        void averaging_with_sampling_times(const hoNDArray< std::complex<float> >& input, hoNDArray< std::complex<float> >& res);
     };
 }

--- a/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
+++ b/gadgets/mri_core/GenericCartesianReconReferencePrepGadget.h
@@ -97,5 +97,13 @@ namespace Gadgetron {
         // default interface function
         virtual int process_config(ACE_Message_Block* mb);
         virtual int process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1);
+
+        // --------------------------------------------------
+        // implementation functions
+        // --------------------------------------------------
+        /// averaging input by counting the time of sampling for a E1/E2 location
+        /// input: [RO E1 E2 CHA N S SLC]
+        /// if alongN==false, the averaging is performed along S dimension
+        void averaging_with_sampling_times(const hoNDArray< std::complex<float> >& input, hoNDArray< std::complex<float> >& res, bool alongN);
     };
 }

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_RealTimeCine.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_RealTimeCine.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!--
+        Gadgetron generic recon chain for 2D and 3D cartesian sampling
+
+        RealTimeCine imaging
+        Triggered by slice
+        Recon N is phase and S is set
+
+        Author: Hui Xue
+        Magnetic Resonance Technology Program, National Heart, Lung and Blood Institute, National Institutes of Health
+        10 Center Drive, Bethesda, MD 20814, USA
+        Email: hui.xue@nih.gov
+    -->
+
+    <!-- reader -->
+    <reader><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageReader</classname></reader>
+
+    <!-- writer -->
+    <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
+
+    <!-- Noise prewhitening -->
+    <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
+
+    <!-- RO asymmetric echo handling -->
+    <gadget><name>AsymmetricEcho</name><dll>gadgetron_mricore</dll><classname>AsymmetricEchoAdjustROGadget</classname></gadget>
+
+    <!-- RO oversampling removal -->
+    <gadget><name>RemoveROOversampling</name><dll>gadgetron_mricore</dll><classname>RemoveROOversamplingGadget</classname></gadget>
+
+    <!-- Data accumulation and trigger gadget -->
+    <gadget>
+        <name>AccTrig</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value>slice</value></property>
+        <property><name>sorting_dimension</name><value>slice</value></property>
+    </gadget>
+
+    <gadget>
+        <name>Buff</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>BucketToBufferGadget</classname>
+        <property><name>N_dimension</name><value>phase</value></property>
+        <property><name>S_dimension</name><value>set</value></property>
+        <property><name>split_slices</name><value>true</value></property>
+        <property><name>ignore_segment</name><value>true</value></property>
+    </gadget>
+
+    <!-- Prep ref -->
+    <gadget>
+        <name>PrepRef</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericCartesianReconReferencePrepGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value>DebugFolder</value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>false</value></property>
+    </gadget>
+
+    <!-- Recon -->
+    <gadget>
+        <name>Recon</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericCartesianGrappaReconGadget</classname>
+
+        <!-- image series -->
+        <property><name>image_series</name><value>0</value></property>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value>DebugFolder</value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- whether to send out gfactor -->
+        <property><name>send_out_gfactor</name><value>true</value></property>
+    </gadget>
+
+    <!-- ImageArray to images -->
+    <gadget>
+        <name>ImageArraySplit</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageArraySplitGadget</classname>
+    </gadget>
+
+    <!-- after recon processing -->
+    <gadget>
+        <name>ComplexToFloatAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ComplexToFloatGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>ImageFinish</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>


### PR DESCRIPTION
a) Add ref preparation to count the sampling times for every E1/E2 location. It is required for interleaved mode if irregular sampling is used or number of frames cannot divide the acceleration factor in full.

b) Fix bugs in make_ref_coil_map

c) Fix BucketToBufferGadget to handle the case where acquisition has already been centered, e.g. passing the AsymmetricEchoHandling.