### PR TITLE
Added scrip for packaging up a chroot image from a docker container

### DIFF
--- a/docker/create_chroot_from_image.sh
+++ b/docker/create_chroot_from_image.sh
@@ -4,7 +4,7 @@ image=$1
 created=$(docker inspect --format='{{.Created}}' $image)
 timestamp="${created:0:4}${created:5:2}${created:8:2}-${created:11:2}${created:14:2}"
 gadgetron_hash=$(docker run --rm $image cut -c-8 /opt/code/gadgetron_sha1.txt)
-gtprep_hash=$(docker run --rm $image [ -f /opt/code/gtprep_sha1.txt ] && $(cut -c-8 /opt/code/gtprep_sha1.txt))
+gtprep_hash=$(docker run --rm $image bash -c  "[ -f /opt/code/gtprep_sha1.txt ] && cut -c-8 /opt/code/gtprep_sha1.txt")
 chroot_name="gadgetron-${timestamp}-$gadgetron_hash"
 if [ -n "$gtprep_hash" ]; then
     chroot_name="${chroot_name}-gtprep-${gtprep_hash}"

--- a/docker/create_chroot_from_image.sh
+++ b/docker/create_chroot_from_image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+image=$1
+created=$(docker inspect --format='{{.Created}}' $image)
+timestamp="${created:0:4}${created:5:2}${created:8:2}-${created:11:2}${created:14:2}"
+gadgetron_hash=$(docker run --rm $image cut -c-8 /opt/code/gadgetron_sha1.txt)
+gtprep_hash=$(docker run --rm $image [ -f /opt/code/gtprep_sha1.txt ] && $(cut -c-8 /opt/code/gtprep_sha1.txt))
+chroot_name="gadgetron-${timestamp}-$gadgetron_hash"
+if [ -n "$gtprep_hash" ]; then
+    chroot_name="${chroot_name}-gtprep-${gtprep_hash}"
+fi
+chroot_name="${chroot_name}.tar.gz"
+echo "Creating chroot image with name: $chroot_name"
+
+docker run -ti --rm --volume=`pwd`:/opt/backup $image tar -cvpzf /opt/backup/$chroot_name --exclude=/opt/code --exclude=/opt/backup --one-file-system / 

--- a/docker/tag_image_with_version.sh
+++ b/docker/tag_image_with_version.sh
@@ -2,4 +2,5 @@
 
 image_name=$1
 gadgetron_version=$(docker run --rm $image_name gadgetron_info | awk '/-- Version/ {print $4}')
-docker tag ${image_name} ${image_name}:${gadgetron_version}
+gadgetron_sha1=$(docker run --rm $image_name cut -c-8 /opt/code/gadgetron_sha1.txt)
+docker tag ${image_name} ${image_name}:${gadgetron_version}-${gadgetron_sha1}


### PR DESCRIPTION
This scrip can be used to make a chroot (tar.gz) from a docker image. Usage:

    docker/create_chroot_from_image.sh gadgetron/ubuntu_1404_no_cuda

@xueh2, do you think this is a reasonable start? 