### PR TITLE
Rest cloud

### DIFF
--- a/apps/gadgetron/GadgetServerAcceptor.cpp
+++ b/apps/gadgetron/GadgetServerAcceptor.cpp
@@ -17,9 +17,9 @@ int GadgetServerAcceptor::open (const ACE_INET_Addr &listen_addr)
   }
 
   //Register a way to close the Acceptor via the ReST API
-  Gadgetron::ReST::instance()->server().route_dynamic("/acceptor/close")([a = this]()
+  Gadgetron::ReST::instance()->server().route_dynamic("/acceptor/close")([this]()
   {
-    a->close();
+    this->close();
     return "Acceptor closed\n";
   });
 

--- a/apps/gadgetron/GadgetServerAcceptor.cpp
+++ b/apps/gadgetron/GadgetServerAcceptor.cpp
@@ -1,3 +1,4 @@
+#include "gadgetron_rest.h"
 #include "GadgetServerAcceptor.h"
 #include "GadgetStreamController.h"
 
@@ -14,6 +15,13 @@ int GadgetServerAcceptor::open (const ACE_INET_Addr &listen_addr)
     GERROR("error opening acceptor\n");
     return -1;
   }
+
+  //Register a way to close the Acceptor via the ReST API
+  Gadgetron::ReST::instance()->server().route_dynamic("/acceptor/close")([a = this]()
+  {
+    a->close();
+    return "Acceptor closed\n";
+  });
 
   return this->reactor ()->register_handler(this, ACE_Event_Handler::ACCEPT_MASK);
 }

--- a/apps/gadgetron/GadgetServerAcceptor.h
+++ b/apps/gadgetron/GadgetServerAcceptor.h
@@ -22,6 +22,11 @@ public:
   virtual int handle_close (ACE_HANDLE handle,
                             ACE_Reactor_Mask close_mask);
 
+  int close()
+  {
+    return this->acceptor_.close();
+  }
+  
   std::map<std::string, std::string> global_gadget_parameters_;
 
 protected:

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -236,7 +236,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
   acceptor.reactor (ACE_Reactor::instance ());
   if (acceptor.open (port_to_listen) == -1)
     return 1;
-
+  
   ACE_Reactor::instance()->run_reactor_event_loop ();
 
   return 0;

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -91,6 +91,7 @@ void print_usage()
   GINFO("gadgetron   -p <PORT>                      (default 9002)       \n");
   GINFO("            -r <RELAY HOST>                (default localhost)  \n");
   GINFO("            -l <RELAY PORT>                (default 0, disabled)\n");
+  GINFO("            -R <REST PORT>                 (default 0, disabled)\n");
 }
 
 int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
@@ -205,10 +206,19 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     Gadgetron::CloudBus::set_relay_address(relay_host);
     Gadgetron::CloudBus::set_relay_port(relay_port);
     Gadgetron::CloudBus::set_gadgetron_port(std::atoi(port_no));
+    Gadgetron::CloudBus::set_rest_port(rest_port);
     Gadgetron::CloudBus* cb = Gadgetron::CloudBus::instance();//This actually starts the bus.
     gadget_parameters["using_cloudbus"] = std::string("true"); //This is our message to the Gadgets that we have activated the bus
+    if (rest_port) {
+      Gadgetron::ReST::instance()->server()
+	.route_dynamic("/cloudbus/active_recons")([]()
+						  {
+						    std::stringstream str;
+						    str << Gadgetron::CloudBus::instance()->active_reconstructions();
+						    return str.str();
+						  });
+    }
   }
-
 
   // if the working directory is not set, use the default path
   if ( !workingDirectorySet )

--- a/toolboxes/cloudbus/CMakeLists.txt
+++ b/toolboxes/cloudbus/CMakeLists.txt
@@ -2,7 +2,8 @@ find_package(ACE REQUIRED)
 find_package(Boost REQUIRED)
 
 include_directories(${ACE_INCLUDE_DIR}
-                    ${Boost_INCLUDE_DIR} 
+                    ${Boost_INCLUDE_DIR}
+		    ${CMAKE_SOURCE_DIR}/toolboxes/rest
                     )
 
 add_library(gadgetron_toolbox_cloudbus SHARED
@@ -30,6 +31,7 @@ add_executable(gadgetron_cloudbus_relay cloudbus_relay.cpp)
 target_link_libraries(gadgetron_cloudbus_relay 
                      gadgetron_toolbox_cloudbus 
 		     gadgetron_toolbox_log
+		     gadgetron_toolbox_rest
                      optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} )
 
 

--- a/toolboxes/cloudbus/CloudBus.h
+++ b/toolboxes/cloudbus/CloudBus.h
@@ -76,6 +76,8 @@ namespace Gadgetron
     static void set_relay_port(int port);
     static void set_query_only(bool m = true);
     static void set_gadgetron_port(uint32_t port);
