### PR TITLE
Change default CUDA_USE_STATIC_CUDA_RUNTIME value to false

### DIFF
--- a/cmake/FindCUDA_advanced.cmake
+++ b/cmake/FindCUDA_advanced.cmake
@@ -1,3 +1,5 @@
+set(CUDA_USE_STATIC_CUDA_RUNTIME OFF CACHE BOOL "")
+
 find_package(CUDA 5.5)
 
 # Check for GPUs present and their compute capability


### PR DESCRIPTION
Signed-off-by: Zhitao Li zhitaoli@email.arizona.edu

This closes #227, since cmake 3.3 they added a new option to allow people to use static CUDA lib, and by default this option is been turned on, and that's why it is returning different result.

This pull request adds a single line to set this value to false, before calling find_package(CUDA 5.5), and that fixed our problem.

The option is still available on the UI under CUDA, it's called CUDA_USE_STATIC_CUDA_RUNTIME, but using static lib is going to cause problems.