### PR TITLE
ReST Interface

### DIFF
--- a/apps/gadgetron/CMakeLists.txt
+++ b/apps/gadgetron/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/apps/gadgetron
   ${CMAKE_SOURCE_DIR}/toolboxes/cloudbus
+  ${CMAKE_SOURCE_DIR}/toolboxes/rest
   ${CMAKE_SOURCE_DIR}/toolboxes/gadgettools
   ${CMAKE_SOURCE_DIR}/toolboxes/core
   ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/hostutils
@@ -33,6 +34,7 @@ add_executable(gadgetron
 target_link_libraries(gadgetron 
   gadgetron_gadgetbase
   gadgetron_toolbox_log
+  gadgetron_toolbox_rest
   gadgetron_toolbox_gadgettools gadgetron_toolbox_cloudbus 
   optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} 
  )

--- a/apps/gadgetron/gadgetron.xml.example
+++ b/apps/gadgetron/gadgetron.xml.example
@@ -9,6 +9,10 @@
     <relayAddress>localhost</relayAddress>
     <port>8002</port>
   </cloudBus>
+
+  <rest>
+    <port>9080</port>
+  </rest>
   
 </gadgetronConfiguration>
   

--- a/apps/gadgetron/gadgetron_xml.cpp
+++ b/apps/gadgetron/gadgetron_xml.cpp
@@ -44,6 +44,15 @@ namespace GadgetronXML
       h.cloudBus = cb;
     }
 
+    pugi::xml_node r = root.child("rest");
+    if (r) {
+      ReST re;
+      re.port = static_cast<unsigned int>(std::atoi(r.child_value("port")));
+      if (re.port == 0) {
+	throw std::runtime_error("Invalid ReST configuration.");
+      }
+      h.rest = re;
+    }
   }
 
   void deserialize(const char* xml_config, GadgetStreamConfiguration& cfg)

--- a/apps/gadgetron/gadgetron_xml.h
+++ b/apps/gadgetron/gadgetron_xml.h
@@ -80,11 +80,17 @@ namespace GadgetronXML
   };
 
 
+  struct ReST
+  {
+    unsigned int port;
+  };
+  
   struct GadgetronConfiguration
   {
     std::string port;
     std::vector<GadgetronParameter> globalGadgetParameter;
-    Optional<CloudBus> cloudBus;    
+    Optional<CloudBus> cloudBus;
+    Optional<ReST> rest;
   };
 
   void EXPORTGADGETBASE deserialize(const char* xml_config, GadgetronConfiguration& h);

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -5,6 +5,8 @@
 #include "gadgetron_config.h"
 #include "gadgetron_paths.h"
 #include "CloudBus.h"
+#include "gadgetron_rest.h"
+#include "gadgetron_system_info.h"
 
 #include <ace/Log_Msg.h>
 #include <ace/Service_Config.h>
@@ -129,6 +131,21 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 	relay_port = c.cloudBus->port;
       }
 
+      if (c.rest) {
+	Gadgetron::ReST::GadgetronReST::port_ = c.rest->port;
+	Gadgetron::ReST::GadgetronReST::instance(); //Fire up the server
+	
+	Gadgetron::ReST::GadgetronReST::instance()->resource["^/info$"]["GET"]=[](Gadgetron::ReST::GadgetronReST::Response& response,
+										  std::shared_ptr<Gadgetron::ReST::GadgetronReST::Request> request)
+	  {
+	    std::stringstream ss;
+	    print_system_information(ss);
+	    std::string content = ss.str();
+	    response << "HTTP/1.1 200 OK\r\nContent-Length: " << content.length() << "\r\n\r\n" << content;
+	  };
+	Gadgetron::ReST::GadgetronReST::instance()->update_resources();
+      }
+      
       for (std::vector<GadgetronXML::GadgetronParameter>::iterator it = c.globalGadgetParameter.begin();
 	   it != c.globalGadgetParameter.end();
 	   ++it)

