### PR TITLE
fix the NE0 assignment in BucketToBufferGadget

### DIFF
--- a/gadgets/mri_core/BucketToBufferGadget.cpp
+++ b/gadgets/mri_core/BucketToBufferGadget.cpp
@@ -381,15 +381,7 @@ namespace Gadgetron{
             // if seperate or external calibration mode, using the acq length for NE0
             if (encoding.parallelImaging)
             {
-                if (forref && (encoding.parallelImaging.get().calibrationMode.get() == "separate"
-                    || encoding.parallelImaging.get().calibrationMode.get() == "external"))
-                {
-                    NE0 = acqhdr.number_of_samples;
-                }
-                else
-                {
-                    NE0 = encoding.reconSpace.matrixSize.x;
-                }
+                NE0 = acqhdr.number_of_samples;
             }
             else
             {


### PR DESCRIPTION
It is incorrect "NE0 = encoding.reconSpace.matrixSize.x", since recon matrix size is independent from encoded matrix size. 

It is fixed to use the incoming data sample length.