### PR TITLE
WIP: fixing Matlab coil map wrappers

### DIFF
--- a/apps/standalone/cpu/gtplus/CMakeLists.txt
+++ b/apps/standalone/cpu/gtplus/CMakeLists.txt
@@ -56,6 +56,14 @@ if (MATLAB_FOUND)
         SET_TARGET_PROPERTIES(Matlab_gt_write_analyze PROPERTIES SUFFIX ${MATLAB_SUFFIX})
         install(TARGETS Matlab_gt_write_analyze DESTINATION ${GADGETRON_INSTALL_MATLAB_PATH} COMPONENT main)
 
+        add_library(Matlab_compute_coil_map_2D SHARED Matlab_compute_coil_map_2D.cpp)
+        SET_TARGET_PROPERTIES(Matlab_compute_coil_map_2D PROPERTIES SUFFIX ${MATLAB_SUFFIX})
+        install(TARGETS Matlab_compute_coil_map_2D DESTINATION ${GADGETRON_INSTALL_MATLAB_PATH} COMPONENT main)
+
+        add_library(Matlab_compute_coil_map_3D SHARED Matlab_compute_coil_map_3D.cpp)
+        SET_TARGET_PROPERTIES(Matlab_compute_coil_map_3D PROPERTIES SUFFIX ${MATLAB_SUFFIX})
+        install(TARGETS Matlab_compute_coil_map_3D DESTINATION ${GADGETRON_INSTALL_MATLAB_PATH} COMPONENT main)
+
     endif ( MKL_FOUND AND FFTW3_FOUND )
 
 else(MATLAB_FOUND)

--- a/apps/standalone/cpu/gtplus/Matlab_compute_coil_map_2D.cpp
+++ b/apps/standalone/cpu/gtplus/Matlab_compute_coil_map_2D.cpp
@@ -85,12 +85,12 @@ void mexFunction(int nlhs,mxArray *plhs[],int nrhs,const mxArray *prhs[])
         const mwSize* dims = mxGetDimensions(prhs[0]);
 
         // algo
-        Gadgetron::gtPlus::ISMRMRDCOILMAPALGO algo = Gadgetron::gtPlus::ISMRMRD_SOUHEIL_ITER;
+        Gadgetron::ISMRMRDCOILMAPALGO algo = Gadgetron::ISMRMRD_SOUHEIL_ITER;
         std::string algoStr;
         converter.Matlab2Str(prhs[1], algoStr);
         if ( algoStr == "ISMRMRD_SOUHEIL" )
         {
-            algo = Gadgetron::gtPlus::ISMRMRD_SOUHEIL;
+            algo = Gadgetron::ISMRMRD_SOUHEIL;
         }
 
         // ks

--- a/apps/standalone/cpu/gtplus/Matlab_compute_coil_map_3D.cpp
+++ b/apps/standalone/cpu/gtplus/Matlab_compute_coil_map_3D.cpp
@@ -86,12 +86,12 @@ void mexFunction(int nlhs,mxArray *plhs[],int nrhs,const mxArray *prhs[])
         const mwSize* dims = mxGetDimensions(prhs[0]);
 
         // algo
-        Gadgetron::gtPlus::ISMRMRDCOILMAPALGO algo = Gadgetron::gtPlus::ISMRMRD_SOUHEIL_ITER;
+        Gadgetron::ISMRMRDCOILMAPALGO algo = Gadgetron::ISMRMRD_SOUHEIL_ITER;
         std::string algoStr;
         converter.Matlab2Str(prhs[1], algoStr);
         if ( algoStr == "ISMRMRD_SOUHEIL" )
         {
-            algo = Gadgetron::gtPlus::ISMRMRD_SOUHEIL;
+            algo = Gadgetron::ISMRMRD_SOUHEIL;
         }
 
         // ks


### PR DESCRIPTION
I noticed that there are Matlab wrappers to the 2D and 3D coil map estimation routines in the codebase, but that these are not being built.  I added them to CMakeLists.txt and fixed a few namespace inconsistencies so that they build successfully.

After this, the build completes and I can find the MEX files in my build directory, but they do not seem to automatically end up in /usr/local/gadgetron/ after "make install", so perhaps I missed another necessary change somewhere?  I have very little familiarity with CMake.

Unfortunately, my Matlab installation is a bit outdated/broken at the moment and I get some library version conflicts when I try to actually call the routines, so I was unable to verify that they are working properly:
```
Invalid MEX-file '/usr/local/gadgetron/bin/libMatlab_compute_coil_map_3D.mexa64':
/usr/local/MATLAB/R2012a/bin/glnxa64/../../sys/os/glnxa64/libgfortran.so.3: version
`GFORTRAN_1.4' not found (required by /usr/lib/libarpack.so.2)
```

It is not a high priority for me to get this running, as I have moved away from using Matlab in most of my current work, but I thought I would bring it up.
