### PR TITLE
Add dicom ismrmrd image dump gadget3

### DIFF
--- a/gadgets/dicom/CMakeLists.txt
+++ b/gadgets/dicom/CMakeLists.txt
@@ -58,11 +58,13 @@ set(gadgetron_dicom_header_files
     gadgetron_dicom_export.h 
     DicomFinishGadget.h 
     DicomImageWriter.h 
+    DicomIsmrmrdImageDumpGadget.h 
     dicom_ismrmrd_utility.h )
 
 set(gadgetron_dicom_src_files 
     DicomFinishGadget.cpp 
     DicomImageWriter.cpp 
+    DicomIsmrmrdImageDumpGadget.cpp 
     dicom_ismrmrd_utility.cpp )
 
 set(gadgetron_dicom_config_files dicom.xml )

--- a/gadgets/dicom/DicomIsmrmrdImageDumpGadget.cpp
+++ b/gadgets/dicom/DicomIsmrmrdImageDumpGadget.cpp
@@ -37,6 +37,7 @@ namespace Gadgetron {
 
         GDEBUG("Measurement ID: %s\n", measurement_id.c_str());
 
+        // analyze measurement id
         if(measurement_id.size()>0)
         {
             std::string mid = measurement_id;
@@ -59,6 +60,15 @@ namespace Gadgetron {
                         measurement_ = mid.substr(ind+1, std::string::npos);
                     }
                 }
+            }
+        }
+
+        // get the protocol name
+        if ( h.measurementInformation )
+        {
+            if ( h.measurementInformation->protocolName )
+            {
+                protocol_name_ = *h.measurementInformation->protocolName;
             }
         }
 
@@ -141,13 +151,13 @@ namespace Gadgetron {
             GadgetContainerMessage< hoNDArray< unsigned short > >* datamb = AsContainerMessage< hoNDArray< unsigned short > >(m1->cont());
             if (!datamb)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, invalid image message objects");
                 return GADGET_FAIL;
             }
 
             if (this->dump_image(m1, datamb) != GADGET_OK)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for unsigned short ... \n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::dump_image failed for unsigned short ... ");
             }
         }
         else if (data_type == ISMRMRD::ISMRMRD_SHORT)
@@ -155,13 +165,13 @@ namespace Gadgetron {
             GadgetContainerMessage< hoNDArray< short > >* datamb = AsContainerMessage< hoNDArray< short > >(m1->cont());
             if (!datamb)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, invalid image message objects");
                 return GADGET_FAIL;
             }
 
             if (this->dump_image(m1, datamb) != GADGET_OK)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for short ... \n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::dump_image failed for short ... ");
             }
         }
         else if (data_type == ISMRMRD::ISMRMRD_UINT)
@@ -169,13 +179,13 @@ namespace Gadgetron {
             GadgetContainerMessage< hoNDArray< unsigned int > >* datamb = AsContainerMessage< hoNDArray< unsigned int > >(m1->cont());
             if (!datamb)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, invalid image message objects");
                 return GADGET_FAIL;
             }
 
             if (this->dump_image(m1, datamb) != GADGET_OK)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for unsigned int ... \n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::dump_image failed for unsigned int ... ");
             }
         }
         else if (data_type == ISMRMRD::ISMRMRD_INT)
@@ -183,13 +193,13 @@ namespace Gadgetron {
             GadgetContainerMessage< hoNDArray< int > >* datamb = AsContainerMessage< hoNDArray< int > >(m1->cont());
             if (!datamb)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, invalid image message objects");
                 return GADGET_FAIL;
             }
 
             if (this->dump_image(m1, datamb) != GADGET_OK)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for int ... \n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::dump_image failed for int ... ");
             }
         }
         else if (data_type == ISMRMRD::ISMRMRD_FLOAT)
