### PR TITLE
Added sequential node usage to DistributeGadget,

### DIFF
--- a/gadgets/distributed/DistributeGadget.cpp
+++ b/gadgets/distributed/DistributeGadget.cpp
@@ -290,22 +290,29 @@ namespace Gadgetron{
     int ret = Gadget::close(flags);
     if (flags) {
       mtx_.acquire();
-      auto it = node_map_.begin();
-      while (it != node_map_.end()) {
-        if (it->second) {
+
+      for (auto n = node_map_.begin(); n != node_map_.end(); n++) {
+        if (n->second) {
           auto m1 = new GadgetContainerMessage<GadgetMessageIdentifier>();
           m1->getObjectPtr()->id = GADGET_MESSAGE_CLOSE;
 
-          if (it->second->putq(m1) == -1) {
+          if (n->second->putq(m1) == -1) {
             GERROR("Unable to put CLOSE package on queue\n");
             return -1;
           }
+	}
+      }
+
+      auto it = node_map_.begin();
+      while (it != node_map_.end()) {
+        if (it->second) {
           it->second->wait();
           delete it->second;
         }
         node_map_.erase(it);
         it = node_map_.begin();
       }
+
       mtx_.release();
       GDEBUG("All connectors closed. Waiting for Gadget to close\n");
     }

--- a/gadgets/distributed/DistributeGadget.h
+++ b/gadgets/distributed/DistributeGadget.h
@@ -34,6 +34,8 @@ namespace Gadgetron{
       "Name of collection Gadget", "Collect");
     GADGET_PROPERTY(single_package_mode, bool,
       "Indicates that only one package is sent to each node", false);
+    GADGET_PROPERTY(nodes_used_sequentially, bool,
+      "Indicates that data is distributed to one node at a time. When new node becomes active, previous receives close message.", true);
     GADGET_PROPERTY(use_this_node_for_compute, bool,
       "This node can also be used for computation", true);
 
@@ -68,6 +70,8 @@ namespace Gadgetron{
     std::string node_xml_config_;
     std::string node_parameters_;
     std::map<int,GadgetronConnector*> node_map_;
+    std::vector<GadgetronConnector*> closed_connectors_;
+    GadgetronConnector* prev_connector_; //Keeps track of previously used connector
 
   };
 }

--- a/gadgets/mri_core/Generic_Cartesian_NonLinear_Spirit_RealTimeCine_Cloud.xml
+++ b/gadgets/mri_core/Generic_Cartesian_NonLinear_Spirit_RealTimeCine_Cloud.xml
@@ -24,15 +24,6 @@
     <writer><slot>1022</slot><dll>gadgetron_mricore</dll><classname>MRIImageWriter</classname></writer>
     <writer><slot>1008</slot><dll>gadgetron_mricore</dll><classname>GadgetIsmrmrdAcquisitionMessageWriter</classname></writer>
 
-    <!-- Distribute slice over nodes -->
-    <gadget>
-      <name>Distribute</name>
-      <dll>gadgetron_distributed</dll>
-      <classname>IsmrmrdAcquisitionDistributeGadget</classname>
-      <property><name>parallel_dimension</name><value>slice</value></property>
-      <property><name>use_this_node_for_compute</name><value>true</value></property>
-    </gadget>
-
     <!-- Noise prewhitening -->
     <gadget><name>NoiseAdjust</name><dll>gadgetron_mricore</dll><classname>NoiseAdjustGadget</classname></gadget>
 
@@ -41,6 +32,15 @@
 
     <!-- RO oversampling removal -->
     <gadget><name>RemoveROOversampling</name><dll>gadgetron_mricore</dll><classname>RemoveROOversamplingGadget</classname></gadget>
+
+    <!-- Distribute slice over nodes -->
+    <gadget>
+      <name>Distribute</name>
+      <dll>gadgetron_distributed</dll>
+      <classname>IsmrmrdAcquisitionDistributeGadget</classname>
+      <property><name>parallel_dimension</name><value>slice</value></property>
+      <property><name>use_this_node_for_compute</name><value>true</value></property>
+    </gadget>
 
     <!-- Data accumulation and trigger gadget -->
     <gadget>


### PR DESCRIPTION
 in this mode (default) nodes receive data sequentially, e.g. slice 1 to node 1, once slice 2 arrives, it is assumed that slice 1 is done. This allows the distribute Gadget to send a close down the pipe and trigger recon and clean up.

@xueh2 could you please verify that this now has the correct behavior?