### PR TITLE
add more controls for ref preparation in generic recon

### DIFF
--- a/gadgets/mri_core/GenericReconCartesianReferencePrepGadget.h
+++ b/gadgets/mri_core/GenericReconCartesianReferencePrepGadget.h
@@ -55,6 +55,9 @@ namespace Gadgetron {
         GADGET_PROPERTY(average_all_ref_N, bool, "Whether to average all N for ref generation", true);
         /// whether to average all S for ref generation
         GADGET_PROPERTY(average_all_ref_S, bool, "Whether to average all S for ref generation", false);
+        /// if no acceleration is used, whether to update ref for every incoming IsmrmrdReconData
+        /// if false, the ref will only be prepared for the first incoming IsmrmrdReconData
+        GADGET_PROPERTY(prepare_ref_always_no_acceleration, bool, "Whether to prepare ref for every incoming IsmrmrdReconData if the no acceleration is used", true);
 
     protected:
 
@@ -64,6 +67,8 @@ namespace Gadgetron {
 
         // number of encoding spaces in the protocol
         size_t num_encoding_spaces_;
+        /// indicate whether ref has been prepared for an encoding space
+        std::vector<bool> ref_prepared_;
 
         // for every encoding space
         // calibration mode

--- a/gadgets/mri_core/Generic_Cartesian_Grappa.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa.xml
@@ -62,9 +62,10 @@
 
         <!-- averaging across repetition -->
         <property><name>average_all_ref_N</name><value>true</value></property>
-
         <!-- every set has its own kernels -->
         <property><name>average_all_ref_S</name><value>true</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always_no_acceleration</name><value>false</value></property>
     </gadget>
 
     <!-- Recon -->

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_EPI.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_EPI.xml
@@ -76,9 +76,10 @@
 
         <!-- averaging across repetition -->
         <property><name>average_all_ref_N</name><value>true</value></property>
-
         <!-- every set has its own kernels -->
         <property><name>average_all_ref_S</name><value>true</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always_no_acceleration</name><value>false</value></property>
     </gadget>
 
     <!-- Coil compression -->

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_RealTimeCine.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_RealTimeCine.xml
@@ -63,9 +63,10 @@
 
         <!-- averaging across repetition -->
         <property><name>average_all_ref_N</name><value>true</value></property>
-
         <!-- every set has its own kernels -->
         <property><name>average_all_ref_S</name><value>false</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always_no_acceleration</name><value>true</value></property>
     </gadget>
 
     <!-- Recon -->

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
@@ -63,9 +63,10 @@
 
         <!-- averaging across repetition -->
         <property><name>average_all_ref_N</name><value>true</value></property>
-
         <!-- every set has its own kernels -->
         <property><name>average_all_ref_S</name><value>false</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always_no_acceleration</name><value>true</value></property>
     </gadget>
 
     <!-- Coil compression -->


### PR DESCRIPTION
Often, if it is in no acceleration mode, no ref data is acquired. So in this case, it is necessary to use the imaging data as ref.

Add a control to only set ref once for the first incoming IsmrmdReconData. So it can avoid unnecessary coil map estimation in the recon step.