@@ -197,13 +207,13 @@ namespace Gadgetron {
             GadgetContainerMessage< hoNDArray< float > >* datamb = AsContainerMessage< hoNDArray< float > >(m1->cont());
             if (!datamb)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, invalid image message objects");
                 return GADGET_FAIL;
             }
 
             if (this->dump_image(m1, datamb) != GADGET_OK)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for float ... \n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::dump_image failed for float ... ");
             }
         }
         else if (data_type == ISMRMRD::ISMRMRD_DOUBLE)
@@ -211,32 +221,70 @@ namespace Gadgetron {
             GadgetContainerMessage< hoNDArray< double > >* datamb = AsContainerMessage< hoNDArray< double > >(m1->cont());
             if (!datamb)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, invalid image message objects");
                 return GADGET_FAIL;
             }
 
             if (this->dump_image(m1, datamb) != GADGET_OK)
             {
-                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for double ... \n");
+                GERROR_STREAM("DicomIsmrmrdImageDumpGadget::dump_image failed for double ... ");
             }
         }
         else if (data_type == ISMRMRD::ISMRMRD_CXFLOAT)
         {
-            GERROR("DicomIsmrmrdImageDumpGadget::process, does not supprot ISMRMRD_CXFLOAT data type\n");
+            GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, does not supprot ISMRMRD_CXFLOAT data type");
         }
         else if (data_type == ISMRMRD::ISMRMRD_CXDOUBLE)
         {
-            GERROR("DicomIsmrmrdImageDumpGadget::process, does not supprot ISMRMRD_CXDOUBLE data type\n");
+            GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, does not supprot ISMRMRD_CXDOUBLE data type");
+        }
+        else
+        {
+            GERROR_STREAM("DicomIsmrmrdImageDumpGadget::process, does not supprot data type : " << data_type);
         }
 
         if (this->next()->putq(m1) == -1)
         {
             m1->release();
-            GDEBUG("Unable to put ismrmrd image on next gadgets queue");
+            GDEBUG_STREAM("Unable to put ismrmrd image on next gadgets queue");
             return GADGET_FAIL;
         }
 
         return GADGET_OK;
+    }
+
+    std::string DicomIsmrmrdImageDumpGadget::get_date_string()
+    {
+        time_t rawtime;
+        struct tm * timeinfo;
+        time ( &rawtime );
+        timeinfo = localtime ( &rawtime );
+
+        std::stringstream str;
+        str << timeinfo->tm_year+1900
+            << std::setw(2) << std::setfill('0') << timeinfo->tm_mon+1
+            << std::setw(2) << std::setfill('0') << timeinfo->tm_mday;
+
+        std::string ret = str.str();
+
+        return ret;
+    }
+
+    std::string DicomIsmrmrdImageDumpGadget::get_time_string()
+    {
+        time_t rawtime;
+        struct tm * timeinfo;
+        time ( &rawtime );
+        timeinfo = localtime ( &rawtime );
+
+        std::stringstream str;
+        str << std::setw(2) << std::setfill('0') << timeinfo->tm_hour
+            << std::setw(2) << std::setfill('0') << timeinfo->tm_min
+            << std::setw(2) << std::setfill('0') << timeinfo->tm_sec;
+
+        std::string ret = str.str();
+
+        return ret;
     }
 
     GADGET_FACTORY_DECLARE(DicomIsmrmrdImageDumpGadget)