+    static void set_rest_port(uint32_t port);
+    
     void set_compute_capability(uint32_t c);
 
     void send_node_info();    
@@ -101,7 +103,8 @@ namespace Gadgetron
     static int relay_port_;
     static bool query_mode_; //Listen only
     static int gadgetron_port_;
-
+    static int rest_port_;
+    
     GadgetronNodeInfo node_info_;
     std::vector<GadgetronNodeInfo> nodes_;
     

--- a/toolboxes/cloudbus/cloudbus_io.h
+++ b/toolboxes/cloudbus/cloudbus_io.h
@@ -4,6 +4,7 @@
 #include <exception>
 #include <cstring>
 #include <vector>
+#include <chrono>
 
 namespace Gadgetron
 {
@@ -21,8 +22,10 @@ namespace Gadgetron
     std::string uuid;
     std::string address;
     uint32_t port;
+    uint32_t rest_port;
     uint32_t compute_capability;
     uint32_t active_reconstructions;
+    std::time_t last_recon;
   };
 
   size_t calculate_node_info_length(GadgetronNodeInfo& n)
@@ -30,7 +33,8 @@ namespace Gadgetron
     size_t len = 0;
     len += 4 + n.uuid.size();
     len += 4 + n.address.size();
-    len += 12;
+    len += 4*sizeof(uint32_t);
+    len += sizeof(std::time_t);
     return len;
   }
   
@@ -49,8 +53,10 @@ namespace Gadgetron
     memcpy ((buffer+pos), n.address.c_str(), n.address.size() ); pos += n.address.size();
 
     *((uint32_t*)(buffer + pos)) = n.port; pos += 4;
+    *((uint32_t*)(buffer + pos)) = n.rest_port; pos += 4;
     *((uint32_t*)(buffer + pos)) = n.compute_capability; pos += 4;
     *((uint32_t*)(buffer + pos)) = n.active_reconstructions; pos += 4;
+    *((std::time_t*)(buffer + pos)) = n.last_recon; pos += sizeof(std::time_t);
     
     return pos;
   }
@@ -68,9 +74,10 @@ namespace Gadgetron
     n.address = std::string(buffer+pos,address_size); pos += address_size;
 
     n.port = *((uint32_t*)(buffer+pos)); pos += 4;
+    n.rest_port = *((uint32_t*)(buffer+pos)); pos += 4;
     n.compute_capability = *((uint32_t*)(buffer+pos)); pos += 4;
     n.active_reconstructions = *((uint32_t*)(buffer+pos)); pos += 4;
-    
+    n.last_recon = *((std::time_t*)(buffer+pos)); pos += sizeof(std::time_t);
     return pos;
   }
 

--- a/toolboxes/cloudbus/cloudbus_relay.cpp
+++ b/toolboxes/cloudbus/cloudbus_relay.cpp
@@ -1,3 +1,5 @@
+#include "gadgetron_rest.h"
+
 #include "ace/Reactor.h"
 #include "ace/SOCK_Acceptor.h"
 #include "ace/Svc_Handler.h"
@@ -6,6 +8,7 @@
 #include "ace/Stream.h"
 
 #include <map>
+#include <chrono>
 
 #include "log.h"
 #include "CloudBus.h"
