### PR TITLE
Update hoNDArray_reductions.h

### DIFF
--- a/toolboxes/core/cpu/math/hoNDArray_reductions.h
+++ b/toolboxes/core/cpu/math/hoNDArray_reductions.h
@@ -168,8 +168,8 @@ namespace Gadgetron{
     typename realType<T>::Type norm1(const hoNDArray<T>& x);
 
     /**
-    * @brief dot product of conj(x) and y
-    r = conj(x) dot y
+    * @brief dot product of x and conj(y)
+    r = x dot conj(y)
     */
     template <typename T> EXPORTCPUCOREMATH 
     void dotc(const hoNDArray<T>& x, const hoNDArray<T>& y, T& r);


### PR DESCRIPTION
Fixed the description of "dotc" to match the actual computation.
I'm not sure if the comment was wrong or the code is wrong, but I didn't want to change the code because there are some files using dotc and I didn't want to change the behavior.  If the intent of the code is what the previous description said, then the code is wrong and should be changed.