--- a/gadgets/dicom/DicomIsmrmrdImageDumpGadget.cpp
+++ b/gadgets/dicom/DicomIsmrmrdImageDumpGadget.cpp
@@ -1,0 +1,244 @@
+
+#include "DicomIsmrmrdImageDumpGadget.h"
+#include <iomanip>
+#include <boost/filesystem.hpp>
+
+namespace bf = boost::filesystem;
+
+namespace Gadgetron {
+
+    DicomIsmrmrdImageDumpGadget::DicomIsmrmrdImageDumpGadget(): BaseClass(), dcmFile()
+    {
+    }
+
+    DicomIsmrmrdImageDumpGadget::~DicomIsmrmrdImageDumpGadget()
+    {
+    }
+
+    int DicomIsmrmrdImageDumpGadget::process_config(ACE_Message_Block* mb)
+    {
+        ISMRMRD::IsmrmrdHeader h;
+        deserialize(mb->rd_ptr(), h);
+
+        xml = h;
+        Gadgetron::fill_dicom_image_from_ismrmrd_header(h, dcmFile);
+
+        // get measurement id
+        std::string measurement_id = "";
+        std::string ismrmrd_filename = "";
+
+        if ( h.measurementInformation )
+        {
+            if ( h.measurementInformation->measurementID )
+            {
+                measurement_id = *h.measurementInformation->measurementID;
+            }
+        }
+
+        GDEBUG("Measurement ID: %s\n", measurement_id.c_str());
+
+        if(measurement_id.size()>0)
+        {
+            std::string mid = measurement_id;
+            size_t ind = mid.find("_");
+            if(ind!=std::string::npos)
+            {
+                device_ = mid.substr(0, ind);
+                mid = mid.substr(ind+1, std::string::npos);
+
+                ind = mid.find("_");
+                if(ind!=std::string::npos)
+                {
+                    patient_ = mid.substr(0, ind);
+                    mid = mid.substr(ind+1, std::string::npos);
+
+                    ind = mid.find("_");
+                    if(ind!=std::string::npos)
+                    {
+                        study_ = mid.substr(0, ind);
+                        measurement_ = mid.substr(ind+1, std::string::npos);
+                    }
+                }
+            }
+        }
+
+        // if patient info was not set, assemble them
+        if(!h.subjectInformation.is_present() || !h.subjectInformation.get().patientName.is_present())
+        {
+            if(h.acquisitionSystemInformation.is_present() && h.acquisitionSystemInformation.get().institutionName.is_present())
+            {
+                if ( file_prefix.value().empty() )
+                {
+                    patient_string_ = h.acquisitionSystemInformation.get().institutionName.get() + "_" + device_ + "_" + patient_;
+                }
+                else
+                {
+                    patient_string_ = h.acquisitionSystemInformation.get().institutionName.get() + "_" + device_ + "_" + file_prefix.value() + "_" + patient_;
+                }
+            }
+        }
+
+        std::string folder_prefix;
+
+        if ( file_prefix.value().empty() )
+        {
+            folder_prefix = "ISMRMRD_DICOM_DUMP";
+        }
+        else
+        {
+            folder_prefix = file_prefix.value();
+        }
+
+        if (append_id.value() && measurement_id.size())
+        {
+            folder_prefix.append("_");
+            folder_prefix.append(measurement_id);
+        }
+
+        dicom_folder_ = folder.value() + "/" + folder_prefix;
+        bf::path p(dicom_folder_);
+
+        if (!exists(p))
+        {
+            try
+            {
+                bf::create_directory(p);
+            }
+            catch(...)
+            {
+                GERROR("Error caught trying to create folder %s\n", folder.value().c_str());
+                return GADGET_FAIL;
+            }
+        }
+        else
+        {
+            if (!is_directory(p))
+            {
+                GERROR("Specified path is not a directory\n");
+                return GADGET_FAIL;
+            }
+        }
+
+        GDEBUG_STREAM("Dicom dump folder : " << dicom_folder_);
+
+        return GADGET_OK;
+    }
+
+    int DicomIsmrmrdImageDumpGadget::process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1)
+    {
+        if (!this->controller_) {
+            GERROR("Cannot return result to controller, no controller set");
+            return GADGET_FAIL;
+        }
+
+        // --------------------------------------------------
+        ISMRMRD::ImageHeader *img = m1->getObjectPtr();
+
+        uint16_t data_type = img->data_type;
+
+        if (data_type == ISMRMRD::ISMRMRD_USHORT)
+        {
+            GadgetContainerMessage< hoNDArray< unsigned short > >* datamb = AsContainerMessage< hoNDArray< unsigned short > >(m1->cont());
+            if (!datamb)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                return GADGET_FAIL;
+            }
+
+            if (this->dump_image(m1, datamb) != GADGET_OK)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for unsigned short ... \n");
+            }
+        }
+        else if (data_type == ISMRMRD::ISMRMRD_SHORT)
+        {
+            GadgetContainerMessage< hoNDArray< short > >* datamb = AsContainerMessage< hoNDArray< short > >(m1->cont());
+            if (!datamb)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                return GADGET_FAIL;
+            }
+
+            if (this->dump_image(m1, datamb) != GADGET_OK)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for short ... \n");
+            }
+        }
+        else if (data_type == ISMRMRD::ISMRMRD_UINT)
+        {
+            GadgetContainerMessage< hoNDArray< unsigned int > >* datamb = AsContainerMessage< hoNDArray< unsigned int > >(m1->cont());
+            if (!datamb)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                return GADGET_FAIL;
+            }
+
+            if (this->dump_image(m1, datamb) != GADGET_OK)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for unsigned int ... \n");
+            }
+        }
+        else if (data_type == ISMRMRD::ISMRMRD_INT)
+        {
+            GadgetContainerMessage< hoNDArray< int > >* datamb = AsContainerMessage< hoNDArray< int > >(m1->cont());
+            if (!datamb)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                return GADGET_FAIL;
+            }
+
+            if (this->dump_image(m1, datamb) != GADGET_OK)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for int ... \n");
+            }
+        }
+        else if (data_type == ISMRMRD::ISMRMRD_FLOAT)
+        {
+            GadgetContainerMessage< hoNDArray< float > >* datamb = AsContainerMessage< hoNDArray< float > >(m1->cont());
+            if (!datamb)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                return GADGET_FAIL;
+            }
+
+            if (this->dump_image(m1, datamb) != GADGET_OK)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for float ... \n");
+            }
+        }
+        else if (data_type == ISMRMRD::ISMRMRD_DOUBLE)
+        {
+            GadgetContainerMessage< hoNDArray< double > >* datamb = AsContainerMessage< hoNDArray< double > >(m1->cont());
+            if (!datamb)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::process, invalid image message objects\n");
+                return GADGET_FAIL;
+            }
+
+            if (this->dump_image(m1, datamb) != GADGET_OK)
+            {
+                GERROR("DicomIsmrmrdImageDumpGadget::dump_image failed for double ... \n");
+            }
+        }
+        else if (data_type == ISMRMRD::ISMRMRD_CXFLOAT)
+        {
+            GERROR("DicomIsmrmrdImageDumpGadget::process, does not supprot ISMRMRD_CXFLOAT data type\n");
+        }
+        else if (data_type == ISMRMRD::ISMRMRD_CXDOUBLE)
+        {
+            GERROR("DicomIsmrmrdImageDumpGadget::process, does not supprot ISMRMRD_CXDOUBLE data type\n");
+        }
+
+        if (this->next()->putq(m1) == -1)
+        {
+            m1->release();
+            GDEBUG("Unable to put ismrmrd image on next gadgets queue");
+            return GADGET_FAIL;
+        }
+
+        return GADGET_OK;
+    }
+
+    GADGET_FACTORY_DECLARE(DicomIsmrmrdImageDumpGadget)
+
+} /* namespace Gadgetron */