@@ -62,7 +65,11 @@ namespace Gadgetron{
     void add_node(CloudBusNodeController* c, GadgetronNodeInfo n)
     {
       mtx_.acquire();
-      GDEBUG("Adding node: %s, %s, %d, (active reconstructions: %d)\n", n.uuid.c_str(), n.address.c_str(), n.port, n.active_reconstructions);
+      auto t = std::chrono::system_clock::from_time_t(n.last_recon);
+      std::chrono::duration<double> time_since_last_recon =
+	std::chrono::system_clock::now() - t;
+      GDEBUG("Adding node: %s, %s, %d, (active reconstructions: %d, last recon %f s)\n",
+	     n.uuid.c_str(), n.address.c_str(), n.port, n.active_reconstructions, time_since_last_recon.count());
       node_map_[c] = n;
       mtx_.release();
     }
@@ -256,16 +263,22 @@ namespace Gadgetron{
 int main(int argc, char** argv)
 {
   int port_no = 8002;
-
-  if (argc > 2) {
+  unsigned short rest_port = 18002;
+  
+  if (argc > 3) {
     GERROR("Invalid number of arguments\n");
-    GERROR("Usage: %s <port no>\n", argv[0]);
+    GERROR("Usage: %s <port no> <rest port no>\n", argv[0]);
   }
 
   if (argc > 1) {
     port_no = std::atoi(argv[1]);
   }
 
+  if (argc > 2) {
+    port_no = std::atoi(argv[2]);
+  }
+
+  
   ACE_INET_Addr port_to_listen (port_no);
 
   Gadgetron::CloudBusRelayAcceptor acceptor;
@@ -273,6 +286,40 @@ int main(int argc, char** argv)
   acceptor.reactor (ACE_Reactor::instance ());
   if (acceptor.open (port_to_listen) == -1)
     return 1;
+
+  Gadgetron::ReST::port_ = rest_port;
+  
+  Gadgetron::ReST::instance()->server()
+    .route_dynamic("/info")([]()
+			    {
+			      return "Gadgetron CloudBusRelay\n";
+			    });
+
+  Gadgetron::ReST::instance()->server()
+    .route_dynamic("/info/json")([&acceptor]()
+				 {
+				   std::vector<Gadgetron::GadgetronNodeInfo> nl;
+				   acceptor.get_node_list(nl);
+				   crow::json::wvalue out, nodes;
+				   out["number_of_nodes"] = nl.size();
+				   size_t idx = 0;
+				   for (auto n: nl)
+				   {
+				     crow::json::wvalue node;
+				     out["nodes"][idx]["uuid"] = n.uuid;
+				     out["nodes"][idx]["address"] = n.address;
+				     out["nodes"][idx]["port"] = n.port;
+				     out["nodes"][idx]["rest_port"] = n.rest_port;
+				     out["nodes"][idx]["compute_capability"] = n.compute_capability;
+				     out["nodes"][idx]["active_reconstructions"] = n.active_reconstructions;
+				     auto t = std::chrono::system_clock::from_time_t(n.last_recon);
+				     std::chrono::duration<double> time_since_last_recon =
+				       std::chrono::system_clock::now() - t;
+				     out["nodes"][idx]["last_recon"] = time_since_last_recon.count();
+				     idx++;
+				   }
+				   return out;
+				 });
 
   ACE_Reactor::instance()->run_reactor_event_loop ();
 

--- a/toolboxes/rest/gadgetron_rest.h
+++ b/toolboxes/rest/gadgetron_rest.h
@@ -4,6 +4,7 @@
 #include <thread>
 
 #include "crow/crow.h"
+#include "crow/json.h"
 
 // require these undef to avoid visual studio conflicts for ERROR and DELETE
 // TODO: remove these once updated to visual studio 2015


### PR DESCRIPTION
This commit adds ReST API to the cloudbus_relay. This is needed/useful for orchestrating a large number of nodes in the cloud that scale dynamically based on workload. For instance, you can query the cloud_relay to see what nodes are available and some statistics:

    curl http://localhost:18002/info/json

which could return something like this:

````
{"nodes":[{"active_reconstructions":0,"rest_port":9080,"port":9002,"last_recon":3.02057,"address":"127.0.0.1","compute_capability":1,"uuid":"f027b732-afe7-4f42-b9f5-1d0a9b34e959"},{"active_reconstructions":0,"rest_port":18003,"port":9004,"last_recon":1.4479e+09,"address":"127.0.0.1","compute_capability":1,"uuid":"defcbf2e-3e2a-4f5d-94e1-2717b427b440"}],"number_of_nodes":2}
````

So in this case we have two active nodes. Or

````
{"nodes":[{"active_reconstructions":1,"rest_port":9080,"port":9002,"last_recon":1.50909,"address":"127.0.0.1","compute_capability":1,"uuid":"f027b732-afe7-4f42-b9f5-1d0a9b34e959"},{"active_reconstructions":0,"rest_port":18003,"port":9004,"last_recon":1.4479e+09,"address":"127.0.0.1","compute_capability":1,"uuid":"defcbf2e-3e2a-4f5d-94e1-2717b427b440"}],"number_of_nodes":2}
```

Now a node is doing some work. Note there is also information in there about when the last_recon was run on a node, so we can get some idea of when the nodes were active. That is actually all that is needed in order to decide if nodes should be added or shut down. This allows all control over the scale logic to be outside the nodes or the relay.

Next thing is how to shut down a node. This is tricky. Say we need to get rid of a node, we identify one from the list that is not doing something and then we want to shut it down. In the mean time, it starts doing some work. Now what? I added some logic to help with this. 

If you want to shut down a node, you must first disable its ability to receive new connections:

    curl http://localhost:9080/acceptor/close
   
   Acceptor closed

Now that the acceptor is closed, you can check if it is doing work:

    curl http://localhost:9080/cloudbus/active_recons

    1

In this case, the node became active while we decided to shut it down, but that is fine, just let it finish it’s recon, that is wait until :

    curl http://localhost:9080/cloudbus/active_recons

    0

And now it is safe to kill the container (and the node) because it is no longer doing any work. 