--- a/toolboxes/CMakeLists.txt
+++ b/toolboxes/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(klt)
 add_subdirectory(nfft)
 add_subdirectory(dwt)
 add_subdirectory(registration)
+add_subdirectory(rest)
 
 IF (ACE_FOUND)
   add_subdirectory(gadgettools)

--- a/toolboxes/rest/CMakeLists.txt
+++ b/toolboxes/rest/CMakeLists.txt
@@ -1,0 +1,25 @@
+find_package(Boost COMPONENTS regex system thread coroutine context filesystem date_time REQUIRED)
+find_package( Threads )
+
+include_directories(${Boost_INCLUDE_DIR})
+
+add_library(gadgetron_toolbox_rest SHARED
+  gadgetron_rest.cpp
+  gadgetron_rest.h
+  gadgetron_rest_exports.h
+)
+
+target_link_libraries(gadgetron_toolbox_rest
+		      gadgetron_toolbox_log
+		      ${Boost_LIBRARIES}
+		      ${CMAKE_THREAD_LIBS_INIT})
+
+set_target_properties(gadgetron_toolbox_rest PROPERTIES COMPILE_DEFINITIONS "__BUILD_GADGETRON_REST__")
+set_target_properties(gadgetron_toolbox_rest  PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
+
+install(TARGETS gadgetron_toolbox_rest DESTINATION lib COMPONENT main)
+
+install(FILES 
+  gadgetron_rest.h
+  gadgetron_rest_exports.h
+  DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH} COMPONENT main)

--- a/toolboxes/rest/gadgetron_rest.cpp
+++ b/toolboxes/rest/gadgetron_rest.cpp
@@ -1,25 +1,35 @@
 #include "gadgetron_rest.h"
-#include <thread>
 
 namespace Gadgetron
 {
-  namespace REST
+  namespace ReST
   {
-    Server<HTTP>* Server<HTTP>::instance_ = nullptr;
-    unsigned int Server<HTTP>::port_ = 8080;
-    size_t Server<HTTP>::threads_ = 1;
+    GadgetronReST* GadgetronReST::instance_ = nullptr;
+    unsigned int GadgetronReST::port_ = 9080;
+    size_t GadgetronReST::threads_ = 1;
     
-    Server<HTTP>* Server<HTTP>::instance()
+    GadgetronReST* GadgetronReST::instance()
     {
       if (!instance_) {
-	instance_ = new Server<HTTP>(port_,threads_);
-	Server<HTTP>* tmp = instance_;
-	std::thread server_thread([tmp](){
-	    tmp->start();
-	});
-	    
+	instance_ = new GadgetronReST(port_,threads_);
+
+	instance_->default_resource["GET"]=[](GadgetronReST::Response& response, std::shared_ptr<GadgetronReST::Request> request)
+	  {
+	    std::string content = "<html><body><h1>GADGETRON</h1></body></html>\n";
+	    response << "HTTP/1.1 200 OK\r\nContent-Length: " << content.length() << "\r\n\r\n" << content;
+	  };
+	
+	instance_->open();
       }
       return instance_;
+    }
+
+    void GadgetronReST::open()
+    {
+      GadgetronReST* tmp = this;
+      server_thread_ = std::thread([tmp](){
+	  tmp->start();
+	});
     }
   }
 }

--- a/toolboxes/rest/gadgetron_rest.cpp
+++ b/toolboxes/rest/gadgetron_rest.cpp
@@ -1,0 +1,25 @@
+#include "gadgetron_rest.h"
+#include <thread>
+
+namespace Gadgetron
+{
+  namespace REST
+  {
+    Server<HTTP>* Server<HTTP>::instance_ = nullptr;
+    unsigned int Server<HTTP>::port_ = 8080;
+    size_t Server<HTTP>::threads_ = 1;
+    
+    Server<HTTP>* Server<HTTP>::instance()
+    {
+      if (!instance_) {
+	instance_ = new Server<HTTP>(port_,threads_);
+	Server<HTTP>* tmp = instance_;
+	std::thread server_thread([tmp](){
+	    tmp->start();
+	});
+	    
+      }
+      return instance_;
+    }
+  }
+}

