### PR TITLE
Added an info/port path to the ReST API.

### DIFF
--- a/apps/gadgetron/GadgetServerAcceptor.h
+++ b/apps/gadgetron/GadgetServerAcceptor.h
@@ -5,6 +5,7 @@
 #include "ace/Reactor.h"
 #include <string>
 #include <map>
+#include <mutex>
 
 namespace Gadgetron{
 class GadgetServerAcceptor : public ACE_Event_Handler
@@ -24,6 +25,8 @@ public:
 
   int close()
   {
+    std::lock_guard<std::mutex> guard(acceptor_mtx_);
+    is_listening_ = false;
     return this->acceptor_.close();
   }
   
@@ -31,6 +34,9 @@ public:
 
 protected:
   ACE_SOCK_Acceptor acceptor_;
+  std::mutex acceptor_mtx_;
+  bool is_listening_;
+  
 };
 }
 #endif //_GADGETSERVERACCEPTOR_H


### PR DESCRIPTION
This PR adds a url or querying the port of the running gadgetron. Will return a 500 server error response when the acceptor is closed. 

```
$ curl http://localhost:9080/info/port
9002
```

If the acceptor is closed:

```
$ curl http://localhost:9080/acceptor/close
Acceptor closed
$ curl http://localhost:9080/info/port
Port not available
```
