### PR TITLE
Added timeout to gadgetron_ismrmrd_client. Defaults to 10 seconds

### DIFF
--- a/apps/clients/gadgetron_ismrmrd_client/gadgetron_ismrmrd_client.cpp
+++ b/apps/clients/gadgetron_ismrmrd_client/gadgetron_ismrmrd_client.cpp
@@ -34,7 +34,9 @@
 #include <iostream>
 #include <exception>
 #include <map>
-
+#include <thread>
+#include <chrono>
+#include <condition_variable>
 
 std::string get_date_time_string()
 {
@@ -941,6 +943,7 @@ class GadgetronClientConnector
 public:
     GadgetronClientConnector() 
         : socket_(0)
+        , timeout_ms_(10000)
     {
 
     }
@@ -953,6 +956,11 @@ public:
         }
     }
 
+    void set_timeout(unsigned int t)
+    {
+        timeout_ms_ = t;
+    }
+    
     void read_task()
     {
         if (!socket_) {
@@ -995,24 +1003,40 @@ public:
         tcp::resolver::query query(tcp::v4(), hostname.c_str(), port.c_str());
         tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
         tcp::resolver::iterator end;
-
+        
         socket_ = new tcp::socket(io_service);
-
         if (!socket_) {
             throw GadgetronClientException("Unable to create socket.");
         }
 
-        //TODO:
-        //For newer versions of Boost, we should use
-        //   boost::asio::connect(*socket_, iterator);
-
+        std::condition_variable cv;
+        std::mutex cv_m;
+        
         boost::system::error_code error = boost::asio::error::host_not_found;
-        while (error && endpoint_iterator != end) {
-            socket_->close();
-            socket_->connect(*endpoint_iterator++, error);
+        std::thread t([&](){
+                //TODO:
+                //For newer versions of Boost, we should use
+                //   boost::asio::connect(*socket_, iterator);
+                while (error && endpoint_iterator != end) {
+                    socket_->close();
+                    socket_->connect(*endpoint_iterator++, error);
+                }
+                cv.notify_all();
+            });
+
+        {
+            std::unique_lock<std::mutex> lk(cv_m);
+            if (std::cv_status::timeout == cv.wait_until(lk, std::chrono::system_clock::now() +std::chrono::milliseconds(timeout_ms_)) ) {
+                socket_->close();
+             }
         }
+
+        t.join();
+        
         if (error)
             throw GadgetronClientException("Error connecting using socket.");
+                               
+
 
         reader_thread_ = boost::thread(boost::bind(&GadgetronClientConnector::read_task, this));
 
@@ -1130,6 +1154,7 @@ protected:
     tcp::socket* socket_;
     boost::thread reader_thread_;
     maptype readers_;
+    unsigned int timeout_ms_;
 
 
 };
@@ -1148,6 +1173,7 @@ int main(int argc, char **argv)
     std::string config_file_local;
     std::string config_xml_local;
     unsigned int loops;
+    unsigned int timeout_ms;
     std::string out_fileformat;
     bool open_input_file = true;
 
@@ -1165,6 +1191,7 @@ int main(int argc, char **argv)
         ("config,c", po::value<std::string>(&config_file)->default_value("default.xml"), "Configuration file (remote)")
         ("config-local,C", po::value<std::string>(&config_file_local), "Configuration file (local)")
         ("loops,l", po::value<unsigned int>(&loops)->default_value(1), "Loops")
+        ("timeout,t", po::value<unsigned int>(&timeout_ms)->default_value(10000), "Timeout [ms]")
         ("outformat,F", po::value<std::string>(&out_fileformat)->default_value("h5"), "Out format, h5 for hdf5 and hdr for analyze image")
         ;
 
@@ -1230,7 +1257,8 @@ int main(int argc, char **argv)
     }
 
     GadgetronClientConnector con;
-
+    con.set_timeout(timeout_ms);
+    
     if ( out_fileformat == "hdr" )
     {
         con.register_reader(GADGET_MESSAGE_ISMRMRD_IMAGE, boost::shared_ptr<GadgetronClientMessageReader>(new GadgetronClientAnalyzeImageMessageReader(hdf5_out_group)));


### PR DESCRIPTION
This timeout option is important since some automated uses of the client will hang for a long time (integration tests or use of the client on a scanner), if a connection cannot be made. 

This is a bit of an ugly way of creating a connection timeout on the client. The connect(...) function on the tcp::socket in boost::asio does not have a timeout option. The asynch_connect(...) should be used instead, but that would require some more reworking of the client, so we have to create our own timeout. It is done with wait on a condition variable.

@xueh2 Please take a careful look at this. I think this is what is needed. Could you also just give it a quick check compiling on Windows. 