--- a/gadgets/dicom/DicomIsmrmrdImageDumpGadget.cpp
+++ b/gadgets/dicom/DicomIsmrmrdImageDumpGadget.cpp
@@ -77,14 +77,7 @@ namespace Gadgetron {
         {
             if(h.acquisitionSystemInformation.is_present() && h.acquisitionSystemInformation.get().institutionName.is_present())
             {
-                if ( file_prefix.value().empty() )
-                {
-                    patient_string_ = h.acquisitionSystemInformation.get().institutionName.get() + "_" + device_ + "_" + patient_;
-                }
-                else
-                {
-                    patient_string_ = h.acquisitionSystemInformation.get().institutionName.get() + "_" + device_ + "_" + file_prefix.value() + "_" + patient_;
-                }
+                patient_string_ = h.acquisitionSystemInformation.get().institutionName.get() + "_" + device_ + "_" + patient_;
             }
         }
 

--- a/gadgets/dicom/DicomIsmrmrdImageDumpGadget.h
+++ b/gadgets/dicom/DicomIsmrmrdImageDumpGadget.h
@@ -162,9 +162,9 @@ namespace Gadgetron
                     key.set(0x0010, 0x0020);
                     write_dcm_string(dataset, key, patient_.c_str());
 
-                    // patient name
-                    key.set(0x0010, 0x0010);
-                    write_dcm_string(dataset, key, patient_.c_str());
+                    //// patient name
+                    //key.set(0x0010, 0x0010);
+                    //write_dcm_string(dataset, key, patient_.c_str());
                 }
 
                 if(!study_.empty())
