### PR TITLE
Updated set_output_mode in solver.h

### DIFF
--- a/toolboxes/solvers/solver.h
+++ b/toolboxes/solvers/solver.h
@@ -25,7 +25,7 @@ namespace Gadgetron
     // Set/get output mode
     virtual int get_output_mode() { return output_mode_; }
     virtual void set_output_mode( int output_mode ) {
-      if( !(output_mode >= OUTPUT_MAX || output_mode < 0 )) 
+      if( !(output_mode > OUTPUT_MAX || output_mode < 0 )) 
 	output_mode_ = output_mode;
     }
   


### PR DESCRIPTION
Allow the output_mode_ to be set to OUTPUT_MAX.
OUTPUT_MAX is supposed to be a "super-verbose" mode, with maximum output, so the set_output_mode method should allow the user to set the output_mode_ to that value.