### PR TITLE
Epi generic chain

### DIFF
--- a/gadgets/epi/CMakeLists.txt
+++ b/gadgets/epi/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(gadgetron_epi SHARED
   EPICorrGadget.h EPICorrGadget.cpp
   FFTXGadget.h FFTXGadget.cpp
   CutXGadget.h CutXGadget.cpp
+  OneEncodingGadget.h OneEncodingGadget.cpp
   epi.xml
   epi_gtplus_grappa.xml
 )

--- a/gadgets/epi/EPIReconXGadget.cpp
+++ b/gadgets/epi/EPIReconXGadget.cpp
@@ -1,6 +1,10 @@
 #include "EPIReconXGadget.h"
 #include "ismrmrd/xml.h"
 
+#ifdef USE_OMP
+#include "omp.h"
+#endif // USE_OMP
+
 namespace Gadgetron{
 
   EPIReconXGadget::EPIReconXGadget() {}
@@ -88,6 +92,10 @@ int EPIReconXGadget::process_config(ACE_Message_Block* mb)
     reconx_other.dwellTime_ = 1.0;
     reconx_other.computeTrajectory();
   }
+
+#ifdef USE_OMP
+  omp_set_num_threads(1);
+#endif // USE_OMP
 
   return 0;
 }

--- a/gadgets/epi/EPIReconXGadget.cpp
+++ b/gadgets/epi/EPIReconXGadget.cpp
@@ -89,6 +89,7 @@ int EPIReconXGadget::process_config(ACE_Message_Block* mb)
     reconx_other.reconNx_   = r_space2.matrixSize.x;
     reconx_other.reconFOV_  = r_space2.fieldOfView_mm.x;
     reconx_other.numSamples_ = e_space2.matrixSize.x;
+    oversamplng_ratio2_ = (float)e_space2.matrixSize.x / r_space2.matrixSize.x;
     reconx_other.dwellTime_ = 1.0;
     reconx_other.computeTrajectory();
   }
