### PR TITLE
Generic chain downstream coilmap

### DIFF
--- a/gadgets/epi/EPIReconXGadget.cpp
+++ b/gadgets/epi/EPIReconXGadget.cpp
@@ -121,6 +121,7 @@ int EPIReconXGadget::process(
     if(reconx_other.encodeNx_>m2->getObjectPtr()->get_size(0)/ oversamplng_ratio2_)
     {
         reconx_other.encodeNx_ = (int)(m2->getObjectPtr()->get_size(0) / oversamplng_ratio2_);
+        reconx_other.computeTrajectory();
     }
 
     if (reconx_other.reconNx_>m2->getObjectPtr()->get_size(0) / oversamplng_ratio2_)
@@ -131,6 +132,7 @@ int EPIReconXGadget::process(
     if(reconx_other.numSamples_>m2->getObjectPtr()->get_size(0))
     {
         reconx_other.numSamples_ = m2->getObjectPtr()->get_size(0);
+        reconx_other.computeTrajectory();
     }
 
     reconx_other.apply(*m1->getObjectPtr(), *m2->getObjectPtr(), hdr_out, data_out);

--- a/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
+++ b/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
@@ -259,7 +259,7 @@ namespace Gadgetron {
                 std::vector<float> E(CHA, 0);
                 long long cha;
 
-#pragma omp parallel default(none) private(cha) shared(CHA, pRef, E)
+#pragma omp parallel default(none) private(cha) shared(RO, E1, E2, CHA, pRef, E)
                 {
                     hoNDArray< std::complex<float> > dataCha;
 #pragma omp for 

--- a/gadgets/mri_core/GenericReconCartesianGrappaGadget.h
+++ b/gadgets/mri_core/GenericReconCartesianGrappaGadget.h
@@ -30,11 +30,13 @@ namespace Gadgetron {
         // ------------------------------------
         /// buffers used in the recon
         // ------------------------------------
-        /// [RO E1 E2 CHA Nor1 Sor1 SLC]
+        /// [RO E1 E2 srcCHA Nor1 Sor1 SLC]
         hoNDArray<T> ref_calib_;
+        /// [RO E1 E2 dstCHA Nor1 Sor1 SLC]
+        hoNDArray<T> ref_calib_dst_;
 
         /// reference data ready for coil map estimation
-        /// [RO E1 E2 CHA Nor1 Sor1 SLC]
+        /// [RO E1 E2 dstCHA Nor1 Sor1 SLC]
         hoNDArray<T> ref_coil_map_;
 
         /// for combined imgae channel
@@ -80,6 +82,15 @@ namespace Gadgetron {
         GADGET_PROPERTY(grappa_reg_lamda, double, "Grappa regularization threshold", 0.0005);
         GADGET_PROPERTY(grappa_calib_over_determine_ratio, double, "Grappa calibration overdermination ratio", 45);
 
+        /// ------------------------------------------------------------------------------------
+        /// down stream coil compression
+        /// if downstream_coil_compression==true, down stream coil compression is used
+        /// if downstream_coil_compression_num_modesKept > 0, this number of channels will be used as the dst channels
+        /// if downstream_coil_compression_num_modesKept==0 and downstream_coil_compression_thres>0, the number of dst channels will be determined  by this threshold
+        GADGET_PROPERTY(downstream_coil_compression, bool, "Whether to perform downstream coil compression", true);
+        GADGET_PROPERTY(downstream_coil_compression_thres, double, "Threadhold for downstream coil compression", 0.002);
+        GADGET_PROPERTY(downstream_coil_compression_num_modesKept, size_t, "Number of modes to keep for downstream coil compression", 0);
+
     protected:
 
         // --------------------------------------------------
@@ -98,6 +109,9 @@ namespace Gadgetron {
         // --------------------------------------------------
         // recon step functions
         // --------------------------------------------------
+
+        // if downstream coil compression is used, determine number of channels used and prepare the ref_calib_dst_
+        virtual void prepare_down_stream_coil_compression_ref_data(const hoNDArray< std::complex<float> >& ref_src, hoNDArray< std::complex<float> >& ref_coil_map, hoNDArray< std::complex<float> >& ref_dst);
 
         // calibration, if only one dst channel is prescribed, the GrappaOne is used
         virtual void perform_calib(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);

--- a/gadgets/mri_core/GenericReconEigenChannelGadget.h
+++ b/gadgets/mri_core/GenericReconEigenChannelGadget.h
@@ -60,7 +60,7 @@ namespace Gadgetron {
         /// optionally, upstream coil compression can be applied
         /// if upstream_coil_compression==true, only kept channels will be sent out to next gadgets and other channels will be removed
         /// no matter whether upstream_coil_compression is true or false, all channels will be converted into eigen channel 
-        GADGET_PROPERTY(upstream_coil_compression, bool, "Whether to perform upstream coil compression", false);
+        GADGET_PROPERTY(upstream_coil_compression, bool, "Whether to perform upstream coil compression", true);
         /// the logic here is that if upstream_coil_compression_num_modesKept>0, only upstream_coil_compression_num_modesKept channels will be kept
         /// if upstream_coil_compression_num_modesKept<=0 and upstream_coil_compression_thres>0, this threshold will be used to determine how many channels to keep
         /// the first N and first S will be used to compute number of channels to keep

--- a/gadgets/mri_core/GenericReconGadget.h
+++ b/gadgets/mri_core/GenericReconGadget.h
@@ -49,6 +49,13 @@ namespace Gadgetron {
         /// image series
         GADGET_PROPERTY(image_series, int, "Image series number", 0);
 
+        /// square-pixel-recon
+        GADGET_PROPERTY(recon_squared_pixel, bool, "Whether to enforce the recon stop to produce images with squared pixel size along RO and E1", true);
+
+        /// coil map estimation method
+        GADGET_PROPERTY_LIMITS(coil_map_algorithm, std::string, "Method for coil map estimation", "Inati",
+            GadgetPropertyLimitsEnumeration, "Inati", "Inati_Iter");
+
         /// ------------------------------------------------------------------------------------
         /// debug and timing
         GADGET_PROPERTY(verbose, bool, "Whether to print more information", false);
@@ -118,6 +125,13 @@ namespace Gadgetron {
         // --------------------------------------------------
         // recon step functions
         // --------------------------------------------------
+
+        // prepare recon
+        // if the squared pixel recon if prescribed, the new recon image size to ensure squared pixel will be computed
+        // if needed, the incoming data matrix will be padded and ref_preparer_ recon size will be updated
+        // then all recon components will be set with updated parameters
+        // finally, the consistency of this recon will be checked; if necessary, changes will be made to ensure the parameter consistency
+        virtual void prepare_squared_pixel_recon(IsmrmrdReconBit& recon_bit, size_t encoding);
 
         // make the ref data for coil map estimation
         virtual void make_ref_coil_map(IsmrmrdDataBuffered& ref_, std::vector<size_t> recon_dims, hoNDArray< std::complex<float> >& ref_calib, hoNDArray< std::complex<float> >& ref_coil_map, size_t encoding);

--- a/gadgets/mri_core/Generic_Cartesian_Grappa.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa.xml
@@ -77,6 +77,12 @@
         <!-- image series -->
         <property><name>image_series</name><value>0</value></property>
 
+        <!-- Whether to perform squared pixel recon -->
+        <property><name>recon_squared_pixel</name><value>true</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
         <!-- parameters for debug and timing -->
         <property><name>debug_folder</name><value>DebugFolder</value></property>
         <property><name>perform_timing</name><value>true</value></property>

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_EPI.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_EPI.xml
@@ -101,8 +101,10 @@
 
         <property><name>average_all_ref_N</name><value>true</value></property>
         <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
         <property><name>upstream_coil_compression</name><value>true</value></property>
-        <property><name>upstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>-1</value></property>
         <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
     </gadget>
 
@@ -114,6 +116,17 @@
 
         <!-- image series -->
         <property><name>image_series</name><value>0</value></property>
+
+        <!-- Whether to perform squared pixel recon -->
+        <property><name>recon_squared_pixel</name><value>true</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- Down stream coil compression -->
+        <property><name>downstream_coil_compression</name><value>true</value></property>
+        <property><name>downstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>downstream_coil_compression_num_modesKept</name><value>0</value></property>
 
         <!-- parameters for debug and timing -->
         <property><name>debug_folder</name><value>DebugFolder</value></property>

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_EPI_AVE.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_EPI_AVE.xml
@@ -101,8 +101,10 @@
 
         <property><name>average_all_ref_N</name><value>true</value></property>
         <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
         <property><name>upstream_coil_compression</name><value>true</value></property>
-        <property><name>upstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>-1</value></property>
         <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
     </gadget>
 
@@ -114,6 +116,17 @@
 
         <!-- image series -->
         <property><name>image_series</name><value>0</value></property>
+
+        <!-- Whether to perform squared pixel recon -->
+        <property><name>recon_squared_pixel</name><value>true</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- Down stream coil compression -->
+        <property><name>downstream_coil_compression</name><value>true</value></property>
+        <property><name>downstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>downstream_coil_compression_num_modesKept</name><value>0</value></property>
 
         <!-- parameters for debug and timing -->
         <property><name>debug_folder</name><value>DebugFolder</value></property>

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_RealTimeCine.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_RealTimeCine.xml
@@ -69,6 +69,26 @@
         <property><name>prepare_ref_always_no_acceleration</name><value>true</value></property>
     </gadget>
 
+    <!-- Coil compression -->
+    <gadget>
+        <name>CoilCompression</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconEigenChannelGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value>DebugFolder</value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
+        <property><name>upstream_coil_compression</name><value>true</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>-1</value></property>
+        <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
+    </gadget>
+
     <!-- Recon -->
     <gadget>
         <name>Recon</name>
@@ -77,6 +97,17 @@
 
         <!-- image series -->
         <property><name>image_series</name><value>0</value></property>
+
+        <!-- Whether to perform squared pixel recon -->
+        <property><name>recon_squared_pixel</name><value>true</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- Down stream coil compression -->
+        <property><name>downstream_coil_compression</name><value>true</value></property>
+        <property><name>downstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>downstream_coil_compression_num_modesKept</name><value>0</value></property>
 
         <!-- parameters for debug and timing -->
         <property><name>debug_folder</name><value>DebugFolder</value></property>

--- a/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Grappa_T2W.xml
@@ -82,6 +82,11 @@
 
         <property><name>average_all_ref_N</name><value>true</value></property>
         <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
+        <property><name>upstream_coil_compression</name><value>true</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>-1</value></property>
+        <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
     </gadget>
 
     <!-- Recon -->
@@ -92,6 +97,17 @@
 
         <!-- image series -->
         <property><name>image_series</name><value>0</value></property>
+
+        <!-- Whether to perform squared pixel recon -->
+        <property><name>recon_squared_pixel</name><value>true</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- Down stream coil compression -->
+        <property><name>downstream_coil_compression</name><value>true</value></property>
+        <property><name>downstream_coil_compression_thres</name><value>0.002</value></property>
+        <property><name>downstream_coil_compression_num_modesKept</name><value>0</value></property>
 
         <!-- parameters for debug and timing -->
         <property><name>debug_folder</name><value>DebugFolder</value></property>

--- a/test/integration/cases/generic_grappa_T2W.cfg
+++ b/test/integration/cases/generic_grappa_T2W.cfg
@@ -10,7 +10,7 @@ siemens_dependency_parameter_xsl=IsmrmrdParameterMap_Siemens.xsl
 siemens_data_measurement=1
 ismrmrd=generic_grappa_T2W.h5
 result_h5=generic_grappa_T2W_out.h5
-reference_h5=gtplus/T2W/generic_grappa_T2W_ref.h5
+reference_h5=gtplus/T2W/generic_grappa_T2W_ref_20160304.h5
 
 [TEST]
 gadgetron_configuration=Generic_Cartesian_Grappa_T2W.xml

--- a/test/integration/data.txt
+++ b/test/integration/data.txt
@@ -65,6 +65,7 @@ gtplus/snr_unit_recon_tpat3/gtplus_snr_unit_recon_ref.h5: 71a665565321165be3c0ce
 gtplus/snr_unit_recon_tpat3/meas_MID00171_FID02908_GRE_reps=150_TPAT=3.dat: 21e219f663a27c22fec4b56216b2f3ed
 gtplus/T2W/gtplus_T2W_ref.h5: 646496067fca502f86f2770f39a71be1
 gtplus/T2W/generic_grappa_T2W_ref.h5: 1c870a3e2b25cee499ad7d7210d7b6b0
+gtplus/T2W/generic_grappa_T2W_ref_20160304.h5: 026b15108383c96eb4a00ff5ac1244d1
 gtplus/T2W/meas_MID00057_T2w.dat: 46aa75c471a41c793006328a224a4001
 epi/epi_2d_out_20150406_sji.h5: bf73508d9730c478b04e22c2323d4805
 epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat: 8790d64a101acdc7b6990dd414b14be6


### PR DESCRIPTION
Prepare generic chain for serious usage:

a) add up and downstream coil compression
b) Add Inati-Iter coil map estimation, since sometimes it gives better coil map phase estimation
c) Update generic T2W reference data
d) Add a missing line in EPIReconXGadget.cpp, which should be in previous PR
e) The new T2W ref file generic_grappa_T2W_ref_20160304.h5 is (\\macau.nhlbi.nih.gov\data1\temp\generic_grappa_T2W_ref_20160304.h5) with checksum 026b15108383c96eb4a00ff5ac1244d1