@@ -177,11 +177,12 @@ namespace Gadgetron
                     write_dcm_string(dataset, key, studyID.c_str());
                 }
 
-                //if(!patient_string_.empty())
-                //{
-                //    key.set(0x0010, 0x0010);
-                //    write_dcm_string(dataset, key, patient_string_.c_str());
-                //}
+                if(!patient_string_.empty())
+                {
+                    // patient name
+                    key.set(0x0010, 0x0010);
+                    write_dcm_string(dataset, key, patient_string_.c_str());
+                }
 
                 if(!protocol_name_.empty())
                 {

--- a/gadgets/dicom/DicomIsmrmrdImageDumpGadget.h
+++ b/gadgets/dicom/DicomIsmrmrdImageDumpGadget.h
@@ -1,0 +1,239 @@
+/** \file   DicomIsmrmrdImageDumpGadget.h
+    \brief  Dump the incoming ismrmrd images as dicom images
+    \author Hui Xue
+*/
+
+#ifndef DicomIsmrmrdImageDumpGadget_H
+#define DicomIsmrmrdImageDumpGadget_H
+
+#include "gadgetron_dicom_export.h"
+
+#include "Gadget.h"
+#include "hoNDArray.h"
+#include "ismrmrd/meta.h"
+#include "GadgetMRIHeaders.h"
+#include "ismrmrd/ismrmrd.h"
+#include "GadgetStreamController.h"
+
+#include "dcmtk/config/osconfig.h"
+#include "dcmtk/ofstd/ofstdinc.h"
+#define INCLUDE_CSTDLIB
+#define INCLUDE_CSTDIO
+#define INCLUDE_CSTRING
+#include "dcmtk/dcmdata/dctk.h"
+#include "dcmtk/dcmdata/dcostrmb.h"
+
+#include "mri_core_def.h"
+
+#include "dicom_ismrmrd_utility.h"
+
+#include <string>
+#include <map>
+#include <complex>
+
+namespace Gadgetron
+{
+    class EXPORTGADGETSDICOM DicomIsmrmrdImageDumpGadget : public Gadget1< ISMRMRD::ImageHeader >
+    {
+    public:
+
+        typedef Gadget1<ISMRMRD::ImageHeader> BaseClass;
+
+        GADGET_DECLARE(DicomIsmrmrdImageDumpGadget);
+
+        DicomIsmrmrdImageDumpGadget();
+        virtual ~DicomIsmrmrdImageDumpGadget();
+
+    protected:
+
+        GADGET_PROPERTY(folder,           std::string, "Base folder for dump file", ".");
+        GADGET_PROPERTY(file_prefix,      std::string, "Prefix for dump file", "ISMRMRD_DICOM_DUMP");
+        GADGET_PROPERTY(append_id,        bool,        "ISMRMRD measurement ID to file name prefix (if available)", true);
+        GADGET_PROPERTY(append_timestamp, bool,        "Append timestamp to file name prefix", true);
+
+        virtual int process_config(ACE_Message_Block * mb);
+        virtual int process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1);
+
+        template <typename T>
+        int dump_image(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1, GadgetContainerMessage< hoNDArray< T > >* m2)
+        {
+            try{
+                GadgetContainerMessage< ISMRMRD::MetaContainer >* m3 = AsContainerMessage< ISMRMRD::MetaContainer >(m2->cont());
+
+                std::string filename;
+
+                if (m3)
+                {
+                    ISMRMRD::MetaContainer* img_attrib = m3->getObjectPtr();
+
+                    size_t n;
+
+                    size_t num = img_attrib->length(GADGETRON_DATA_ROLE);
+
+                    std::vector<std::string> dataRole;
+                    if (num == 0)
+                    {
+                        dataRole.push_back("Image");
+                    }
+                    else
+                    {
+                        dataRole.resize(num);
+                        for (n = 0; n < num; n++)
+                        {
+                            dataRole[n] = std::string(img_attrib->as_str(GADGETRON_DATA_ROLE, n));
+                        }
+                    }
+
+                    long imageNumber = img_attrib->as_long(GADGETRON_IMAGENUMBER, 0);
+
+                    long slc, con, phs, rep, set, ave;
+                    slc = m1->getObjectPtr()->slice;
+                    con = m1->getObjectPtr()->contrast;
+                    phs = m1->getObjectPtr()->phase;
+                    rep = m1->getObjectPtr()->repetition;
+                    set = m1->getObjectPtr()->set;
+                    ave = m1->getObjectPtr()->average;
+
+                    std::ostringstream ostr;
+
+                    for (n = 0; n < dataRole.size(); n++)
+                    {
+                        ostr << dataRole[n] << "_";
+                    }
+
+                    ostr << "SLC" << slc << "_"
+                        << "CON" << con << "_"
+                        << "PHS" << phs << "_"
+                        << "REP" << rep << "_"
+                        << "SET" << set << "_"
+                        << "AVE" << ave << "_"
+                        << imageNumber;
+
+                    filename = ostr.str();
+                }
+                else
+                {
+                    std::ostringstream ostr;
+                    ostr << "Image_" << m1->getObjectPtr()->image_index << "_" << m1->getObjectPtr()->image_series_index;
+                    filename = ostr.str();
+                }
+
+                // --------------------------------------------------
+
+                unsigned short series_number = m1->getObjectPtr()->image_series_index + 1;
+
+                // Try to find an already-generated Series Instance UID in our map
+                std::map<unsigned int, std::string>::iterator it = seriesIUIDs.find(series_number);
+
+                if (it == seriesIUIDs.end()) {
+                    // Didn't find a Series Instance UID for this series number
+                    char newuid[96];
+                    dcmGenerateUniqueIdentifier(newuid);
+                    seriesIUIDs[series_number] = std::string(newuid);
+                }
+
+                // --------------------------------------------------
+
+                ISMRMRD::ImageHeader mh = *m1->getObjectPtr();
+
+                if(m3)
+                {
+                    Gadgetron::write_ismrmd_image_into_dicom(mh, *m2->getObjectPtr(), xml, *m3->getObjectPtr(), seriesIUIDs[series_number], dcmFile);
+                }
+                else
+                {
+                    ISMRMRD::MetaContainer attrib;
+                    Gadgetron::write_ismrmd_image_into_dicom(mh, *m2->getObjectPtr(), xml, attrib, seriesIUIDs[series_number], dcmFile);
+                }
+
+                DcmTagKey key;
+                DcmDataset *dataset = dcmFile.getDataset();
+
+                if(!device_.empty())
+                {
+                    key.set(0x0018, 0x1000);
+                    write_dcm_string(dataset, key, device_.c_str());
+                }
+
+                if(!patient_.empty())
+                {
+                    key.set(0x0010, 0x0020);
+                    write_dcm_string(dataset, key, patient_.c_str());
+                }
+
+                if(!study_.empty())
+                {
+                    key.set(0x0020, 0x000D);
+                    write_dcm_string(dataset, key, study_.c_str());
+
+                    std::string studyID = study_ + "19000101";
+                    key.set(0x0020, 0x0010);
+                    write_dcm_string(dataset, key, studyID.c_str());
+                }
+
+                if(!patient_string_.empty())
+                {
+                    key.set(0x0010, 0x0010);
+                    write_dcm_string(dataset, key, patient_string_.c_str());
+                }
+
+                // --------------------------------------------------
+                // dump dicom image
+
+                DcmFileFormat mdcm = dcmFile;
+
+                mdcm.transferInit();
+
+                long buffer_length = mdcm.calcElementLength(EXS_LittleEndianExplicit, EET_ExplicitLength) * 2;
+                std::vector<char> bufferChar(buffer_length);
+                char* buffer = &bufferChar[0];
+
+                DcmOutputBufferStream out_stream(buffer, buffer_length);
+
+                OFCondition status;
+
+                status = mdcm.write(out_stream, EXS_LittleEndianExplicit, EET_ExplicitLength, NULL);
+                if (!status.good())
+                {
+                    GERROR_STREAM("Dump dicom image failed : " << filename);
+                    GADGET_THROW("Failed to write DcmFileFormat to DcmOutputStream ... ");
+                }
+
+                void *serialized = NULL;
+                offile_off_t serialized_length = 0;
+                out_stream.flushBuffer(serialized, serialized_length);
+
+                mdcm.transferEnd();
+
+                std::string file_full_name = dicom_folder_ + "/" + filename + ".dcm";
+
+                std::ofstream outfile;
+                outfile.open(file_full_name.c_str(), std::ios::out | std::ios::binary);
+
+                outfile.write( (char*)serialized, serialized_length);
+                outfile.close();
+            }
+            catch(...)
+            {
+                GERROR_STREAM("Exceptions happened in DicomIsmrmrdImageDumpGadget::dump_image(...) ... ");
+                return GADGET_FAIL;
+            }
+
+            return GADGET_OK;
+        }
+
+    private:
+        ISMRMRD::IsmrmrdHeader xml;
+        DcmFileFormat dcmFile;
+        std::map <unsigned int, std::string> seriesIUIDs;
+        std::string dicom_folder_;
+        std::string device_;
+        std::string patient_;
+        std::string patient_string_;
+        std::string study_;
+        std::string measurement_;
+    };
+
+} /* namespace Gadgetron */
+
+#endif // DicomIsmrmrdImageDumpGadget_H