--- a/toolboxes/rest/gadgetron_rest.h
+++ b/toolboxes/rest/gadgetron_rest.h
@@ -1,0 +1,394 @@
+#ifndef GADGETRON_REST_H
+#define	GADGETRON_REST_H
+
+#include <boost/asio.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/regex.hpp>
+
+#include <unordered_map>
+#include <thread>
+#include <functional>
+#include <iostream>
+#include <sstream>
+
+/*
+
+  This simple webserver was inspired by:
+
+  https://github.com/eidheim/Simple-Web-Server
+
+  We have made modifications but it is largely unchanged.
+  We are including the license text here to comply with the original license. 
+
+  The MIT License (MIT)
+
+  Copyright (c) 2014 Ole Christian Eidheim
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*/
+
+
+namespace Gadgetron {
+  namespace REST {
+  
+    template <class socket_type> class ServerBase
+      {
+      public:
+	class Response : public std::ostream {
+	friend class ServerBase<socket_type>;
+      private:
+	boost::asio::yield_context& yield;
+            
+	boost::asio::streambuf streambuf;
+
+	socket_type &socket;
+            
+      Response(boost::asio::io_service& io_service, socket_type &socket, boost::asio::yield_context& yield): 
+	std::ostream(&streambuf), yield(yield), socket(socket) {}
+                        
+      public:
+	size_t size() {
+	  return streambuf.size();
+	}
+	void flush() {
+	  boost::system::error_code ec;
+	  boost::asio::async_write(socket, streambuf, yield[ec]);
+                
+	  if(ec)
+	    throw std::runtime_error(ec.message());
+	}
+      };
+        
+      class Content : public std::istream {
+	friend class ServerBase<socket_type>;
+      public:
+	size_t size() {
+	  return streambuf.size();
+	}
+	std::string string() {
+	  std::stringstream ss;
+	  ss << rdbuf();
+	  return ss.str();
+	}
+      private:
+	boost::asio::streambuf &streambuf;
+      Content(boost::asio::streambuf &streambuf): std::istream(&streambuf), streambuf(streambuf) {}
+      };
+        
+      class Request {
+	friend class ServerBase<socket_type>;
+      public:
+	std::string method, path, http_version;
+
+	Content content;
+
+	std::unordered_multimap<std::string, std::string> header;
+
+	boost::smatch path_match;
+            
+	std::string remote_endpoint_address;
+	unsigned short remote_endpoint_port;
+            
+      private:
+      Request(boost::asio::io_service &io_service): content(streambuf), strand(io_service) {}
+            
+	boost::asio::streambuf streambuf;
+            
+	boost::asio::strand strand;
+            
+	void read_remote_endpoint_data(socket_type& socket) {
+	  try {
+	    remote_endpoint_address=socket.lowest_layer().remote_endpoint().address().to_string();
+	    remote_endpoint_port=socket.lowest_layer().remote_endpoint().port();
+	  }
+	  catch(const std::exception& e) {}
+	}
+      };
+        
+      std::unordered_map<std::string, std::unordered_map<std::string, 
+	std::function<void(typename ServerBase<socket_type>::Response&, std::shared_ptr<typename ServerBase<socket_type>::Request>)> > >  resource;
+        
+      std::unordered_map<std::string, 
+	std::function<void(typename ServerBase<socket_type>::Response&, std::shared_ptr<typename ServerBase<socket_type>::Request>)> > default_resource;
+
+      private:
+      std::vector<std::pair<std::string, std::vector<std::pair<boost::regex,
+	std::function<void(typename ServerBase<socket_type>::Response&, std::shared_ptr<typename ServerBase<socket_type>::Request>)> > > > > opt_resource;
+        
+      public:
+      void start() {
+	//Copy the resources to opt_resource for more efficient request processing
+	opt_resource.clear();
+	for(auto& res: resource) {
+	  for(auto& res_method: res.second) {
+	    auto it=opt_resource.end();
+	    for(auto opt_it=opt_resource.begin();opt_it!=opt_resource.end();opt_it++) {
+	      if(res_method.first==opt_it->first) {
+		it=opt_it;
+		break;
+	      }
+	    }
+	    if(it==opt_resource.end()) {
+	      opt_resource.emplace_back();
+	      it=opt_resource.begin()+(opt_resource.size()-1);
+	      it->first=res_method.first;
+	    }
+	    it->second.emplace_back(boost::regex(res.first), res_method.second);
+	  }
+	}
+                        
+	accept(); 
+            
+	//If num_threads>1, start m_io_service.run() in (num_threads-1) threads for thread-pooling
+	threads.clear();
+	for(size_t c=1;c<num_threads;c++) {
+	  threads.emplace_back([this](){
+	      io_service.run();
+	    });
+	}
+
+	//Main thread
+	io_service.run();
+
+	//Wait for the rest of the threads, if any, to finish as well
+	for(auto& t: threads) {
+	  t.join();
+	}
+      }
+        
+      void stop() {
+	io_service.stop();
+      }
+
+      protected:
+      boost::asio::io_service io_service;
+      boost::asio::ip::tcp::endpoint endpoint;
+      boost::asio::ip::tcp::acceptor acceptor;
+      size_t num_threads;
+      std::vector<std::thread> threads;
+        
+      size_t timeout_request;
+      size_t timeout_content;
+        
+      ServerBase(unsigned short port, size_t num_threads, size_t timeout_request, size_t timeout_send_or_receive) : 
+      endpoint(boost::asio::ip::tcp::v4(), port), acceptor(io_service, endpoint),
+	num_threads(num_threads), timeout_request(timeout_request), timeout_content(timeout_send_or_receive) {}
+        
+      virtual void accept()=0;
+        
+      std::shared_ptr<boost::asio::deadline_timer> set_timeout_on_socket(std::shared_ptr<socket_type> socket, size_t seconds) {
+	std::shared_ptr<boost::asio::deadline_timer> timer(new boost::asio::deadline_timer(io_service));
+	timer->expires_from_now(boost::posix_time::seconds(seconds));
+	timer->async_wait([socket](const boost::system::error_code& ec){
+	    if(!ec) {
+	      boost::system::error_code ec;
+	      socket->lowest_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+	      socket->lowest_layer().close();
+	    }
+	  });
+	return timer;
+      }
+        
+      std::shared_ptr<boost::asio::deadline_timer> set_timeout_on_socket(std::shared_ptr<socket_type> socket, std::shared_ptr<Request> request, size_t seconds) {
+	std::shared_ptr<boost::asio::deadline_timer> timer(new boost::asio::deadline_timer(io_service));
+	timer->expires_from_now(boost::posix_time::seconds(seconds));
+	timer->async_wait(request->strand.wrap([socket](const boost::system::error_code& ec){
+	      if(!ec) {
+		boost::system::error_code ec;
+		socket->lowest_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+		socket->lowest_layer().close();
+	      }
+	    }));
+	return timer;
+      }
+        
+      void read_request_and_content(std::shared_ptr<socket_type> socket) {
+	//Create new streambuf (Request::streambuf) for async_read_until()
+	//shared_ptr is used to pass temporary objects to the asynchronous functions
+	std::shared_ptr<Request> request(new Request(io_service));
+	request->read_remote_endpoint_data(*socket);
+
+	//Set timeout on the following boost::asio::async-read or write function
+	std::shared_ptr<boost::asio::deadline_timer> timer;
+	if(timeout_request>0)
+	  timer=set_timeout_on_socket(socket, timeout_request);
+                        
+	boost::asio::async_read_until(*socket, request->streambuf, "\r\n\r\n",
+				      [this, socket, request, timer](const boost::system::error_code& ec, size_t bytes_transferred) {
+					if(timeout_request>0)
+					  timer->cancel();
+					if(!ec) {
+					  //request->streambuf.size() is not necessarily the same as bytes_transferred, from Boost-docs:
+					  //"After a successful async_read_until operation, the streambuf may contain additional data beyond the delimiter"
+					  //The chosen solution is to extract lines from the stream directly when parsing the header. What is left of the
+					  //streambuf (maybe some bytes of the content) is appended to in the async_read-function below (for retrieving content).
+					  size_t num_additional_bytes=request->streambuf.size()-bytes_transferred;
+                    
+					  parse_request(request, request->content);
+                    
+					  //If content, read that as well
+					  const auto it=request->header.find("Content-Length");
+					  if(it!=request->header.end()) {
+					    //Set timeout on the following boost::asio::async-read or write function
+					    std::shared_ptr<boost::asio::deadline_timer> timer;
+					    if(timeout_content>0)
+					      timer=set_timeout_on_socket(socket, timeout_content);
+					    unsigned long long content_length;
+					    try {
+					      content_length=stoull(it->second);
+					    }
+					    catch(const std::exception &e) {
+					      return;
+					    }
+					    boost::asio::async_read(*socket, request->streambuf, 
+								    boost::asio::transfer_exactly(content_length-num_additional_bytes),
+								    [this, socket, request, timer]
+								    (const boost::system::error_code& ec, size_t /*bytes_transferred*/) {
+								      if(timeout_content>0)
+									timer->cancel();
+								      if(!ec)
+									find_resource(socket, request);
+								    });
+					  }
+					  else {
+					    find_resource(socket, request);
+					  }
+					}
+				      });
+      }
+
+      void parse_request(std::shared_ptr<Request> request, std::istream& stream) const {
+	std::string line;
+	getline(stream, line);
+	size_t method_end=line.find(' ');
+	size_t path_end=line.find(' ', method_end+1);
+	if(method_end!=std::string::npos && path_end!=std::string::npos) {
+	  request->method=line.substr(0, method_end);
+	  request->path=line.substr(method_end+1, path_end-method_end-1);
+	  request->http_version=line.substr(path_end+6, line.size()-path_end-7);
+
+	  getline(stream, line);
+	  size_t param_end=line.find(':');
+	  while(param_end!=std::string::npos) {                
+	    size_t value_start=param_end+1;
+	    if(line[value_start]==' ')
+	      value_start++;
+
+	    std::string key=line.substr(0, param_end);
+	    request->header.insert(std::make_pair(key, line.substr(value_start, line.size()-value_start-1)));
+
+	    getline(stream, line);
+	    param_end=line.find(':');
+	  }
+	}
+      }
+
+      void find_resource(std::shared_ptr<socket_type> socket, std::shared_ptr<Request> request) {
+	//Find path- and method-match, and call write_response
+	for(auto& res: opt_resource) {
+	  if(request->method==res.first) {
+	    for(auto& res_path: res.second) {
+	      boost::smatch sm_res;
+	      if(boost::regex_match(request->path, sm_res, res_path.first)) {
+		request->path_match=std::move(sm_res);
+		write_response(socket, request, res_path.second);
+		return;
+	      }
+	    }
+	  }
+	}
+	auto it_method=default_resource.find(request->method);
+	if(it_method!=default_resource.end()) {
+	  write_response(socket, request, it_method->second);
+	}
+      }
+        
+      void write_response(std::shared_ptr<socket_type> socket, std::shared_ptr<Request> request, 
+			  std::function<void(typename ServerBase<socket_type>::Response&, std::shared_ptr<typename ServerBase<socket_type>::Request>)>& resource_function) {
+	//Set timeout on the following boost::asio::async-read or write function
+	std::shared_ptr<boost::asio::deadline_timer> timer;
+	if(timeout_content>0)
+	  timer=set_timeout_on_socket(socket, request, timeout_content);
+
+	boost::asio::spawn(request->strand, [this, &resource_function, socket, request, timer](boost::asio::yield_context yield) {
+	    Response response(io_service, *socket, yield);
+
+	    try {
+	      resource_function(response, request);
+	    }
+	    catch(const std::exception& e) {
+	      return;
+	    }
+                
+	    if(response.size()>0) {
+	      try {
+		response.flush();
+	      }
+	      catch(const std::exception &e) {
+		return;
+	      }
+	    }
+	    if(timeout_content>0)
+	      timer->cancel();
+	    if(stof(request->http_version)>1.05)
+	      read_request_and_content(socket);
+	  });
+      }
+      };
+    
+    template<class socket_type>
+      class Server : public ServerBase<socket_type> {};
+    
+    typedef boost::asio::ip::tcp::socket HTTP;
+    
+    template<> class Server<HTTP> : public ServerBase<HTTP> {
+
+    public:
+      static Server<HTTP>* instance();
+      static unsigned int port_;
+      static size_t threads_;
+      
+    private:
+      static Server<HTTP>* instance_;
+      
+    Server(unsigned short port, size_t num_threads=1, size_t timeout_request=5, size_t timeout_content=300) : 
+      ServerBase<HTTP>::ServerBase(port, num_threads, timeout_request, timeout_content) {}
+      
+      void accept() {
+	//Create new socket for this connection
+	//Shared_ptr is used to pass temporary objects to the asynchronous functions
+	std::shared_ptr<HTTP> socket(new HTTP(io_service));
+                        
+	acceptor.async_accept(*socket, [this, socket](const boost::system::error_code& ec){
+	    //Immediately start accepting a new connection
+	    accept();
+                                
+	    if(!ec) {
+	      boost::asio::ip::tcp::no_delay option(true);
+	      socket->set_option(option);
+                    
+	      read_request_and_content(socket);
+	    }
+	  });
+      }
+    };
+  }
+}
+#endif	//GADGETRON_REST_H

