### PR TITLE
fix_bugs_refactoring_generic_chain

### DIFF
--- a/gadgets/mri_core/BucketToBufferGadget.cpp
+++ b/gadgets/mri_core/BucketToBufferGadget.cpp
@@ -544,7 +544,7 @@ namespace Gadgetron{
           NS = 1;
         }
 
-        GDEBUG_CONDITION_STREAM(verbose.value(), "Data dimensions [RO E1 E2 CHA N S SLC] : [" << NE0 << " " << NE1 << " " << NE2 << " " << NCHA << " " << NN << " " << NS << " " << NLOC);
+        GDEBUG_CONDITION_STREAM(verbose.value(), "Data dimensions [RO E1 E2 CHA N S SLC] : [" << NE0 << " " << NE1 << " " << NE2 << " " << NCHA << " " << NN << " " << NS << " " << NLOC <<"]");
 
         //Allocate the array for the data
         dataBuffer.data_.create(NE0, NE1, NE2, NCHA, NN, NS, NLOC);
@@ -661,8 +661,8 @@ namespace Gadgetron{
 
         GDEBUG_STREAM("Sampling limits : "
                 << "- RO : [ " << sampling.sampling_limits_[0].min_ << " " << sampling.sampling_limits_[0].center_ << " " << sampling.sampling_limits_[0].max_
-                << "- E1 : [ " << sampling.sampling_limits_[1].min_ << " " << sampling.sampling_limits_[1].center_ << " " << sampling.sampling_limits_[1].max_
-                << "- E2 : [ " << sampling.sampling_limits_[2].min_ << " " << sampling.sampling_limits_[2].center_ << " " << sampling.sampling_limits_[2].max_);
+                << " ] - E1 : [ " << sampling.sampling_limits_[1].min_ << " " << sampling.sampling_limits_[1].center_ << " " << sampling.sampling_limits_[1].max_
+                << " ] - E2 : [ " << sampling.sampling_limits_[2].min_ << " " << sampling.sampling_limits_[2].center_ << " " << sampling.sampling_limits_[2].max_ << " ]");
     }
   }
 

--- a/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
+++ b/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
@@ -568,63 +568,16 @@ namespace Gadgetron {
             }
 
             // SNR unit scaling