--- a/gadgets/dicom/dicom_ismrmrd_utility.cpp
+++ b/gadgets/dicom/dicom_ismrmrd_utility.cpp
@@ -613,14 +613,17 @@ namespace Gadgetron
             const T *src = m2.get_data_ptr();
             ACE_INT16 *dst = data.get_data_ptr();
 
-            T min_pix_val, max_pix_val, sum_pix_val = 0;
+            T min_pix_val, max_pix_val = 0;
             if (m2.get_number_of_elements() > 0)
             {
                 min_pix_val = src[0];
                 max_pix_val = src[0];
             }
 
-            for (unsigned long i = 0; i < m2.get_number_of_elements(); i++)
+            size_t numPixel = m2.get_number_of_elements();
+
+            double sum_pix_val = 0;
+            for (unsigned long i = 0; i < numPixel; i++)
             {
                 T pix_val = src[i];
                 // search for minimum and maximum pixel values
@@ -630,7 +633,7 @@ namespace Gadgetron
 
                 dst[i] = static_cast<ACE_INT16>(pix_val);
             }
-            T mean_pix_val = (T)((sum_pix_val * 4) / (T)data.get_number_of_elements());
+            T mean_pix_val = (T)((sum_pix_val * 4) / (T)( (numPixel>1) ? numPixel : 1 ));
 
             unsigned int BUFSIZE = 1024;
             std::vector<char> bufVec(BUFSIZE);

