### PR TITLE
Added ability to control log file location in Docker container

### DIFF
--- a/docker/incremental/ubuntu_1404_cuda55/Dockerfile
+++ b/docker/incremental/ubuntu_1404_cuda55/Dockerfile
@@ -71,6 +71,7 @@ RUN cd /opt && \
     echo '#!/bin/bash' > start_web.sh && \
     echo '[ -n "${GADGETRON_RELAY_HOST}" ] && { sed -i "s/relay_host=.*/relay_host=${GADGETRON_RELAY_HOST}/g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
     echo '[ -n "${GADGETRON_LB_ENDPOINT}" ] && { sed -i "s/lb_endpoint=.*/lb_endpoint=${GADGETRON_LB_ENDPOINT}/g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
+    echo '[ -n "${GADGETRON_LOG_FILE}" ] && { sed -i "s|logfile=/tmp/gadgetron.log|logfile=${GADGETRON_LOG_FILE}|g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
     echo 'python /usr/local/bin/gadgetron_web_app.py /usr/local/share/gadgetron/config/gadgetron_web_app.cfg' >> start_web.sh && \
     chmod +x start_web.sh
 

--- a/docker/incremental/ubuntu_1404_cuda75/Dockerfile
+++ b/docker/incremental/ubuntu_1404_cuda75/Dockerfile
@@ -71,6 +71,7 @@ RUN cd /opt && \
     echo '#!/bin/bash' > start_web.sh && \
     echo '[ -n "${GADGETRON_RELAY_HOST}" ] && { sed -i "s/relay_host=.*/relay_host=${GADGETRON_RELAY_HOST}/g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
     echo '[ -n "${GADGETRON_LB_ENDPOINT}" ] && { sed -i "s/lb_endpoint=.*/lb_endpoint=${GADGETRON_LB_ENDPOINT}/g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
+    echo '[ -n "${GADGETRON_LOG_FILE}" ] && { sed -i "s|logfile=/tmp/gadgetron.log|logfile=${GADGETRON_LOG_FILE}|g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
     echo 'python /usr/local/bin/gadgetron_web_app.py /usr/local/share/gadgetron/config/gadgetron_web_app.cfg' >> start_web.sh && \
     chmod +x start_web.sh
 

--- a/docker/incremental/ubuntu_1404_no_cuda/Dockerfile
+++ b/docker/incremental/ubuntu_1404_no_cuda/Dockerfile
@@ -71,6 +71,7 @@ RUN cd /opt && \
     echo '#!/bin/bash' > start_web.sh && \
     echo '[ -n "${GADGETRON_RELAY_HOST}" ] && { sed -i "s/relay_host=.*/relay_host=${GADGETRON_RELAY_HOST}/g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
     echo '[ -n "${GADGETRON_LB_ENDPOINT}" ] && { sed -i "s/lb_endpoint=.*/lb_endpoint=${GADGETRON_LB_ENDPOINT}/g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
+    echo '[ -n "${GADGETRON_LOG_FILE}" ] && { sed -i "s|logfile=/tmp/gadgetron.log|logfile=${GADGETRON_LOG_FILE}|g" /usr/local/share/gadgetron/config/gadgetron_web_app.cfg; }' >> start_web.sh && \
     echo 'python /usr/local/bin/gadgetron_web_app.py /usr/local/share/gadgetron/config/gadgetron_web_app.cfg' >> start_web.sh && \
     chmod +x start_web.sh
 


### PR DESCRIPTION
Added the ability to control the gadgetron log file location in the container. 

The reason for this is that having it directly in `/tmp` can be problematic when tmp is mounted from outside the container and `/tmp/gadgetron` is mounted from outside the container too. One mount can shadow the other and it is not completely well defined (or at least not guaranteed) what the order is. 