-            size_t e1, e2, n, s;
-            size_t num_readout_lines = 0;
-            for (s = 0; s < S; s++)
+            float effective_acce_factor(1), snr_scaling_ratio(1);
+            this->compute_snr_scaling_factor(recon_bit, effective_acce_factor, snr_scaling_ratio);
+            if (effective_acce_factor > 1)
             {
-                for (n = 0; n < N; n++)
-                {
-                    for (e2 = 0; e2 < E2; e2++)
-                    {
-                        for (e1 = 0; e1 < E1; e1++)
-                        {
-                            if (std::abs(recon_bit.data_.data_(RO / 2, e1, e2, 0, n)) > 0)
-                            {
-                                num_readout_lines++;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (num_readout_lines > 0)
-            {
-                double lenRO = RO;
-
-                size_t start_RO = recon_bit.data_.sampling_.sampling_limits_[0].min_;
-                size_t end_RO = recon_bit.data_.sampling_.sampling_limits_[0].max_;
-
-                if ( (start_RO>=0 && start_RO<RO) && (end_RO>=0 && end_RO<RO) && (end_RO - start_RO + 1 < RO) )
-                {
-                    lenRO = (end_RO - start_RO + 1);
-                }
-                if (this->verbose.value()) GDEBUG_STREAM("GenericReconCartesianGrappaGadget, length for RO : " << lenRO << " - " << lenRO / RO);
-
-                double effectiveAcceFactor = (double)(S*N*E1*E2) / (num_readout_lines);
-                if (this->verbose.value()) GDEBUG_STREAM("GenericReconCartesianGrappaGadget, effectiveAcceFactor : " << effectiveAcceFactor);
-
-                double ROScalingFactor = (double)RO / (double)lenRO;
-
                 // since the grappa in gadgetron is doing signal preserving scaling, to perserve noise level, we need this compensation factor
                 double grappaKernelCompensationFactor = 1.0 / (acceFactorE1_[e] * acceFactorE2_[e]);
+                Gadgetron::scal((float)(grappaKernelCompensationFactor*snr_scaling_ratio), complex_im_recon_buf_);
 
-                float fftCompensationRatio = (float)(std::sqrt(ROScalingFactor*effectiveAcceFactor) * grappaKernelCompensationFactor);
-
-                if (this->verbose.value()) GDEBUG_STREAM("GenericReconCartesianGrappaGadget, fftCompensationRatio : " << fftCompensationRatio);
-
-                Gadgetron::scal(fftCompensationRatio, complex_im_recon_buf_);
+                if (this->verbose.value()) GDEBUG_STREAM("GenericReconCartesianGrappaGadget, grappaKernelCompensationFactor*snr_scaling_ratio : " << grappaKernelCompensationFactor*snr_scaling_ratio);
             }
-            else
-            {
-                GWARN_STREAM("GenericReconCartesianGrappaGadget, cannot find any sampled lines ... ");
-            }
-
-            //float effectiveAcceFactor = acceFactorE1_[e] * acceFactorE2_[e];
-            //if (effectiveAcceFactor > 1)
-            //{
-            //    float fftCompensationRatio = (float)(1.0 / std::sqrt(effectiveAcceFactor));
-            //    Gadgetron::scal(fftCompensationRatio, complex_im_recon_buf_);
-            //}
 
             /*if (!debug_folder_full_path_.empty())
             {

--- a/gadgets/mri_core/GenericReconCartesianSpiritGadget.h
+++ b/gadgets/mri_core/GenericReconCartesianSpiritGadget.h
@@ -105,5 +105,8 @@ namespace Gadgetron {
         // perform spirit unwrapping
         // kspace, kerIm, full_kspace: [RO E1 CHA N S SLC]
         void perform_spirit_unwrapping(hoNDArray< std::complex<float> >& kspace, hoNDArray< std::complex<float> >& kerIm, hoNDArray< std::complex<float> >& full_kspace);
+
+        // perform coil combination
+        void perform_spirit_coil_combine(ReconObjType& recon_obj);
     };
 }

--- a/gadgets/mri_core/GenericReconEigenChannelGadget.cpp
+++ b/gadgets/mri_core/GenericReconEigenChannelGadget.cpp
@@ -118,7 +118,7 @@ namespace Gadgetron {
             size_t S = data.get_size(5);
             size_t SLC = data.get_size(6);
 
-            GDEBUG_CONDITION_STREAM(verbose.value(), "GenericReconEigenChannelGadget - incoming data array : [RO E1 E2 CHA N S SLC] - [" << RO << " " << E1 << " " << E2 << " " << CHA << " " << N << " " << S << " " << SLC << "]");
+            GDEBUG_STREAM("GenericReconEigenChannelGadget - incoming data array : [RO E1 E2 CHA N S SLC] - [" << RO << " " << E1 << " " << E2 << " " << CHA << " " << N << " " << S << " " << SLC << "]");
 
             // whether it is needed to update coefficients
             bool recompute_coeff = false;
@@ -152,11 +152,11 @@ namespace Gadgetron {
                 }
             }
 
-            if(recompute_coeff)
-            {
                 bool average_N = average_all_ref_N.value();
                 bool average_S = average_all_ref_S.value();
 
+            if(recompute_coeff)
+            {
                 if(rbit.ref_)
                 {
                     // use ref to compute coefficients
@@ -182,13 +182,56 @@ namespace Gadgetron {
                             {
                                 KLT_[e][slc][s][n].eigen_value(E);
 
-                                GDEBUG_STREAM("Number of modes kept: " << KLT_[e][slc][s][n].output_length() << "; Eigen value, slc - " << slc << ", S - " << s << ", N - " << n << " : [");
+                                GDEBUG_STREAM("GenericReconEigenChannelGadget - Number of modes kept: " << KLT_[e][slc][s][n].output_length() << " out of " << CHA << "; Eigen value, slc - " << slc << ", S - " << s << ", N - " << n << " : [");
 
                                 for (size_t c = 0; c < E.get_size(0); c++)
                                 {
                                     GDEBUG_STREAM("        " << E(c));
                                 }
                                 GDEBUG_STREAM("]");
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    if(average_N && average_S)
+                    {
+                        for (slc = 0; slc < SLC; slc++)
+                        {
+                            GDEBUG_STREAM("GenericReconEigenChannelGadget - Number of modes kept, SLC : " << slc << " - " << KLT_[e][slc][0][0].output_length() << " out of " << CHA);
+                        }
+                    }
+                    else if(average_N && !average_S)
+                    {
+                        for (slc = 0; slc < SLC; slc++)
+                        {
+                            for (s = 0; s < S; s++)
+                            {
+                                GDEBUG_STREAM("GenericReconEigenChannelGadget - Number of modes kept, [SLC S] : [" << slc << " " << s << "] - " << KLT_[e][slc][s][0].output_length() << " out of " << CHA);
+                            }
+                        }
+                    }
+                    else if(!average_N && average_S)
+                    {
+                        for (slc = 0; slc < SLC; slc++)
+                        {
+                            for (n = 0; n < N; n++)
+                            {
+                                GDEBUG_STREAM("GenericReconEigenChannelGadget - Number of modes kept, [SLC N] : [" << slc << " " << n << "] - " << KLT_[e][slc][0][n].output_length() << " out of " << CHA);
+                            }
+                        }
+                    }
+                    else if(!average_N && !average_S)
+                    {
+                        for (slc = 0; slc < SLC; slc++)
+                        {
+                            for (s = 0; s < S; s++)
+                            {
+                                for (n = 0; n < N; n++)
+                                {
+                                    GDEBUG_STREAM("GenericReconEigenChannelGadget - Number of modes kept, [SLC S N] : [" << slc << " " << s << " " << n << "] - " << KLT_[e][slc][s][n].output_length() << " out of " << CHA);
+                                }
                             }
                         }
                     }

--- a/gadgets/mri_core/GenericReconGadget.h
+++ b/gadgets/mri_core/GenericReconGadget.h
@@ -91,6 +91,9 @@ namespace Gadgetron {
         // send out the recon results
         virtual int send_out_image_array(IsmrmrdReconBit& recon_bit, IsmrmrdImageArray& res, size_t encoding, int series_num, const std::string& data_role);
 
+        // compute snr scaling factor from effective acceleration rate and sampling region
+        void compute_snr_scaling_factor(IsmrmrdReconBit& recon_bit, float& effective_acce_factor, float& snr_scaling_ratio);
+
         // --------------------------------------------------
         // utility functions
         // --------------------------------------------------


### PR DESCRIPTION
A few fix and refactoring before the nl spirit:

a) Fix output messages in BueckerToBufferGadget
b) Pull SNR unit scaling computation as a member function into GadgetronReconGadget, as it is useful for all recon algorithms
c) Pull coil combination code as a member function in linear spirit gadget, as the same code pieces are used also for nl spirit
d) Adjust the print out messages at GenericReconEigenChannelGadget