### PR TITLE
Added folder and measurement ID to IsmrmrdDumpGadget

### DIFF
--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -41,7 +41,8 @@ include_directories(
     ${ARMADILLO_INCLUDE_DIRS}
     ${MKL_INCLUDE_DIR}
     ${ISMRMRD_INCLUDE_DIR}
-)
+    ${Boost_INCLUDE_DIR}
+)   
 
 if (ARMADILLO_FOUND)
     list(APPEND OPTIMIZED_GADGETS NoiseAdjustGadget.cpp)
@@ -176,6 +177,7 @@ target_link_libraries(gadgetron_mricore
     ${FFTW3_LIBRARIES} 
     optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY} 
     ${OPTIMIZED_GADGET_LIBS}
+    ${Boost_LIBRARIES}
 )
 
 install(FILES 

--- a/gadgets/mri_core/IsmrmrdDumpGadget.h
+++ b/gadgets/mri_core/IsmrmrdDumpGadget.h
@@ -21,8 +21,10 @@ namespace Gadgetron{
       IsmrmrdDumpGadget();
 
     protected:
-      GADGET_PROPERTY(file_prefix, std::string, "Prefix for dump file", "ISMRMRD_DUMP");
-      GADGET_PROPERTY(append_timestamp, bool, "Append timestamp to file name prefix", true);
+      GADGET_PROPERTY(folder,           std::string, "Folder  for dump file", ".");
+      GADGET_PROPERTY(file_prefix,      std::string, "Prefix for dump file", "ISMRMRD_DUMP");
+      GADGET_PROPERTY(append_id,        bool,        "ISMRMRD measurement ID to file name prefix (if available)", true);
+      GADGET_PROPERTY(append_timestamp, bool,        "Append timestamp to file name prefix", true);
 
       virtual int process_config(ACE_Message_Block* mb);
 
@@ -30,10 +32,7 @@ namespace Gadgetron{
 			  GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2);
 
     private:
-      std::string file_prefix_;
-      std::string ismrmrd_file_name_;
       boost::shared_ptr<ISMRMRD::Dataset>  ismrmrd_dataset_;
-      bool append_timestamp_;
     };
 }
 #endif //ISMRMRDDUMPGADGET_H


### PR DESCRIPTION
A folder can be added to the ISMRMRD dump file name and the folder will be created if it does not exist. Measurement ID is also added to the filename. 

@xueh2, can you check if this does the trick for the data saving?