--- a/gadgets/dicom/dicom_ismrmrd_utility.cpp
+++ b/gadgets/dicom/dicom_ismrmrd_utility.cpp
@@ -602,7 +602,7 @@ namespace Gadgetron
     }
 
     template<typename T> 
-    void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<T>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile)
+    void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<T>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile)
     {
         try
         {
@@ -610,7 +610,7 @@ namespace Gadgetron
             boost::shared_ptr< std::vector<size_t> > dims = m2.get_dimensions();
             data.create(dims.get());
 
-            T *src = m2.get_data_ptr();
+            const T *src = m2.get_data_ptr();
             ACE_INT16 *dst = data.get_data_ptr();
 
             T min_pix_val, max_pix_val, sum_pix_val = 0;
@@ -631,10 +631,6 @@ namespace Gadgetron
                 dst[i] = static_cast<ACE_INT16>(pix_val);
             }
             T mean_pix_val = (T)((sum_pix_val * 4) / (T)data.get_number_of_elements());
-
-            /* update the image data_type.
-            * There is currently no SIGNED SHORT type so this will have to suffice */
-            m1.data_type = ISMRMRD::ISMRMRD_USHORT;
 
             unsigned int BUFSIZE = 1024;
             std::vector<char> bufVec(BUFSIZE);
@@ -778,15 +774,15 @@ namespace Gadgetron
         }
     }
 
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<short>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<unsigned short>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<int>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<unsigned int>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<float>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<double>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<short>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<unsigned short>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<int>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<unsigned int>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<float>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<double>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
 
     template<typename T> 
