### PR TITLE
BUG: wrong variable name in coil_map_3d_Inati_Iter

### DIFF
--- a/toolboxes/mri_core/mri_core_coil_map_estimation.cpp
+++ b/toolboxes/mri_core/mri_core_coil_map_estimation.cpp
@@ -547,7 +547,7 @@ void coil_map_3d_Inati_Iter(const hoNDArray<T>& data, hoNDArray<T>& coilMap, siz
         size_t iter, cha;
 
         hoNDArray<T> dataByCha(RO*E1*E2, CHA, const_cast<T*>(data.begin()));
-        GADGET_CATCH_THROW(Gadgetron::sum_over_dimension(data, D_sum, 0));
+        GADGET_CATCH_THROW(Gadgetron::sum_over_dimension(dataByCha, D_sum, 0));
         Gadgetron::norm2(D_sum, v);
         Gadgetron::scal((value_type)1.0 / v, D_sum);
 


### PR DESCRIPTION
This fixes what I believe is a bug in the 3D iterative coil map routine.  I believe the intent of the `sum_over_dimensions``  line modified here, was to sum all non-channel dimensions.  There was a reshape of via ``dataByCha`` to facilitate this but the reshaped array isn't used in the subsequent call.

Also, I made a simple python based implementation of this same iterative coilmap estimation that I am willing to contribute to https://github.com/ismrmrd/ismrmrd-python-tools if there is interest.  It would complement the Walsh method that is already implemented there.