@@ -115,7 +116,23 @@ int EPIReconXGadget::process(
   if (hdr_in.encoding_space_ref == 0) {
     reconx.apply(*m1->getObjectPtr(), *m2->getObjectPtr(), hdr_out, data_out);
   }
-  else {
+  else
+  {
+    if(reconx_other.encodeNx_>m2->getObjectPtr()->get_size(0)/ oversamplng_ratio2_)
+    {
+        reconx_other.encodeNx_ = (int)(m2->getObjectPtr()->get_size(0) / oversamplng_ratio2_);
+    }
+
+    if (reconx_other.reconNx_>m2->getObjectPtr()->get_size(0) / oversamplng_ratio2_)
+    {
+        reconx_other.reconNx_ = (int)(m2->getObjectPtr()->get_size(0) / oversamplng_ratio2_);
+    }
+
+    if(reconx_other.numSamples_>m2->getObjectPtr()->get_size(0))
+    {
+        reconx_other.numSamples_ = m2->getObjectPtr()->get_size(0);
+    }
+
     reconx_other.apply(*m1->getObjectPtr(), *m2->getObjectPtr(), hdr_out, data_out);
   }
 

--- a/gadgets/epi/EPIReconXGadget.h
+++ b/gadgets/epi/EPIReconXGadget.h
@@ -35,6 +35,9 @@ namespace Gadgetron{
       EPI::EPIReconXObjectTrapezoid<std::complex<float> > reconx;
       EPI::EPIReconXObjectFlat<std::complex<float> > reconx_other;
 
+      // readout oversampling for reconx_other
+      float oversamplng_ratio2_;
+
     };
 }
 #endif //EPIRECONXGADGET_H

--- a/gadgets/epi/FFTXGadget.cpp
+++ b/gadgets/epi/FFTXGadget.cpp
@@ -13,7 +13,13 @@ namespace Gadgetron{
   {
 
     // FFT along 1st dimensions (x)
-    hoNDFFT<float>::instance()->fft1c( *m2->getObjectPtr() );
+    if(buf_.get_size(0)!= m2->getObjectPtr()->get_size(0))
+    {
+        buf_ = *m2->getObjectPtr();
+    }
+
+    hoNDFFT<float>::instance()->fft1c( *m2->getObjectPtr(), r_, buf_);
+    memcpy(m2->getObjectPtr()->begin(), r_.begin(), r_.get_number_of_bytes());
 
     if (this->next()->putq(m1) < 0)
     {

--- a/gadgets/epi/FFTXGadget.h
+++ b/gadgets/epi/FFTXGadget.h
@@ -20,6 +20,9 @@ namespace Gadgetron{
     protected:
       virtual int process( GadgetContainerMessage< ISMRMRD::AcquisitionHeader>* m1,
                        GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2);
+
+      hoNDArray< std::complex<float> > r_;
+      hoNDArray< std::complex<float> > buf_;
   };
 }
 #endif //FFTXGADGET_H

--- a/gadgets/epi/OneEncodingGadget.cpp
+++ b/gadgets/epi/OneEncodingGadget.cpp
@@ -1,0 +1,26 @@
+#include "OneEncodingGadget.h"
+
+namespace Gadgetron {
+
+    OneEncodingGadget::OneEncodingGadget()
+    {
+    }
+
+    OneEncodingGadget::~OneEncodingGadget()
+    {
+    }
+
+    int OneEncodingGadget::process(GadgetContainerMessage< ISMRMRD::AcquisitionHeader>* m1, GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2)
+    {
+        m1->getObjectPtr()->encoding_space_ref = 0;
+
+        if (this->next()->putq(m1) < 0)
+        {
+            return GADGET_FAIL;
+        }
+
+        return GADGET_OK;
+    }
+
+    GADGET_FACTORY_DECLARE(OneEncodingGadget)
+}

--- a/gadgets/epi/OneEncodingGadget.h
+++ b/gadgets/epi/OneEncodingGadget.h
@@ -1,0 +1,30 @@
+/** \file   OneEncodingGadget.h
+    \brief  This is the class gadget to make sure EPI Flash Ref lines are in the same encoding space as the imaging lines.
+    \author Hui Xue
+*/
+
+#ifndef ONEENCODINGGADGET_H
+#define ONEENCODINGGADGET_H
+
+#include "Gadget.h"
+#include "hoNDArray.h"
+#include "gadgetron_epi_export.h"
+
+#include <ismrmrd/ismrmrd.h>
+#include <complex>
+
+namespace Gadgetron {
+
+    class EXPORTGADGETS_EPI OneEncodingGadget :
+        public Gadget2<ISMRMRD::AcquisitionHeader, hoNDArray< std::complex<float> > >
+    {
+    public:
+        OneEncodingGadget();
+        virtual ~OneEncodingGadget();
+
+    protected:
+        virtual int process(GadgetContainerMessage< ISMRMRD::AcquisitionHeader>* m1, GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2);
+    };
+}
+
+#endif // ONEENCODINGGADGET_H

--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -155,6 +155,7 @@ set( gadgetron_mricore_config_files
     Generic_Cartesian_Grappa_T2W.xml
     Generic_Cartesian_Grappa_RealTimeCine.xml
     Generic_Cartesian_Grappa_EPI.xml
+    Generic_Cartesian_Grappa_EPI_AVE.xml
 )
 
 add_library(gadgetron_mricore SHARED 

--- a/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
+++ b/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
@@ -49,6 +49,8 @@ namespace Gadgetron {
 
     int GenericReconCartesianGrappaGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1)
     {
+        if (perform_timing.value()) { gt_timer_local_.start("GenericReconCartesianGrappaGadget::process"); }
+
         process_called_times_++;
 
         IsmrmrdReconData* recon_bit_ = m1->getObjectPtr();
@@ -192,6 +194,9 @@ namespace Gadgetron {
         }
 
         m1->release();
+
+        if (perform_timing.value()) { gt_timer_local_.stop(); }
+
         return GADGET_OK;
     }
 

--- a/gadgets/mri_core/GenericReconEigenChannelGadget.cpp
+++ b/gadgets/mri_core/GenericReconEigenChannelGadget.cpp
@@ -9,8 +9,8 @@ namespace Gadgetron {
 
     GenericReconEigenChannelGadget::GenericReconEigenChannelGadget() : num_encoding_spaces_(1), process_called_times_(0)
     {
-        /*gt_timer_.set_timing_in_destruction(false);
-        gt_timer_local_.set_timing_in_destruction(false);*/
+        gt_timer_.set_timing_in_destruction(false);
+        gt_timer_local_.set_timing_in_destruction(false);
     }
 
     GenericReconEigenChannelGadget::~GenericReconEigenChannelGadget()
@@ -102,6 +102,8 @@ namespace Gadgetron {
 
     int GenericReconEigenChannelGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1)
     {
+        if (perform_timing.value()) { gt_timer_.start("GenericReconEigenChannelGadget::process"); }
+
         process_called_times_++;
 
         IsmrmrdReconData* recon_bit_ = m1->getObjectPtr();
@@ -233,6 +235,8 @@ namespace Gadgetron {
                 }*/
             }
         }
+
+        if (perform_timing.value()) { gt_timer_.stop(); }
 
         if (this->next()->putq(m1) < 0)
         {

--- a/gadgets/mri_core/GenericReconEigenChannelGadget.h
+++ b/gadgets/mri_core/GenericReconEigenChannelGadget.h
@@ -108,8 +108,8 @@ namespace Gadgetron {
         // std::string debug_folder_full_path_;
 
         // clock for timing
-        // Gadgetron::GadgetronTimer gt_timer_local_;
-        // Gadgetron::GadgetronTimer gt_timer_;
+        Gadgetron::GadgetronTimer gt_timer_local_;
+        Gadgetron::GadgetronTimer gt_timer_;
 
         //// exporter
         // Gadgetron::gtPlus::gtPlusIOAnalyze gt_exporter_;

--- a/gadgets/mri_core/GenericReconFieldOfViewAdjustmentGadget.cpp
+++ b/gadgets/mri_core/GenericReconFieldOfViewAdjustmentGadget.cpp
@@ -95,6 +95,8 @@ namespace Gadgetron {
 
     int GenericReconFieldOfViewAdjustmentGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdImageArray >* m1)
     {
+        if (perform_timing.value()) { gt_timer_.start("GenericReconFieldOfViewAdjustmentGadget::process"); }
+
         GDEBUG_CONDITION_STREAM(verbose.value(), "GenericReconFieldOfViewAdjustmentGadget::process(...) starts ... ");
 
         process_called_times_++;
@@ -138,6 +140,8 @@ namespace Gadgetron {
             GERROR("GenericReconFieldOfViewAdjustmentGadget::process, passing data on to next gadget");
             return GADGET_FAIL;
         }
+
+        if (perform_timing.value()) { gt_timer_.stop(); }
 
         return GADGET_OK;
     }

--- a/gadgets/mri_core/GenericReconGadget.cpp
+++ b/gadgets/mri_core/GenericReconGadget.cpp
@@ -71,7 +71,7 @@ namespace Gadgetron {
 
             if (!h.encoding[e].parallelImaging)
             {
-                GDEBUG_STREAM("Parallel Imaging section not found in header");
+                GDEBUG_STREAM("Parallel Imaging section not found in header for encoding space " << e);
                 calib_mode_[e] = ISMRMRD_noacceleration;
                 acceFactorE1_[e] = 1;
                 acceFactorE2_[e] = 1;

--- a/gadgets/mri_core/GenericReconImageArrayScalingGadget.cpp
+++ b/gadgets/mri_core/GenericReconImageArrayScalingGadget.cpp
@@ -62,6 +62,8 @@ namespace Gadgetron {
 
     int GenericReconImageArrayScalingGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdImageArray >* m1)
     {
+        if (perform_timing.value()) { gt_timer_.start("GenericReconImageArrayScalingGadget::process"); }
+
         GDEBUG_CONDITION_STREAM(verbose.value(), "GenericReconImageArrayScalingGadget::process(...) starts ... ");
 
         process_called_times_++;
@@ -107,6 +109,8 @@ namespace Gadgetron {
             GERROR("GenericReconImageArrayScalingGadget::process, passing data on to next gadget");
             return GADGET_FAIL;
         }
+
+        if (perform_timing.value()) { gt_timer_.stop(); }
 
         return GADGET_OK;
     }

--- a/gadgets/mri_core/GenericReconKSpaceFilteringGadget.cpp
+++ b/gadgets/mri_core/GenericReconKSpaceFilteringGadget.cpp
@@ -91,6 +91,8 @@ namespace Gadgetron {
 
     int GenericReconKSpaceFilteringGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdImageArray >* m1)
     {
+        if (perform_timing.value()) { gt_timer_.start("GenericReconKSpaceFilteringGadget::process"); }
+
         GDEBUG_CONDITION_STREAM(verbose.value(), "GenericReconKSpaceFilteringGadget::process(...) starts ... ");
 
         process_called_times_++;
@@ -349,6 +351,8 @@ namespace Gadgetron {
             GERROR("GenericReconKSpaceFilteringGadget::process, passing data on to next gadget");
             return GADGET_FAIL;
         }
+
+        if (perform_timing.value()) { gt_timer_.stop(); }
 
         return GADGET_OK;
     }

--- a/gadgets/mri_core/GenericReconPartialFourierHandlingGadget.cpp
+++ b/gadgets/mri_core/GenericReconPartialFourierHandlingGadget.cpp
@@ -61,7 +61,7 @@ namespace Gadgetron {
         {
             if (!h.encoding[e].parallelImaging)
             {
-                GDEBUG_STREAM("Parallel Imaging section not found in header");
+                GDEBUG_STREAM("Parallel Imaging section not found in header for encoding " << e);
                 acceFactorE1_[e] = 1;
                 acceFactorE2_[e] = 1;
             }
@@ -93,6 +93,8 @@ namespace Gadgetron {
 
     int GenericReconPartialFourierHandlingGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdImageArray >* m1)
     {
+        if (perform_timing.value()) { gt_timer_local_.start("GenericReconPartialFourierHandlingGadget::process"); }
+
         GDEBUG_CONDITION_STREAM(verbose.value(), "GenericReconPartialFourierHandlingGadget::process(...) starts ... ");
 
         process_called_times_++;
@@ -116,6 +118,8 @@ namespace Gadgetron {
                 GERROR("GenericReconPartialFourierHandlingGadget::process, passing incoming image array on to next gadget");
                 return GADGET_FAIL;
             }
+
+            if (perform_timing.value()) { gt_timer_local_.stop(); }
 
             return GADGET_OK;
         }
@@ -188,6 +192,8 @@ namespace Gadgetron {
                 return GADGET_FAIL;
             }
 
+            if (perform_timing.value()) { gt_timer_local_.stop(); }
+
             return GADGET_OK;
         }
 
@@ -245,6 +251,8 @@ namespace Gadgetron {
             GERROR("GenericReconPartialFourierHandlingGadget::process, passing data on to next gadget");
             return GADGET_FAIL;
         }
+
+        if (perform_timing.value()) { gt_timer_local_.stop(); }
 
         return GADGET_OK;
     }

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_EPI_AVE.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_EPI_AVE.xml
@@ -7,7 +7,7 @@
         Gadgetron generic recon chain for 2D cartesian EPI sampling
 
         EPI imaging
-        Triggered by repetition
+        Triggered by average
         Recon N is repetition and S is set
 
         Author: Hui Xue
@@ -55,16 +55,16 @@
         <name>AccTrig</name>
         <dll>gadgetron_mricore</dll>
         <classname>AcquisitionAccumulateTriggerGadget</classname>
-        <property><name>trigger_dimension</name><value>repetition</value></property>
-        <property><name>sorting_dimension</name><value>average</value></property>
+        <property><name>trigger_dimension</name><value>average</value></property>
+        <property><name>sorting_dimension</name><value>repetition</value></property>
     </gadget>
 
     <gadget>
         <name>Buff</name>
         <dll>gadgetron_mricore</dll>
         <classname>BucketToBufferGadget</classname>
-        <property><name>N_dimension</name><value>repetition</value></property>
-        <property><name>S_dimension</name><value>average</value></property>
+        <property><name>N_dimension</name><value>average</value></property>
+        <property><name>S_dimension</name><value>repetition</value></property>
         <property><name>split_slices</name><value>false</value></property>
         <property><name>ignore_segment</name><value>true</value></property>
     </gadget>

--- a/toolboxes/mri/epi/EPIReconXObjectFlat.h
+++ b/toolboxes/mri/epi/EPIReconXObjectFlat.h
@@ -119,6 +119,11 @@ template <typename T> int EPIReconXObjectFlat<T>::apply(ISMRMRD::AcquisitionHead
     int Ne = 2*Km + 1;
     int p,q; // counters
 
+    if(numSamples_!=data_in.get_size(0))
+    {
+        numSamples_ = data_in.get_size(0);
+    }
+
     // resize the reconstruction operator
     Mpos_.create(reconNx_,numSamples_);
     Mneg_.create(reconNx_,numSamples_);

--- a/toolboxes/mri/epi/EPIReconXObjectFlat.h
+++ b/toolboxes/mri/epi/EPIReconXObjectFlat.h
@@ -9,6 +9,7 @@
 #include "EPIReconXObject.h"
 #include "hoArmadillo.h"
 #include "hoNDArray_elemwise.h"
+#include "hoNDArray_linalg.h"
 #include "gadgetronmath.h"
 #include <complex>
 
@@ -166,16 +167,18 @@ template <typename T> int EPIReconXObjectFlat<T>::apply(ISMRMRD::AcquisitionHead
   }
 
   // convert to armadillo representation of matrices and vectors
-  arma::Mat<typename stdType<T>::Type> adata_in = as_arma_matrix(&data_in);
-  arma::Mat<typename stdType<T>::Type> adata_out = as_arma_matrix(&data_out);
+  //arma::Mat<typename stdType<T>::Type> adata_in = as_arma_matrix(&data_in);
+  //arma::Mat<typename stdType<T>::Type> adata_out = as_arma_matrix(&data_out);
 
   // Apply it
   if (hdr_in.isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_REVERSE)) {
     // Negative readout
-    adata_out = as_arma_matrix(&Mneg_) * adata_in;
+    // adata_out = as_arma_matrix(&Mneg_) * adata_in;
+      Gadgetron::gemm(data_out, Mneg_, data_in);
   } else {
     // Forward readout
-    adata_out = as_arma_matrix(&Mpos_) * adata_in;
+    //adata_out = as_arma_matrix(&Mpos_) * adata_in;
+      Gadgetron::gemm(data_out, Mpos_, data_in);
   }
 
   // Copy the input header to the output header and set the size and the center sample

--- a/toolboxes/mri/epi/EPIReconXObjectTrapezoid.h
+++ b/toolboxes/mri/epi/EPIReconXObjectTrapezoid.h
@@ -9,6 +9,7 @@
 #include "EPIReconXObject.h"
 #include "hoArmadillo.h"
 #include "hoNDArray_elemwise.h"
+#include "hoNDArray_linalg.h"
 #include "gadgetronmath.h"
 #include <complex>
 
@@ -217,16 +218,18 @@ template <typename T> int EPIReconXObjectTrapezoid<T>::apply(ISMRMRD::Acquisitio
   }
 
   // convert to armadillo representation of matrices and vectors
-  arma::Mat<typename stdType<T>::Type> adata_in = as_arma_matrix(&data_in);
-  arma::Mat<typename stdType<T>::Type> adata_out = as_arma_matrix(&data_out);
+  //arma::Mat<typename stdType<T>::Type> adata_in = as_arma_matrix(&data_in);
+  //arma::Mat<typename stdType<T>::Type> adata_out = as_arma_matrix(&data_out);
 
   // Apply it
   if (hdr_in.isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_REVERSE)) {
     // Negative readout
-    adata_out = as_arma_matrix(&Mneg_) * adata_in;
+    // adata_out = as_arma_matrix(&Mneg_) * adata_in;
+      Gadgetron::gemm(data_out, Mneg_, data_in);
   } else {
     // Forward readout
-    adata_out = as_arma_matrix(&Mpos_) * adata_in;
+    // adata_out = as_arma_matrix(&Mpos_) * adata_in;
+      Gadgetron::gemm(data_out, Mpos_, data_in);
   }
 
   // Copy the input header to the output header and set the size and the center sample


### PR DESCRIPTION
Make EPI reconx data driven, so it is more robust for FLASH ref line cases
Speedup EPI correction by calling gemm and avoiding some memory allocation
Add more timing in generic chain gadgets
Add a OneEncodingGadget to make EPI with flash ref line works with generic chain
Add a Generic_Grappa_EPI_AVE.xml to trigger EPI recon by average