-    void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<T>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile)
+    void write_ismrmd_image_into_dicom(const  ISMRMRD::ImageHeader& m1, const  hoNDArray<T>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile)
     {
         try
         {
@@ -945,10 +941,10 @@ namespace Gadgetron
         }
     }
 
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<short>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<unsigned short>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<int>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<unsigned int>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<float>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
-    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<double>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<short>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<unsigned short>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<int>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<unsigned int>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<float>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<double>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
 }

--- a/gadgets/dicom/dicom_ismrmrd_utility.h
+++ b/gadgets/dicom/dicom_ismrmrd_utility.h
@@ -44,7 +44,7 @@ namespace Gadgetron
     // --------------------------------------------------------------------------
     /// write ismrmrd image into a dcm image
     // --------------------------------------------------------------------------
-    template<typename T> EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<T>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template<typename T> EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<T>& m2, std::string& seriesIUID, DcmFileFormat& dcmFile);
     // with image attribute
-    template<typename T> EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(ISMRMRD::ImageHeader& m1, hoNDArray<T>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
+    template<typename T> EXPORTGADGETSDICOM void write_ismrmd_image_into_dicom(const ISMRMRD::ImageHeader& m1, const hoNDArray<T>& m2, ISMRMRD::IsmrmrdHeader& h, ISMRMRD::MetaContainer& attrib, std::string& seriesIUID, DcmFileFormat& dcmFile);
 }


### PR DESCRIPTION
a) Add a dicom dump ismrmrd image gadget; this gadget can save incoming ismrmrd images are dicom images into a folder

b) Fix a bug in dicom_ismrmrd_utility.cpp where the sum of all pixel in an image may overflow if the datatype is short or unsigned short.

c) The exported dicom images can be loaded into pacs like this:

![image](https://cloud.githubusercontent.com/assets/7012710/15114996/b3f00408-15ca-11e6-9151-c38e34f31bb9.png)