--- a/toolboxes/rest/gadgetron_rest.h
+++ b/toolboxes/rest/gadgetron_rest.h
@@ -13,6 +13,8 @@
 #include <thread>
 #include <mutex>
 
+#include "gadgetron_rest_exports.h"
+
 /*
 
   This simple webserver was inspired by:
@@ -368,7 +370,7 @@ namespace Gadgetron {
     
     typedef boost::asio::ip::tcp::socket HTTP;
     
-    template<> class Server<HTTP> : public ServerBase<HTTP> {
+    template<> class EXPORTREST Server<HTTP> : public ServerBase<HTTP> {
 
     public:
       static Server<HTTP>* instance();

--- a/toolboxes/rest/gadgetron_rest_exports.h
+++ b/toolboxes/rest/gadgetron_rest_exports.h
@@ -1,0 +1,14 @@
+#ifndef REST_EXPORT_H_
+#define REST_EXPORT_H_
+
+#if defined (WIN32)
+    #if defined (__BUILD_GADGETRON_REST__) || defined (gadgetron_toolbox_rest_EXPORTS)
+        #define EXPORTREST __declspec(dllexport)
+    #else
+        #define EXPORTREST __declspec(dllimport)
+    #endif
+#else
+    #define EXPORTREST
+#endif
+
+#endif


### PR DESCRIPTION
As discussed, here is a first stab at some kind of configurable ReST interface.

If you remember to update your gadgetron.xml config file as per the new example to set the ReST interface port, you should be able to access the interface with something like:

    LCE-ML01943636:~ hansenms$ curl http://localhost:9080/info 
    Gadgetron Version Info
      -- Version            : 3.9.1
      -- Git SHA1           : c5e253e6432026643a2b73bd13bf7bbbbf857d78
      -- System Memory size : 16384 MB
      -- Python Support     : YES
      -- Matlab Support     : YES
      -- CUDA Support       : NO

Or you can of course use your browser. With the proposed interface, it is possible to add web pages from any Gadget or other component of the gadgetron and thus enable user interaction. Right now, we just have the info option, but it should be fairly easy ti extrapolate from there.

@naegelejd, @inati What do you think?

@xueh2 Does this compile on Windows? What do you think?

