### PR TITLE
add linear spirit recon gadget for generic chain

### DIFF
--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -27,6 +27,10 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/hostutils
     ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/math
     ${CMAKE_SOURCE_DIR}/toolboxes/core/gpu
+    ${CMAKE_SOURCE_DIR}/toolboxes/operators
+    ${CMAKE_SOURCE_DIR}/toolboxes/operators/cpu
+    ${CMAKE_SOURCE_DIR}/toolboxes/solvers 
+    ${CMAKE_SOURCE_DIR}/toolboxes/solvers/cpu
     ${CMAKE_SOURCE_DIR}/toolboxes/mri_core
     ${CMAKE_SOURCE_DIR}/toolboxes/mri/pmri/gpu
     ${CMAKE_SOURCE_DIR}/toolboxes/fft/cpu
@@ -87,6 +91,7 @@ set( gadgetron_mricore_header_files GadgetMRIHeaders.h
                                     GenericReconBase.h 
                                     GenericReconGadget.h 
                                     GenericReconCartesianGrappaGadget.h 
+                                    GenericReconCartesianSpiritGadget.h 
                                     GenericReconCartesianReferencePrepGadget.h 
                                     GenericReconPartialFourierHandlingGadget.h 
                                     GenericReconPartialFourierHandlingFilterGadget.h 
@@ -133,6 +138,7 @@ set( gadgetron_mricore_src_files AcquisitionPassthroughGadget.cpp
                                 GenericReconBase.cpp 
                                 GenericReconGadget.cpp 
                                 GenericReconCartesianGrappaGadget.cpp 
+                                GenericReconCartesianSpiritGadget.cpp 
                                 GenericReconCartesianReferencePrepGadget.cpp 
                                 GenericReconPartialFourierHandlingGadget.cpp 
                                 GenericReconPartialFourierHandlingFilterGadget.cpp 
@@ -159,6 +165,7 @@ set( gadgetron_mricore_config_files
     Generic_Cartesian_Grappa_RealTimeCine.xml
     Generic_Cartesian_Grappa_EPI.xml
     Generic_Cartesian_Grappa_EPI_AVE.xml
+    Generic_Cartesian_Spirit.xml
 )
 
 add_library(gadgetron_mricore SHARED 
@@ -179,6 +186,8 @@ target_link_libraries(gadgetron_mricore
     gadgetron_toolbox_cpufft
     gadgetron_toolbox_cpuklt
     gadgetron_toolbox_mri_core
+    gadgetron_toolbox_cpuoperator
+    gadgetron_toolbox_cpu_solver
     # gadgetron_toolbox_gtplus_io
     ${ISMRMRD_LIBRARIES} 
     ${FFTW3_LIBRARIES} 

--- a/gadgets/mri_core/GenericReconCartesianSpiritGadget.cpp
+++ b/gadgets/mri_core/GenericReconCartesianSpiritGadget.cpp
@@ -1,0 +1,758 @@
+
+#include "GenericReconCartesianSpiritGadget.h"
+#include "mri_core_spirit.h"
+#include "hoNDArray_reductions.h"
+#include "hoSPIRIT2DOperator.h"
+#include "hoLsqrSolver.h"
+
+namespace Gadgetron {
+
+    GenericReconCartesianSpiritGadget::GenericReconCartesianSpiritGadget() : BaseClass()
+    {
+    }
+
+    GenericReconCartesianSpiritGadget::~GenericReconCartesianSpiritGadget()
+    {
+    }
+
+    int GenericReconCartesianSpiritGadget::process_config(ACE_Message_Block* mb)
+    {
+        GADGET_CHECK_RETURN(BaseClass::process_config(mb) == GADGET_OK, GADGET_FAIL);
+
+        // -------------------------------------------------
+
+        ISMRMRD::IsmrmrdHeader h;
+        try
+        {
+            deserialize(mb->rd_ptr(), h);
+        }
+        catch (...)
+        {
+            GDEBUG("Error parsing ISMRMRD Header");
+        }
+
+        size_t NE = h.encoding.size();
+        num_encoding_spaces_ = NE;
+        GDEBUG_CONDITION_STREAM(verbose.value(), "Number of encoding spaces: " << NE);
+
+        recon_obj_.resize(NE);
+
+        // -------------------------------------------------
+        // check the parameters
+        if(this->spirit_iter_max.value()==0)
+        {
+            size_t acceFactor = acceFactorE1_[0] * acceFactorE2_[0];
+
+            if(acceFactor>=6)
+            {
+                this->spirit_iter_max.value(150);
+            }
+            else if (acceFactor >= 5)
+            {
+                this->spirit_iter_max.value(120);
+            }
+            else if (acceFactor >= 4)
+            {
+                this->spirit_iter_max.value(100);
+            }
+            else if (acceFactor >= 3)
+            {
+                this->spirit_iter_max.value(60);
+            }
+            else
+            {
+                this->spirit_iter_max.value(50);
+            }
+
+            GDEBUG_STREAM("spirit_iter_max: " << this->spirit_iter_max.value());
+        }
+
+        if (this->spirit_iter_thres.value()<FLT_EPSILON)
+        {
+            this->spirit_iter_thres.value(0.0015);
+            GDEBUG_STREAM("spirit_iter_thres: " << this->spirit_iter_thres.value());
+        }
+
+        if (this->spirit_reg_lamda.value()<FLT_EPSILON)
+        {
+            if(acceFactorE2_[0]>1)
+            {
+                this->spirit_reg_lamda.value(0.01);
+            }
+            else
+            {
+                this->spirit_reg_lamda.value(0.005);
+            }
+            GDEBUG_STREAM("spirit_reg_lamda: " << this->spirit_reg_lamda.value());
+        }
+
+        return GADGET_OK;
+    }
+
+    int GenericReconCartesianSpiritGadget::process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1)
+    {
+        if (perform_timing.value()) { gt_timer_local_.start("GenericReconCartesianSpiritGadget::process"); }
+
+        process_called_times_++;
+
+        IsmrmrdReconData* recon_bit_ = m1->getObjectPtr();
+        if (recon_bit_->rbit_.size() > num_encoding_spaces_)
+        {
+            GWARN_STREAM("Incoming recon_bit has more encoding spaces than the protocol : " << recon_bit_->rbit_.size() << " instead of " << num_encoding_spaces_);
+        }
+
+        // for every encoding space
+        for (size_t e = 0; e < recon_bit_->rbit_.size(); e++)
+        {
+            std::stringstream os;
+            os << "_encoding_" << e;
+
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Calling " << process_called_times_ << " , encoding space : " << e);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "======================================================================");
+
+            // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data" + os.str()); }
+
+            if (recon_bit_->rbit_[e].ref_)
+            {
+                // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].ref_->data_, debug_folder_full_path_ + "ref" + os.str()); }
+
+                // after this step, the recon_obj_[e].ref_calib_ and recon_obj_[e].ref_coil_map_ are set
+
+                if (perform_timing.value()) { gt_timer_.start("GenericReconCartesianSpiritGadget::make_ref_coil_map"); }
+                this->make_ref_coil_map(*recon_bit_->rbit_[e].ref_,*recon_bit_->rbit_[e].data_.data_.get_dimensions(), recon_obj_[e].ref_calib_, recon_obj_[e].ref_coil_map_, e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // if (!debug_folder_full_path_.empty()) { this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_calib_, debug_folder_full_path_ + "ref_calib" + os.str()); }
+                // if (!debug_folder_full_path_.empty()) { this->gt_exporter_.exportArrayComplex(recon_obj_[e].ref_coil_map_, debug_folder_full_path_ + "ref_coil_map" + os.str()); }
+
+                // ----------------------------------------------------------
+
+                // after this step, coil map is computed and stored in recon_obj_[e].coil_map_
+                if (perform_timing.value()) { gt_timer_.start("GenericReconCartesianSpiritGadget::perform_coil_map_estimation"); }
+                this->perform_coil_map_estimation(recon_obj_[e].ref_coil_map_, recon_obj_[e].coil_map_, e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // if (!debug_folder_full_path_.empty()) { this->gt_exporter_.exportArrayComplex(recon_obj_[e].coil_map_, debug_folder_full_path_ + "coil_map_" + os.str()); }
+
+                // ---------------------------------------------------------------
+
+                // after this step, recon_obj_[e].kernel_, recon_obj_[e].kernelIm_ or recon_obj_[e].kernelIm3D_ are filled
+                if (perform_timing.value()) { gt_timer_.start("GenericReconCartesianSpiritGadget::perform_calib"); }
+                this->perform_calib(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ---------------------------------------------------------------
+
+                recon_bit_->rbit_[e].ref_ = boost::none;
+            }
+
+            if (recon_bit_->rbit_[e].data_.data_.get_number_of_elements() > 0)
+            {
+                // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(recon_bit_->rbit_[e].data_.data_, debug_folder_full_path_ + "data_before_unwrapping" + os.str()); }
+
+                if (perform_timing.value()) { gt_timer_.start("GenericReconCartesianSpiritGadget::perform_unwrapping"); }
+                this->perform_unwrapping(recon_bit_->rbit_[e], recon_obj_[e], e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ---------------------------------------------------------------
+
+                if (perform_timing.value()) { gt_timer_.start("GenericReconCartesianSpiritGadget::compute_image_header"); }
+                this->compute_image_header(recon_bit_->rbit_[e], recon_obj_[e].recon_res_, e);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+
+                // ---------------------------------------------------------------
+
+                // if (!debug_folder_full_path_.empty()) { this->gt_exporter_.exportArrayComplex(recon_obj_[e].recon_res_.data_, debug_folder_full_path_ + "recon_res" + os.str()); }
+
+                if (perform_timing.value()) { gt_timer_.start("GenericReconCartesianSpiritGadget::send_out_image_array"); }
+                this->send_out_image_array(recon_bit_->rbit_[e], recon_obj_[e].recon_res_, e, image_series.value() + ((int)e + 1), GADGETRON_IMAGE_REGULAR);
+                if (perform_timing.value()) { gt_timer_.stop(); }
+            }
+
+            recon_obj_[e].recon_res_.data_.clear();
+            recon_obj_[e].recon_res_.headers_.clear();
+            recon_obj_[e].recon_res_.meta_.clear();
+        }
+
+        m1->release();
+
+        if (perform_timing.value()) { gt_timer_local_.stop(); }
+
+        return GADGET_OK;
+    }
+
+    void GenericReconCartesianSpiritGadget::perform_calib(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t e)
+    {
+        try
+        {
+            size_t RO = recon_bit.data_.data_.get_size(0);
+            size_t E1 = recon_bit.data_.data_.get_size(1);
+            size_t E2 = recon_bit.data_.data_.get_size(2);
+
+            hoNDArray< std::complex<float> >& src = recon_obj.ref_calib_;
+            hoNDArray< std::complex<float> >& dst = recon_obj.ref_calib_;
+
+            size_t ref_RO = src.get_size(0);
+            size_t ref_E1 = src.get_size(1);
+            size_t ref_E2 = src.get_size(2);
+            size_t srcCHA = src.get_size(3);
+            size_t ref_N = src.get_size(4);
+            size_t ref_S = src.get_size(5);
+            size_t ref_SLC = src.get_size(6);
+
+            size_t dstCHA = dst.get_size(3);
+
+            if (acceFactorE1_[e] > 1 || acceFactorE2_[e] > 1)
+            {
+                // allocate buffer for kernels
+                size_t kRO = spirit_kSize_RO.value();
+                size_t kE1 = spirit_kSize_E1.value();
+                size_t kE2 = spirit_kSize_E2.value();
+
+                size_t convKRO = 2 * kRO - 1;
+                size_t convKE1 = 2 * kE1 - 1;
+                size_t convKE2 = 2 * kE2 - 1;
+
+                if (E2 > 1)
+                {
+                    recon_obj.kernel_.create(convKRO, convKE1, convKE2, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+                    recon_obj.kernelIm3D_.create(convKE1, convKE2, srcCHA, dstCHA, RO, ref_N, ref_S, ref_SLC);
+                    Gadgetron::clear(recon_obj.kernelIm3D_);
+                }
+                else
+                {
+                    recon_obj.kernel_.create(convKRO, convKE1, 1, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+                    recon_obj.kernelIm2D_.create(RO, E1, srcCHA, dstCHA, ref_N, ref_S, ref_SLC);
+                    Gadgetron::clear(recon_obj.kernelIm2D_);
+                }
+
+                Gadgetron::clear(recon_obj.kernel_);
+
+                long long num = ref_N*ref_S*ref_SLC;
+
+                double reg_lamda = this->spirit_reg_lamda.value();
+                double over_determine_ratio = this->spirit_calib_over_determine_ratio.value();
+
+                long long ii;
+
+#pragma omp parallel for default(none) private(ii) shared(src, dst, recon_obj, e, num, ref_N, ref_S, ref_RO, ref_E1, ref_E2, RO, E1, E2, dstCHA, srcCHA, convKRO, convKE1, convKE2, kRO, kE1, kE2, reg_lamda, over_determine_ratio) if(num>1)
+                for (ii = 0; ii < num; ii++)
+                {
+                    size_t slc = ii / (ref_N*ref_S);
+                    size_t s = (ii - slc*ref_N*ref_S) / (ref_N);
+                    size_t n = ii - slc*ref_N*ref_S - s*ref_N;
+
+                    std::stringstream os;
+                    os << "n" << n << "_s" << s << "_slc" << slc << "_encoding_" << e;
+                    std::string suffix = os.str();
+
+                    std::complex<float>* pSrc = &(src(0, 0, 0, 0, n, s, slc));
+                    hoNDArray< std::complex<float> > ref_src(ref_RO, ref_E1, ref_E2, srcCHA, pSrc);
+
+                    std::complex<float>* pDst = &(dst(0, 0, 0, 0, n, s, slc));
+                    hoNDArray< std::complex<float> > ref_dst(ref_RO, ref_E1, ref_E2, dstCHA, pDst);
+
+                    // -----------------------------------
+
+                    if (E2 > 1)
+                    {
+                        hoNDArray< std::complex<float> > convKer(convKRO, convKE1, convKE2, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc)));
+                        hoNDArray< std::complex<float> > kIm(convKE1, convKE2, srcCHA, dstCHA, RO, &(recon_obj.kernelIm3D_(0, 0, 0, 0, 0, n, s, slc)));
+
+                        Gadgetron::spirit3d_calib_convolution_kernel(ref_src, ref_dst, reg_lamda, over_determine_ratio, kRO, kE1, kE2, 1, 1, 1, convKer, true);
+                        Gadgetron::spirit3d_kspace_image_domain_kernel(convKer, RO, kIm);
+                    }
+                    else
+                    {
+                        hoNDArray< std::complex<float> > acsSrc(ref_RO, ref_E1, srcCHA, const_cast< std::complex<float>*>(ref_src.begin()));
+                        hoNDArray< std::complex<float> > acsDst(ref_RO, ref_E1, dstCHA, const_cast< std::complex<float>*>(ref_dst.begin()));
+
+                        hoNDArray< std::complex<float> > convKer(convKRO, convKE1, srcCHA, dstCHA, &(recon_obj.kernel_(0, 0, 0, 0, 0, n, s, slc)));
+                        hoNDArray< std::complex<float> > kIm(RO, E1, srcCHA, dstCHA, &(recon_obj.kernelIm2D_(0, 0, 0, 0, n, s, slc)));
+
+                        Gadgetron::spirit2d_calib_convolution_kernel(acsSrc, acsDst, reg_lamda, kRO, kE1, 1, 1, convKer, true);
+                        Gadgetron::spirit2d_image_domain_kernel(convKer, RO, E1, kIm);
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericReconCartesianSpiritGadget::perform_calib(...) ... ");
+        }
+    }
+
+    void GenericReconCartesianSpiritGadget::perform_unwrapping(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t e)
+    {
+        try
+        {
+            typedef std::complex<float> T;
+
+            size_t RO = recon_bit.data_.data_.get_size(0);
+            size_t E1 = recon_bit.data_.data_.get_size(1);
+            size_t E2 = recon_bit.data_.data_.get_size(2);
+            size_t dstCHA = recon_bit.data_.data_.get_size(3);
+            size_t N = recon_bit.data_.data_.get_size(4);
+            size_t S = recon_bit.data_.data_.get_size(5);
+            size_t SLC = recon_bit.data_.data_.get_size(6);
+
+            hoNDArray< std::complex<float> >& src = recon_obj.ref_calib_;
+
+            size_t ref_RO = src.get_size(0);
+            size_t ref_E1 = src.get_size(1);
+            size_t ref_E2 = src.get_size(2);
+            size_t srcCHA = src.get_size(3);
+            size_t ref_N = src.get_size(4);
+            size_t ref_S = src.get_size(5);
+            size_t ref_SLC = src.get_size(6);
+
+            size_t convkRO = recon_obj.kernel_.get_size(0);
+            size_t convkE1 = recon_obj.kernel_.get_size(1);
+            size_t convkE2 = recon_obj.kernel_.get_size(2);
+
+            recon_obj.recon_res_.data_.create(RO, E1, E2, 1, N, S, SLC);
+            Gadgetron::clear(recon_obj.recon_res_.data_);
+            recon_obj.full_kspace_ = recon_bit.data_.data_;
+            Gadgetron::clear(recon_obj.full_kspace_);
+
+            std::stringstream os;
+            os << "encoding_" << e;
+            std::string suffix = os.str();
+
+            // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(recon_bit.data_.data_, debug_folder_full_path_ + "data_src_" + suffix); }
+
+            // ------------------------------------------------------------------
+            // compute effective acceleration factor
+            // ------------------------------------------------------------------
+            size_t e1, e2, n, s;
+            size_t num_readout_lines = 0;
+            for (s = 0; s < S; s++)
+            {
+                for (n = 0; n < N; n++)
+                {
+                    for (e2 = 0; e2 < E2; e2++)
+                    {
+                        for (e1 = 0; e1 < E1; e1++)
+                        {
+                            if (std::abs(recon_bit.data_.data_(RO / 2, e1, e2, 0, n)) > 0)
+                            {
+                                num_readout_lines++;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (num_readout_lines > 0)
+            {
+                double lenRO = RO;
+
+                size_t start_RO = recon_bit.data_.sampling_.sampling_limits_[0].min_;
+                size_t end_RO = recon_bit.data_.sampling_.sampling_limits_[0].max_;
+
+                if ( (start_RO>=0 && start_RO<RO) && (end_RO>=0 && end_RO<RO) && (end_RO - start_RO + 1 < RO) )
+                {
+                    lenRO = (end_RO - start_RO + 1);
+                }
+                if (this->verbose.value()) GDEBUG_STREAM("length for RO : " << lenRO << " - " << lenRO / RO);
+
+                double effectiveAcceFactor = (double)(S*N*E1*E2) / (num_readout_lines);
+                if (this->verbose.value()) GDEBUG_STREAM("effectiveAcceFactor : " << effectiveAcceFactor);
+
+                double ROScalingFactor = (double)RO / (double)lenRO;
+
+                float fftCompensationRatio = (float)(std::sqrt(ROScalingFactor*effectiveAcceFactor));
+
+                if (this->verbose.value()) GDEBUG_STREAM("fftCompensationRatio : " << fftCompensationRatio);
+
+                Gadgetron::scal(fftCompensationRatio, recon_bit.data_.data_);
+            }
+            else
+            {
+                GWARN_STREAM("cannot find any sampled lines ... ");
+            }
+
+            Gadgetron::GadgetronTimer timer(false);
+
+            // ------------------------------------------------------------------
+            // compute the reconstruction
+            // ------------------------------------------------------------------
+            long long num = N*S*SLC;
+            long long ii;
+
+            if(this->acceFactorE1_[e]<=1 && this->acceFactorE2_[e]<=1)
+            {
+                recon_obj.full_kspace_ = recon_bit.data_.data_;
+            }
+            else
+            {
+                hoNDArray< std::complex<float> >& kspace = recon_bit.data_.data_;
+                hoNDArray< std::complex<float> >& res = recon_obj.full_kspace_;
+                size_t iter_max = this->spirit_iter_max.value();
+                double iter_thres = this->spirit_iter_thres.value();
+                bool print_iter = this->spirit_print_iter.value();
+
+                size_t RO_recon_size = 32; // every 32 images were computed together
+
+                GDEBUG_CONDITION_STREAM(this->verbose.value(), "iter_max : " << iter_max);
+                GDEBUG_CONDITION_STREAM(this->verbose.value(), "iter_thres : " << iter_thres);
+                GDEBUG_CONDITION_STREAM(this->verbose.value(), "print_iter : " << print_iter);
+                GDEBUG_CONDITION_STREAM(this->verbose.value(), "RO_recon_size : " << RO_recon_size);
+
+                if (E2 > 1)
+                {
+                    // 3D recon
+
+                    hoNDArray<T> kspaceIfftRO(RO, E1, E2, srcCHA);
+                    hoNDArray<T> kspaceIfftROPermuted(E1, E2, srcCHA, RO);
+                    hoNDArray<T> kIm(E1, E2, srcCHA, dstCHA, RO_recon_size, 1, 1);
+                    hoNDArray<T> res_ro_recon(E1, E2, 1, dstCHA, RO_recon_size, 1, 1);
+
+                    for (ii = 0; ii < num; ii++)
+                    {
+                        size_t slc = ii / (N*S);
+                        size_t s = (ii - slc*N*S) / N;
+                        size_t n = ii - slc*N*S - s*N;
+
+                        GDEBUG_CONDITION_STREAM(this->verbose.value(), "3D recon, [n s slc] : [" << n << " " << s << " " << slc << "]");
+
+                        std::stringstream os;
+                        os << "encoding_" << e << "_n" << n << "_s" << s << "_slc" << slc;
+                        std::string suffix_3D = os.str();
+
+                        size_t ro, e1, e2, scha, dcha;
+
+                        // ------------------------------------------------------
+                        // check whether the kspace is undersampled
+                        // ------------------------------------------------------
+                        bool undersampled = false;
+                        for (e2= 0; e2< E2; e2++)
+                        {
+                            for (e1 = 0; e1 < E1; e1++)
+                            {
+                                if ((std::abs(kspace(RO / 2, e1, e2, srcCHA - 1, n, s, slc)) == 0)
+                                    && (std::abs(kspace(RO / 2, e1, e2, 0, n, s, slc)) == 0))
+                                {
+                                    undersampled = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        size_t kerN = (n<ref_N) ? n : ref_N-1;
+                        size_t kerS = (s<ref_S) ? s : ref_S - 1;
+
+                        // ---------------------------------------------------------------------
+                        // permute the kspace
+                        // ---------------------------------------------------------------------
+                        std::complex<float>* pKSpace = &(kspace(0, 0, 0, 0, n, s, slc));
+                        hoNDArray< std::complex<float> > kspace3D(RO, E1, E2, srcCHA, pKSpace);
+
+                        if (this->perform_timing.value()) timer.start("SPIRIT linear 3D, ifft1c along RO ... ");
+                        Gadgetron::hoNDFFT<float>::instance()->ifft1c(kspace3D, kspaceIfftRO);
+                        if (this->perform_timing.value()) timer.stop();
+                        // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(kspaceIfftRO, debug_folder_full_path_ + "kspaceIfftRO_" + suffix_3D); }
+
+                        if (this->perform_timing.value()) timer.start("SPIRIT linear 3D, permute along RO ... ");
+                        std::complex<float>* pKspaceRO = kspaceIfftRO.begin();
+                        std::complex<float>* pKspacePermutedRO = kspaceIfftROPermuted.begin();
+                        for (scha = 0; scha < srcCHA; scha++)
+                        {
+                            for (e2 = 0; e2 < E2; e2++)
+                            {
+                                for (e1 = 0; e1 < E1; e1++)
+                                {
+                                    size_t ind = e1*RO + e2*RO*E1 + scha*RO*E1*E2;
+                                    size_t ind_dst = e1 + e2*E1 + scha*E1*E2;
+
+                                    for (ro = 0; ro < RO; ro++)
+                                    {
+                                        pKspacePermutedRO[ind_dst + ro*E1*E2*srcCHA] = pKspaceRO[ro + ind];
+                                    }
+                                }
+                            }
+                        }
+                        if (this->perform_timing.value()) timer.stop();
+                        // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(kspaceIfftROPermuted, debug_folder_full_path_ + "kspaceIfftROPermuted_" + suffix_3D); }
+
+                        // ---------------------------------------------------------------------
+                        // get the kspace for recon
+                        // ---------------------------------------------------------------------
+                        hoNDArray< std::complex<float> > kspace3D_recon(E1, E2, 1, srcCHA, RO, kspaceIfftROPermuted.begin());
+
+                        // ---------------------------------------------------------------------
+                        // get spirit kernel for recon
+                        // ---------------------------------------------------------------------
+                        std::complex<float>* pKer = &(recon_obj.kernelIm3D_(0, 0, 0, 0, 0, kerN, kerS, slc));
+                        hoNDArray< std::complex<float> > kIm3D_recon(convkE1, convkE2, srcCHA, dstCHA, RO, pKer);
+
+                        // ---------------------------------------------------------------------
+                        // get the array to store results
+                        // ---------------------------------------------------------------------
+                        std::complex<float>* pRes = &(res(0, 0, 0, 0, n, s, slc));
+                        hoNDArray< std::complex<float> > res_recon(RO, E1, E2, dstCHA, pRes);
+
+                        // ---------------------------------------------------------------------
+                        // perform recon along RO
+                        // ---------------------------------------------------------------------
+                        size_t start_ro = 0;
+                        for (start_ro = 0; start_ro < RO; start_ro += RO_recon_size)
+                        {
+                            size_t end_ro = start_ro + RO_recon_size - 1;
+                            if (end_ro > RO) end_ro = RO - 1;
+                            size_t num = end_ro - start_ro + 1;
+
+                            GDEBUG_CONDITION_STREAM(this->verbose.value(), "3D recon, start_ro - end_ro : " << start_ro << " - " << end_ro);
+
+                            hoNDArray< std::complex<float> > kspace3D_recon_ro(E1, E2, 1, srcCHA, num, 1, 1, kspace3D_recon.begin() + start_ro*E1*E2*srcCHA);
+                            hoNDArray< std::complex<float> > kIm3D_recon_ro(convkE1, convkE2, srcCHA, dstCHA, num, 1, 1, kIm3D_recon.begin() + start_ro*convkE1*convkE2*srcCHA*dstCHA);
+
+                            std::stringstream os_ro;
+                            os_ro << "encoding_" << e << "_n" << n << "_s" << s << "_slc" << slc << "_ro" << start_ro << "_" << end_ro;
+                            std::string suffix_3D_ro = os_ro.str();
+
+                            // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(kspace3D_recon_ro, debug_folder_full_path_ + "kspace3D_recon_ro_" + suffix_3D_ro); }
+                            // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(kIm3D_recon_ro, debug_folder_full_path_ + "kIm3D_recon_ro_" + suffix_3D_ro); }
+
+                            if(num==RO_recon_size)
+                            {
+                                if (this->perform_timing.value()) timer.start("SPIRIT linear 3D, image domain kernel along E1 and E2 ... ");
+                                Gadgetron::spirit3d_image_domain_kernel(kIm3D_recon_ro, E1, E2, kIm);
+                                if (this->perform_timing.value()) timer.stop();
+                                // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(kIm, debug_folder_full_path_ + "kIm_" + suffix_3D_ro); }
+
+                                if (this->perform_timing.value()) timer.start("SPIRIT linear 3D, linear unwrapping ... ");
+                                this->perform_spirit_unwrapping(kspace3D_recon_ro, kIm, res_ro_recon);
+                                if (this->perform_timing.value()) timer.stop();
+                            }
+                            else
+                            {
+                                if (this->perform_timing.value()) timer.start("SPIRIT linear 3D, image domain kernel along E1 and E2, last ... ");
+                                hoNDArray< std::complex<float> > kIm_last(E1, E2, srcCHA, dstCHA, num);
+                                Gadgetron::spirit3d_image_domain_kernel(kIm3D_recon_ro, E1, E2, kIm_last);
+                                if (this->perform_timing.value()) timer.stop();
+                                // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(kIm_last, debug_folder_full_path_ + "kIm_last_" + suffix_3D_ro); }
+
+                                if (this->perform_timing.value()) timer.start("SPIRIT linear 3D, linear unwrapping ... ");
+                                this->perform_spirit_unwrapping(kspace3D_recon_ro, kIm_last, res_ro_recon);
+                                if (this->perform_timing.value()) timer.stop();
+                            }
+
+                            // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(res_ro_recon, debug_folder_full_path_ + "res_ro_recon_" + suffix_3D_ro); }
+
+                            // ---------------------------------------------------------------------
+                            // copy the recon results
+                            // ---------------------------------------------------------------------
+                            std::complex<float>* pResRO = res_ro_recon.begin();
+                            for (dcha = 0; dcha < dstCHA; dcha++)
+                            {
+                                for (e2 = 0; e2 < E2; e2++)
+                                {
+                                    for (e1 = 0; e1 < E1; e1++)
+                                    {
+                                        for (ro = 0; ro < num; ro++)
+                                        {
+                                            pRes[ro + start_ro + e1*RO + e2*RO*E1 + dcha*RO*E1*E2] = pResRO[e1 + e2*E1 + dcha*E1*E2 + ro*E1*E2*dstCHA];
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // ---------------------------------------------------------------------
+                        // go back to kspace for RO
+                        // ---------------------------------------------------------------------
+                        if (this->perform_timing.value()) timer.start("SPIRIT linear 3D, fft along RO for res ... ");
+                        Gadgetron::hoNDFFT<float>::instance()->fft1c(res_recon);
+                        if (this->perform_timing.value()) timer.stop();
+                        // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(res_recon, debug_folder_full_path_ + "res_recon_" + suffix_3D); }
+                    }
+                }
+                else
+                {
+                    if (this->perform_timing.value()) timer.start("SPIRIT 2D, linear unwrapping ... ");
+                    this->perform_spirit_unwrapping(kspace, recon_obj.kernelIm2D_, res);
+                    if (this->perform_timing.value()) timer.stop();
+
+                    // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(res, debug_folder_full_path_ + "res_spirit_2D_" + suffix); }
+                }
+            }
+
+            // ---------------------------------------------------------------------
+            // compute coil combined images
+            // ---------------------------------------------------------------------
+            if (this->perform_timing.value()) timer.start("SPIRIT linear, coil combination ... ");
+
+            if (E2>1)
+            {
+                Gadgetron::hoNDFFT<float>::instance()->ifft3c(recon_obj.full_kspace_, complex_im_recon_buf_);
+            }
+            else
+            {
+                Gadgetron::hoNDFFT<float>::instance()->ifft2c(recon_obj.full_kspace_, complex_im_recon_buf_);
+            }
+
+            // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(complex_im_recon_buf_, debug_folder_full_path_ + "complex_im_recon_buf_" + suffix); }
+
+#pragma omp parallel default(none) private(ii) shared(num, N, S, recon_obj, RO, E1, E2, dstCHA) if(num>1)
+            {
+                hoNDArray< std::complex<float> > complexImBuf(RO, E1, E2, dstCHA);
+
+#pragma omp for 
+                for (ii = 0; ii < num; ii++)
+                {
+                    size_t slc = ii / (N*S);
+                    size_t s = (ii - slc*N*S) / N;
+                    size_t n = ii - slc*N*S - s*N;
+
+                    size_t coilMapN = n;
+                    if (coilMapN >= recon_obj.coil_map_.get_size(5)) coilMapN = recon_obj.coil_map_.get_size(5) - 1;
+
+                    size_t coilMapS = s;
+                    if (coilMapS >= recon_obj.coil_map_.get_size(6)) coilMapS = recon_obj.coil_map_.get_size(6) - 1;
+
+                    hoNDArray< std::complex<float> > complexIm(RO, E1, E2, dstCHA, &(complex_im_recon_buf_(0, 0, 0, 0, n, s, slc)));
+                    hoNDArray< std::complex<float> > coilMap(RO, E1, E2, dstCHA, &(recon_obj.coil_map_(0, 0, 0, 0, coilMapN, coilMapS, slc)));
+                    hoNDArray< std::complex<float> > combined(RO, E1, E2, 1, &(recon_obj.recon_res_.data_(0, 0, 0, 0, n, s, slc)));
+
+                    Gadgetron::multiplyConj(complexIm, coilMap, complexImBuf);
+                    Gadgetron::sum_over_dimension(complexImBuf, combined, 3);
+                }
+            }
+
+            if (this->perform_timing.value()) timer.stop();
+
+            // if (!debug_folder_full_path_.empty()) { gt_exporter_.exportArrayComplex(recon_obj.recon_res_.data_, debug_folder_full_path_ + "unwrappedIm_" + suffix); }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericReconCartesianSpiritGadget::perform_unwrapping(...) ... ");
+        }
+    }
+
+    void GenericReconCartesianSpiritGadget::perform_spirit_unwrapping(hoNDArray< std::complex<float> >& kspace, hoNDArray< std::complex<float> >& kerIm, hoNDArray< std::complex<float> >& res)
+    {
+        try
+        {
+            size_t iter_max = this->spirit_iter_max.value();
+            double iter_thres = this->spirit_iter_thres.value();
+            bool print_iter = this->spirit_print_iter.value();
+
+            size_t RO = kspace.get_size(0);
+            size_t E1 = kspace.get_size(1);
+            size_t E2 = kspace.get_size(2);
+            size_t CHA = kspace.get_size(3);
+            size_t N = kspace.get_size(4);
+            size_t S = kspace.get_size(5);
+            size_t SLC = kspace.get_size(6);
+
+            size_t ref_N = kerIm.get_size(4);
+            size_t ref_S = kerIm.get_size(5);
+
+            long long num = N*S*SLC;
+            long long ii;
+
+            hoNDArray< std::complex<float> > ker_Shifted(kerIm);
+            Gadgetron::hoNDFFT<float>::instance()->ifftshift2D(kerIm, ker_Shifted);
+
+            hoNDArray< std::complex<float> > kspace_Shifted;
+            kspace_Shifted = kspace;
+            Gadgetron::hoNDFFT<float>::instance()->ifftshift2D(kspace, kspace_Shifted);
+
+#pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, CHA, ref_N, ref_S, kspace, res, kspace_Shifted, ker_Shifted, iter_max, iter_thres, print_iter) if(num>1)
+            {
+                std::vector<size_t> dim(3, 1);
+                dim[0] = RO;
+                dim[1] = E1;
+                dim[2] = CHA;
+
+                boost::shared_ptr< hoSPIRIT2DOperator< std::complex<float> > > oper(new hoSPIRIT2DOperator< std::complex<float> >(&dim));
+                hoSPIRIT2DOperator< std::complex<float> >& spirit = *oper;
+                spirit.use_non_centered_fft_ = true;
+                spirit.no_null_space_ = false;
+
+                if (ref_N == 1 && ref_S == 1)
+                {
+                    boost::shared_ptr<hoNDArray< std::complex<float> > > ker(new hoNDArray< std::complex<float> >(RO, E1, CHA, CHA, ker_Shifted.begin()));
+                    spirit.set_forward_kernel(*ker, false);
+                }
+
+                hoLsqrSolver< std::complex<float> > cgSolver;
+                cgSolver.set_tc_tolerance((float)iter_thres);
+                cgSolver.set_max_iterations(iter_max);
+                cgSolver.set_output_mode(print_iter ? hoLsqrSolver< std::complex<float> >::OUTPUT_VERBOSE : hoLsqrSolver< std::complex<float> >::OUTPUT_SILENT);
+                cgSolver.set_encoding_operator(oper);
+
+                hoNDArray< std::complex<float> > b(RO, E1, CHA);
+                hoNDArray< std::complex<float> > unwarppedKSpace(RO, E1, CHA);
+
+#pragma omp for 
+                for (ii = 0; ii < num; ii++)
+                {
+                    size_t slc = ii / (N*S);
+                    size_t s = (ii - slc*N*S) / N;
+                    size_t n = ii - slc*N*S - s*N;
+
+                    // check whether the kspace is undersampled
+                    bool undersampled = false;
+                    for (size_t e1 = 0; e1 < E1; e1++)
+                    {
+                        if ((std::abs(kspace(RO / 2, e1, 0, CHA - 1, n, s, slc)) == 0)
+                            && (std::abs(kspace(RO / 2, e1, 0, 0, n, s, slc)) == 0))
+                        {
+                            undersampled = true;
+                            break;
+                        }
+                    }
+
+                    std::complex<float>* pKpaceShifted = &(kspace_Shifted(0, 0, 0, 0, n, s, slc));
+                    std::complex<float>* pRes = &(res(0, 0, 0, 0, n, s, slc));
+
+                    if (!undersampled)
+                    {
+                        memcpy(pRes, pKpaceShifted, sizeof(std::complex<float>)*RO*E1*CHA);
+                        continue;
+                    }
+
+                    long long kernelN = n;
+                    if (kernelN >= (long long)ref_N) kernelN = (long long)ref_N - 1;
+
+                    long long kernelS = n;
+                    if (kernelS >= (long long)ref_S) kernelS = (long long)ref_S - 1;
+
+                    boost::shared_ptr< hoNDArray< std::complex<float> > > acq(new hoNDArray< std::complex<float> >(RO, E1, CHA, pKpaceShifted));
+                    spirit.set_acquired_points(*acq);
+                    cgSolver.set_x0(acq);
+
+                    if (ref_N == 1 && ref_S == 1)
+                    {
+                        spirit.compute_righ_hand_side(*acq, b);
+                        cgSolver.solve(&unwarppedKSpace, &b);
+                    }
+                    else
+                    {
+                        std::complex<float>* pKer = &(ker_Shifted(0, 0, 0, 0, kernelN, kernelS, slc));
+                        boost::shared_ptr<hoNDArray< std::complex<float> > > ker(new hoNDArray< std::complex<float> >(RO, E1, CHA, CHA, pKer));
+                        spirit.set_forward_kernel(*ker, false);
+
+                        spirit.compute_righ_hand_side(*acq, b);
+                        cgSolver.solve(&unwarppedKSpace, &b);
+                    }
+
+                    // restore the acquired points
+                    spirit.restore_acquired_kspace(*acq, unwarppedKSpace);
+                    memcpy(pRes, unwarppedKSpace.begin(), unwarppedKSpace.get_number_of_bytes());
+                }
+            }
+
+            Gadgetron::hoNDFFT<float>::instance()->fftshift2D(res, kspace_Shifted);
+            res = kspace_Shifted;
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors happened in GenericReconCartesianSpiritGadget::perform_spirit_unwrapping(...) ... ");
+        }
+    }
+
+    GADGET_FACTORY_DECLARE(GenericReconCartesianSpiritGadget)
+}

--- a/gadgets/mri_core/GenericReconCartesianSpiritGadget.h
+++ b/gadgets/mri_core/GenericReconCartesianSpiritGadget.h
@@ -1,0 +1,109 @@
+/** \file   GenericReconCartesianSpiritGadget.h
+    \brief  This is the class gadget for both 2DT and 3DT cartesian Spirit reconstruction, working on the IsmrmrdReconData.
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include "GenericReconGadget.h"
+
+namespace Gadgetron {
+
+    /// define the recon status
+    template <typename T>
+    class EXPORTGADGETSMRICORE GenericReconCartesianSpiritObj
+    {
+    public:
+
+        GenericReconCartesianSpiritObj() {}
+        virtual ~GenericReconCartesianSpiritObj() {}
+
+        // ------------------------------------
+        /// recon outputs
+        // ------------------------------------
+        /// reconstructed images, headers and meta attributes
+        IsmrmrdImageArray recon_res_;
+
+        /// full kspace reconstructed
+        hoNDArray<T> full_kspace_;
+
+        // ------------------------------------
+        /// buffers used in the recon
+        // ------------------------------------
+        /// [RO E1 E2 dstCHA Nor1 Sor1 SLC]
+        hoNDArray<T> ref_calib_;
+
+        /// reference data ready for coil map estimation
+        /// [RO E1 E2 dstCHA Nor1 Sor1 SLC]
+        hoNDArray<T> ref_coil_map_;
+
+        /// for combined imgae channel
+        /// convolution kernel, [convRO convE1 convE2 dstCHA dstCHA Nor1 Sor1 SLC]
+        hoNDArray<T> kernel_;
+        /// image domain kernel for 2D, [RO E1 dstCHA dstCHA Nor1 Sor1 SLC]
+        hoNDArray<T> kernelIm2D_;
+
+        /// due to the iterative nature of SPIRIT method, the complete memory storage of 3D kernel is not feasible
+        /// the RO decouplling is used for 3D spirit
+        /// image domain kernel 3D, [convE1 convE2 dstCHA dstCHA RO Nor1 Sor1 SLC]
+        hoNDArray<T> kernelIm3D_;
+
+        /// coil sensitivity map, [RO E1 E2 dstCHA Nor1 Sor1 SLC]
+        hoNDArray<T> coil_map_;
+    };
+}
+
+namespace Gadgetron {
+
+    class EXPORTGADGETSMRICORE GenericReconCartesianSpiritGadget : public GenericReconGadget
+    {
+    public:
+        GADGET_DECLARE(GenericReconCartesianSpiritGadget);
+
+        typedef GenericReconGadget BaseClass;
+        typedef Gadgetron::GenericReconCartesianSpiritObj< std::complex<float> > ReconObjType;
+
+        GenericReconCartesianSpiritGadget();
+        ~GenericReconCartesianSpiritGadget();
+
+        /// ------------------------------------------------------------------------------------
+        /// Spirit parameters
+        GADGET_PROPERTY(spirit_kSize_RO, int, "Spirit kernel size RO", 7);
+        GADGET_PROPERTY(spirit_kSize_E1, int, "Spirit kernel size E1", 7);
+        GADGET_PROPERTY(spirit_kSize_E2, int, "Spirit kernel size E2", 5);
+        GADGET_PROPERTY(spirit_reg_lamda, double, "Spirit regularization threshold", 0);
+        GADGET_PROPERTY(spirit_calib_over_determine_ratio, double, "Spirit calibration overdermination ratio", 45);
+        GADGET_PROPERTY(spirit_iter_max, int, "Spirit maximal number of iterations", 0);
+        GADGET_PROPERTY(spirit_iter_thres, double, "Spirit threshold to stop iteration", 0);
+        GADGET_PROPERTY(spirit_print_iter, bool, "Spirit print out iterations", false);
+
+    protected:
+
+        // --------------------------------------------------
+        // variable for recon
+        // --------------------------------------------------
+        // record the recon kernel, coil maps etc. for every encoding space
+        std::vector< ReconObjType > recon_obj_;
+
+        // --------------------------------------------------
+        // gadget functions
+        // --------------------------------------------------
+        // default interface function
+        virtual int process_config(ACE_Message_Block* mb);
+        virtual int process(Gadgetron::GadgetContainerMessage< IsmrmrdReconData >* m1);
+
+        // --------------------------------------------------
+        // recon step functions
+        // --------------------------------------------------
+
+        // calibration, if only one dst channel is prescribed, the SpiritOne is used
+        virtual void perform_calib(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // unwrapping or coil combination
+        virtual void perform_unwrapping(IsmrmrdReconBit& recon_bit, ReconObjType& recon_obj, size_t encoding);
+
+        // perform spirit unwrapping
+        // kspace, kerIm, full_kspace: [RO E1 CHA N S SLC]
+        void perform_spirit_unwrapping(hoNDArray< std::complex<float> >& kspace, hoNDArray< std::complex<float> >& kerIm, hoNDArray< std::complex<float> >& full_kspace);
+    };
+}

--- a/gadgets/mri_core/Generic_Cartesian_Spirit.xml
+++ b/gadgets/mri_core/Generic_Cartesian_Spirit.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!--
+        Gadgetron generic recon chain for 2D and 3D cartesian sampling with the SPIRIT reconstruction
+
+        Triggered by repetition
+        Recon N is contrast and S is set
+
+        Author: Hui Xue
+        Magnetic Resonance Technology Program, National Heart, Lung and Blood Institute, National Institutes of Health
+        10 Center Drive, Bethesda, MD 20814, USA
+        Email: hui.xue@nih.gov
+    -->
+
+    <!-- reader -->
+    <reader><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageReader</classname></reader>
+
+    <!-- writer -->
+    <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
+
+    <!-- Noise prewhitening -->
+    <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
+
+    <!-- RO asymmetric echo handling -->
+    <gadget><name>AsymmetricEcho</name><dll>gadgetron_mricore</dll><classname>AsymmetricEchoAdjustROGadget</classname></gadget>
+
+    <!-- RO oversampling removal -->
+    <gadget><name>RemoveROOversampling</name><dll>gadgetron_mricore</dll><classname>RemoveROOversamplingGadget</classname></gadget>
+
+    <!-- Data accumulation and trigger gadget -->
+    <gadget>
+        <name>AccTrig</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value></value></property>
+        <property><name>sorting_dimension</name><value></value></property>
+    </gadget>
+
+    <gadget>
+        <name>BucketToBuffer</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>BucketToBufferGadget</classname>
+        <property><name>N_dimension</name><value>contrast</value></property>
+        <property><name>S_dimension</name><value>average</value></property>
+        <property><name>split_slices</name><value>false</value></property>
+        <property><name>ignore_segment</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+    </gadget>
+
+    <!-- Prep ref -->
+    <gadget>
+        <name>PrepRef</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianReferencePrepGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value>DebugFolder</value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <!-- averaging across repetition -->
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <!-- every set has its own kernels -->
+        <property><name>average_all_ref_S</name><value>true</value></property>
+        <!-- whether always to prepare ref if no acceleration is used -->
+        <property><name>prepare_ref_always</name><value>true</value></property>
+        <!-- whether to fill ref readouts into the data array for the embeded mode -->
+        <property><name>ref_fill_into_data_embedded</name><value>true</value></property>
+    </gadget>
+
+    <!-- Coil compression -->
+    <gadget>
+        <name>CoilCompression</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconEigenChannelGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+
+        <property><name>average_all_ref_N</name><value>true</value></property>
+        <property><name>average_all_ref_S</name><value>true</value></property>
+
+        <!-- Up stream coil compression -->
+        <property><name>upstream_coil_compression</name><value>true</value></property>
+        <property><name>upstream_coil_compression_thres</name><value>0.001</value></property>
+        <property><name>upstream_coil_compression_num_modesKept</name><value>0</value></property>
+    </gadget>
+
+    <!-- Recon -->
+    <gadget>
+        <name>Recon</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconCartesianSpiritGadget</classname>
+
+        <!-- image series -->
+        <property><name>image_series</name><value>0</value></property>
+
+        <!-- Coil map estimation, Inati or Inati_Iter -->
+        <property><name>coil_map_algorithm</name><value>Inati</value></property>
+
+        <!-- parameters for SPIRIT recon -->
+        <property><name>spirit_print_iter</name><value>true</value></property>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value>DebugFolder</value></property>
+        <property><name>perform_timing</name><value>true</value></property>
+        <property><name>verbose</name><value>true</value></property>
+    </gadget>
+
+    <!-- Partial fourier handling -->
+    <gadget>
+        <name>PartialFourierHandling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconPartialFourierHandlingFilterGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- Parfial fourier handling filter parameters -->
+        <property><name>partial_fourier_filter_RO_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_E1_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_E2_width</name><value>0.15</value></property>
+        <property><name>partial_fourier_filter_densityComp</name><value>false</value></property>
+    </gadget>
+
+    <!-- Kspace filtering -->
+    <gadget>
+        <name>KSpaceFilter</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconKSpaceFilteringGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <!-- if incoming images have this meta field, it will not be processed -->
+        <property><name>skip_processing_meta_field</name><value>Skip_processing_after_recon</value></property>
+
+        <!-- parameters for kspace filtering -->
+        <property><name>filterRO</name><value>Gaussian</value></property>
+        <property><name>filterRO_sigma</name><value>1.0</value></property>
+        <property><name>filterRO_width</name><value>0.15</value></property>
+
+        <property><name>filterE1</name><value>Gaussian</value></property>
+        <property><name>filterE1_sigma</name><value>1.0</value></property>
+        <property><name>filterE1_width</name><value>0.15</value></property>
+
+        <property><name>filterE2</name><value>Gaussian</value></property>
+        <property><name>filterE2_sigma</name><value>1.0</value></property>
+        <property><name>filterE2_width</name><value>0.15</value></property>
+    </gadget>
+
+    <!-- FOV Adjustment -->
+    <gadget>
+        <name>FOVAdjustment</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconFieldOfViewAdjustmentGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+    </gadget>
+
+    <!-- Image Array Scaling -->
+    <gadget>
+        <name>Scaling</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>GenericReconImageArrayScalingGadget</classname>
+
+        <!-- parameters for debug and timing -->
+        <property><name>perform_timing</name><value>false</value></property>
+        <property><name>verbose</name><value>false</value></property>
+
+        <property><name>min_intensity_value</name><value>64</value></property>
+        <property><name>max_intensity_value</name><value>4095</value></property>
+        <property><name>scalingFactor</name><value>10.0</value></property>
+        <property><name>use_constant_scalingFactor</name><value>true</value></property>
+        <property><name>auto_scaling_only_once</name><value>true</value></property>
+        <property><name>scalingFactor_dedicated</name><value>100.0</value></property>
+    </gadget>
+
+    <!-- ImageArray to images -->
+    <gadget>
+        <name>ImageArraySplit</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageArraySplitGadget</classname>
+    </gadget>
+
+    <!-- after recon processing -->
+    <gadget>
+        <name>ComplexToFloatAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ComplexToFloatGadget</classname>
+    </gadget>
+
+    <gadget>
+        <name>FloatToShortAttrib</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>FloatToUShortGadget</classname>
+
+        <property><name>max_intensity</name><value>32767</value></property>
+        <property><name>min_intensity</name><value>0</value></property>
+        <property><name>intensity_offset</name><value>0</value></property>
+    </gadget>
+
+    <gadget>
+        <name>ImageFinish</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>

--- a/toolboxes/mri_core/mri_core_spirit.cpp
+++ b/toolboxes/mri_core/mri_core_spirit.cpp
@@ -744,7 +744,7 @@ void spirit3d_kspace_image_domain_kernel(const hoNDArray<T>& convKer, size_t RO,
         size_t srcCHA = convKer.get_size(3);
         size_t dstCHA = convKer.get_size(4);
 
-        if (kIm.get_size(0) != kE1 || kIm.get_size(1) != kE2 || kIm.get_size(2) != srcCHA || kIm.get_size(3) != dstCHA || kIm.get_size(5) != RO)
+        if (kIm.get_size(0) != kE1 || kIm.get_size(1) != kE2 || kIm.get_size(2) != srcCHA || kIm.get_size(3) != dstCHA || kIm.get_size(4) != RO)
         {
             kIm.create(kE1, kE2, srcCHA, dstCHA, RO);
         }


### PR DESCRIPTION
Add linear spirit gadget into the generic chain

a) Both 2D and 3D linear spirit was implemented

b) Add Generic_Cartesian_Spirit.xml for spirit reconstruction

c) This linear spirit gadget will serve as basis for further nonlinear spirit reconstruction.

d) Integration test cases to be added in next PR.