### PR TITLE
add kspace binning recon linear and nonlinear

### DIFF
--- a/toolboxes/cmr/CMakeLists.txt
+++ b/toolboxes/cmr/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/image
     ${CMAKE_SOURCE_DIR}/toolboxes/fft/cpu
     ${CMAKE_SOURCE_DIR}/toolboxes/klt/cpu
+    ${CMAKE_SOURCE_DIR}/toolboxes/dwt/cpu
     ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/hostutils
     ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/math
     ${CMAKE_SOURCE_DIR}/toolboxes/core/cpu/image
@@ -36,11 +37,13 @@ include_directories(
 set(cmr_header_fiels cmr_export.h 
                     cmr_kspace_binning.h
                     cmr_time_stamp.h 
-                    cmr_motion_correction.h )
+                    cmr_motion_correction.h 
+                    cmr_spirit_recon.h )
 
 set(cmr_src_fiels cmr_kspace_binning.cpp 
                 cmr_time_stamp.cpp 
-                cmr_motion_correction.cpp )
+                cmr_motion_correction.cpp 
+                cmr_spirit_recon.cpp )
 
 add_library(gadgetron_toolbox_cmr SHARED 
             ${cmr_header_fiels} 
@@ -56,7 +59,8 @@ target_link_libraries(gadgetron_toolbox_cmr
                     gadgetron_toolbox_cpuklt 
                     gadgetron_toolbox_image_analyze_io 
                     gadgetron_toolbox_mri_core 
-                    gadgetron_toolbox_cpudwt )
+                    gadgetron_toolbox_cpudwt 
+                    gadgetron_toolbox_cpuoperator )
 
 install(TARGETS gadgetron_toolbox_cmr DESTINATION lib COMPONENT main)
 

--- a/toolboxes/cmr/cmr_kspace_binning.h
+++ b/toolboxes/cmr/cmr_kspace_binning.h
@@ -51,7 +51,7 @@ namespace Gadgetron {
         hoNDArray< std::complex<T> > full_kspace_raw_;
         /// complex images, [RO E1 1 N S]
         hoNDArray< std::complex<T> > complex_image_raw_;
-        /// coil map, [RO E1 dstCHA]
+        /// coil map, [RO E1 dstCHA S]
         hoNDArray< std::complex<T> > coil_map_raw_;
 
         /// mean RR interval in ms
@@ -90,6 +90,7 @@ namespace Gadgetron {
         hoNDArray<float> cpt_time_stamp_;
         /// cardiac phase time ratio (CPT) [0 1] for kspace lines, [E1 N S]
         hoNDArray<float> cpt_time_ratio_;
+
         /// time stamp for every raw images, [N S]
         hoNDArray<float> phs_time_stamp_;
         /// cardiac phase time in ms for every raw images, [N S]
@@ -104,13 +105,22 @@ namespace Gadgetron {
         std::vector< std::vector< std::pair<size_t, size_t> > > starting_heart_beat_;
         std::vector< std::vector< std::pair<size_t, size_t> > > ending_heart_beat_;
 
-        // output cardiac phases
+        // output cardiac phase time stamp in ms
         std::vector<float> desired_cardiac_phases_;
         // output cardiac phase ratio
         std::vector<float> desired_cpt_;
 
         /// respiratory navigator signal for every kspace line, [E1 N S]
         hoNDArray<float> navigator_;
+
+        /// binned kspace
+        /// [RO E1 1ordstCHA output_N_ S]
+        hoNDArray< std::complex<T> > kspace_binning_;
+        /// image domain averaged kspace, [RO E1 1ordstCHA output_N_ S]
+        hoNDArray< std::complex<T> > kspace_binning_image_domain_average_;
+        /// the number of lines falling into the binned kspace
+        /// [E1 output_N_ S]
+        hoNDArray< float > kspace_binning_hit_count_;
     };
 
     template<typename T> 
@@ -133,6 +143,13 @@ namespace Gadgetron {
         // image type
         typedef Gadgetron::hoNDImage<T, 2> ImageType;
         typedef Gadgetron::hoNDImageContainer2D<ImageType> ImageContinerType;
+
+        // image type
+        typedef Gadgetron::hoNDImage< std::complex<T>, 2> ComplexImageType;
+        typedef Gadgetron::hoNDImageContainer2D<ComplexImageType> ComplexImageContinerType;
+
+        // deformation field
+        typedef hoNDImageContainer2D< hoNDImage<float, 2> > DeformationFieldContinerType;
 
         CmrKSpaceBinning();
         virtual ~CmrKSpaceBinning();
@@ -190,7 +207,7 @@ namespace Gadgetron {
         // time tick for every time stamp unit, in ms (e.g. 2.5ms)
         float time_tick_;
 
-        // index of cardiac trigger time in physilogical time stamp
+        // index of cardiac trigger time in the physilogical time stamp array
         size_t trigger_time_index_;
 
         // if a heart beat RR is not in the range of [ (1-arrhythmiaRejectorFactor)*meanRR (1+arrhythmiaRejectorFactor)*meanRR], it will be rejected
@@ -219,9 +236,52 @@ namespace Gadgetron {
         /// parameter for cardiac binning
         // ======================================================================================
 
+        // whether to interpolate heart beat images; if not, interpolate the deformation fields
+        bool kspace_binning_interpolate_heart_beat_images_;
+
+        // acceptance window for respiratory navigator
+        float kspace_binning_navigator_acceptance_window_;
+
+        // regularization strength of binning moco
+        T kspace_binning_moco_reg_strength_;
+
+        // number of iterations for binning moco
+        std::vector<unsigned int> kspace_binning_moco_iters_;
+
+        // max allowed temporal ratio window
+        float kspace_binning_max_temporal_window_;
+
+        // minimal allowed temporal window in ms
+        float kspace_binning_minimal_cardiac_phase_width_;
+
         // ======================================================================================
         /// parameter for recon after binning
         // ======================================================================================
+
+        // kernel size and calibration regularization threshold on the binned kspace
+        int kspace_binning_kSize_RO_;
+        int kspace_binning_kSize_E1_;
+        double kspace_binning_reg_lamda_;
+
+        // maximal number of iterations for linear recon on binned kspace
+        size_t kspace_binning_linear_iter_max_;
+        // threshold to stop iterations for linear recon on binned kspace
+        double kspace_binning_linear_iter_thres_;
+
+        // maximal number of iterations for non-linear recon on binned kspace
+        size_t kspace_binning_nonlinear_iter_max_;
+        // threshold to stop the non-linear iterations
+        double kspace_binning_nonlinear_iter_thres_;
+        // data fidelity term; if 0, null-space constraint is applied
+        double kspace_binning_nonlinear_data_fidelity_lamda_;
+        // image regularization term
+        double kspace_binning_nonlinear_image_reg_lamda_;
+        // regularization weighting ratio along the N dimension
+        double kspace_binning_nonlinear_reg_N_weighting_ratio_;
+        // whether to use coil map in the image regularization term
+        bool kspace_binning_nonlinear_reg_use_coil_sen_map_;
+        // whether to keep approximation coefficients during regularization
+        bool kspace_binning_nonlinear_reg_with_approx_coeff_;
 
         // ======================================================================================
         /// parameter for debugging
@@ -266,11 +326,11 @@ namespace Gadgetron {
         /// reject heart beat with irregular rhythm
         virtual void reject_irregular_heart_beat();
 
-        /// compute RR interval for a heart beat
-        void compute_RRInterval(size_t s, size_t HB, float& RRInterval);
+        /// compute kspace after binning
+        virtual void compute_kspace_binning(const std::vector<size_t>& bestHB);
 
-        /// compute navigator metrics for a heart beat
-        void compute_metrics_navigator_heart_beat(size_t s, size_t HB, float& mean_resp, float& var_resp);
+        /// perform recon on the binned kspace
+        virtual void perform_recon_binned_kspace();
 
         // ======================================================================================
         // implementation functions
@@ -286,5 +346,32 @@ namespace Gadgetron {
                                 hoNDArray<float>& phs_cpt_time_stamp, hoNDArray<float>& phs_cpt_time_ratio, 
                                 hoNDArray<int>& indHeartBeat, HeartBeatIndexType& startingHB, 
                                 HeartBeatIndexType& endingHB, float& meanRRInterval);
+
+        /// compute RR interval for a heart beat
+        void compute_RRInterval(size_t s, size_t HB, float& RRInterval);
+
+        /// compute navigator metrics for a heart beat
+        void compute_metrics_navigator_heart_beat(size_t s, size_t HB, float& mean_resp, float& var_resp, float& min_resp, float& max_resp);
+
+        /// interpolate the best heart beat images to get images at the desired cardiace phase ration
+        void interpolate_best_HB_images(const std::vector<float>& cpt_time_ratio_bestHB, const hoNDArray<T>& mag_bestHB, const std::vector<float>& desired_cpt, hoNDArray<T>& mag_bestHB_at_desired_cpt);
+
+        /// select images using the navigator and cpt time ratio
+        /// selected: store the selected image n indexes
+        void select_images_with_navigator(float desired_cpt_time_ratio, float accepted_nav[2], size_t n, size_t s, std::vector<size_t>& selected);
+
+        /// perform moco between best heart beat images and selected images
+        void perform_moco_selected_images_with_best_heart_beat(const std::vector < std::vector<size_t> >& selected_images, const hoNDArray<T>& mag_s, const hoNDArray<T>& mag_bestHB_at_desired_cpt, DeformationFieldContinerType& dx, DeformationFieldContinerType& dy);
+
+        /// warp complex images using the moco between best heart beat images and selected images
+        void perform_moco_warp_on_selected_images(const std::vector < std::vector<size_t> >& selected_images, const ArrayType& complex_image, DeformationFieldContinerType deform[2], std::vector<ArrayType>& warpped_complex_images);
+
+        /// fill the binned kspace
+        void fill_binned_kspace(size_t s, size_t dst_n, const std::vector<size_t>& selected_images, const ArrayType& warpped_kspace, ArrayType& kspace_filled, hoNDArray<float>& hit_count);
+
+        /// perform linear recon on binning
+        void perform_linear_recon_on_kspace_binning(const ArrayType& underSampledKspace, const ArrayType& kspaceInitial, const ArrayType& coilMap, ArrayType& resKSpace, ArrayType& resIm, ArrayType& kernel, ArrayType& kernelIm);
+        /// perform nonlinear recon for binning
+        void perform_non_linear_recon_on_kspace_binning(const ArrayType& underSampledKspace, const ArrayType& kspaceLinear, const ArrayType& coilMap, const ArrayType& kernel, const ArrayType& kernelIm, ArrayType& resKSpace, ArrayType& resIm);
     };
 }

--- a/toolboxes/cmr/cmr_motion_correction.h
+++ b/toolboxes/cmr/cmr_motion_correction.h
@@ -34,6 +34,9 @@ namespace Gadgetron {
     /// reg_strength : regularization strength in the unit of pixel
     template <typename T> EXPORTCMR void perform_moco_fixed_key_frame_2DT(const Gadgetron::hoNDArray<T>& input, size_t key_frame, 
         T reg_strength, std::vector<unsigned int> iters, bool bidirectional_moco, Gadgetron::hoImageRegContainer2DRegistration<T, float, 2, 2>& reg);
+    /// perform 2D moco on input image container
+    template <typename T> EXPORTCMR void perform_moco_fixed_key_frame_2DT(Gadgetron::hoNDImageContainer2D< hoNDImage<T, 2> >& input, const std::vector<unsigned int>& key_frame, 
+        T reg_strength, std::vector<unsigned int> iters, bool bidirectional_moco, Gadgetron::hoImageRegContainer2DRegistration<T, float, 2, 2>& reg);
 
     /// series a is mocoed to series b
     /// a, b : [RO E1 N]

--- a/toolboxes/cmr/cmr_spirit_recon.cpp
+++ b/toolboxes/cmr/cmr_spirit_recon.cpp
@@ -1,0 +1,368 @@
+/** \file   cmr_spirit_recon.cpp
+    \brief  Implement some functionalities commonly used in cmr applications for spirit recon
+    \author Hui Xue
+*/
+
+#include "cmr_spirit_recon.h"
+
+#include "mri_core_utility.h"
+#include "mri_core_spirit.h"
+#include "hoNDArray_reductions.h"
+#include "hoNDFFT.h"
+#include "hoSPIRIT2DOperator.h"
+#include "hoLsqrSolver.h"
+#include "hoSPIRIT2DTDataFidelityOperator.h"
+#include "hoWavelet2DTOperator.h"
+#include "hoGdSolver.h"
+#include <boost/make_shared.hpp>
+
+namespace Gadgetron { 
+
+    template <typename T> 
+    void perform_spirit_recon_linear_2DT(const Gadgetron::hoNDArray<T>& kspace, const Gadgetron::hoNDArray<T>& kerIm, 
+                                const Gadgetron::hoNDArray<T>& kspaceInitial, Gadgetron::hoNDArray<T>& res, size_t iter_max, double iter_thres, bool print_iter)
+    {
+        try
+        {
+            size_t RO = kspace.get_size(0);
+            size_t E1 = kspace.get_size(1);
+            size_t CHA = kspace.get_size(2);
+            size_t N = kspace.get_size(3);
+            size_t S = kspace.get_size(4);
+
+            size_t ref_N = kerIm.get_size(4);
+            size_t ref_S = kerIm.get_size(5);
+
+            long long num = N*S;
+
+            hoNDArray<T> ker_Shifted(kerIm);
+            Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifftshift2D(kerIm, ker_Shifted);
+
+            hoNDArray<T> kspace_Shifted;
+            kspace_Shifted = kspace;
+            Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifftshift2D(kspace, kspace_Shifted);
+
+            hoNDArray<T> kspace_initial_Shifted;
+            bool hasInitial = false;
+            if ( kspaceInitial.dimensions_equal(&kspace) )
+            {
+                kspace_initial_Shifted = kspaceInitial;
+                Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->ifftshift2D(kspaceInitial, kspace_initial_Shifted);
+                hasInitial = true;
+            }
+
+#ifdef USE_OMP
+            int numThreads = (int)num;
+            if (numThreads > omp_get_num_procs()) numThreads = omp_get_num_procs();
+            GDEBUG_CONDITION_STREAM(print_iter, "numThreads : " << numThreads);
+#endif // USE_OMP
+
+            long long ii;
+
+#pragma omp parallel default(none) private(ii) shared(num, N, S, RO, E1, CHA, ref_N, ref_S, kspace, res, kspace_Shifted, ker_Shifted, kspace_initial_Shifted, hasInitial, iter_max, iter_thres, print_iter) num_threads(numThreads) if(num>1) 
+            {
+                std::vector<size_t> dim(3, 1);
+                dim[0] = RO;
+                dim[1] = E1;
+                dim[2] = CHA;
+
+                boost::shared_ptr< hoSPIRIT2DOperator< T > > oper(new hoSPIRIT2DOperator< T >(&dim));
+                hoSPIRIT2DOperator< T >& spirit = *oper;
+                spirit.use_non_centered_fft_ = true;
+                spirit.no_null_space_ = false;
+
+                if (ref_N == 1 && ref_S == 1)
+                {
+                    boost::shared_ptr<hoNDArray<T> > ker(new hoNDArray< T >(RO, E1, CHA, CHA, ker_Shifted.begin()));
+                    spirit.set_forward_kernel(*ker, false);
+                }
+
+                hoLsqrSolver< T > cgSolver;
+                cgSolver.set_tc_tolerance((float)iter_thres);
+                cgSolver.set_max_iterations( (unsigned int)iter_max);
+                cgSolver.set_output_mode(print_iter ? hoLsqrSolver< T >::OUTPUT_VERBOSE : hoLsqrSolver< T >::OUTPUT_SILENT);
+                cgSolver.set_encoding_operator(oper);
+
+                hoNDArray< T > b(RO, E1, CHA);
+                hoNDArray< T > unwarppedKSpace(RO, E1, CHA);
+
+#pragma omp for 
+                for (ii = 0; ii < num; ii++)
+                {
+                    size_t s = ii / N;
+                    size_t n = ii - s*N;
+
+                    // check whether the kspace is undersampled
+                    bool undersampled = false;
+                    for (size_t e1 = 0; e1 < E1; e1++)
+                    {
+                        if ((std::abs(kspace(RO / 2, e1, CHA - 1, n, s)) == 0)
+                            && (std::abs(kspace(RO / 2, e1, 0, n, s)) == 0))
+                        {
+                            undersampled = true;
+                            break;
+                        }
+                    }
+
+                    T* pKpaceShifted = &(kspace_Shifted(0, 0, 0, n, s));
+                    T* pRes = &(res(0, 0, 0, n, s));
+
+                    if (!undersampled)
+                    {
+                        memcpy(pRes, pKpaceShifted, sizeof(T)*RO*E1*CHA);
+                        continue;
+                    }
+
+                    long long kernelN = n;
+                    if (kernelN >= (long long)ref_N) kernelN = (long long)ref_N - 1;
+
+                    long long kernelS = s;
+                    if (kernelS >= (long long)ref_S) kernelS = (long long)ref_S - 1;
+
+                    boost::shared_ptr< hoNDArray< T > > acq(new hoNDArray< T >(RO, E1, CHA, pKpaceShifted));
+                    spirit.set_acquired_points(*acq);
+
+                    boost::shared_ptr< hoNDArray<T> > initialAcq;
+                    if ( hasInitial )
+                    {
+                        initialAcq = boost::shared_ptr< hoNDArray<T> >(new hoNDArray<T>(RO, E1, CHA, &kspace_initial_Shifted(0, 0, 0, n, s)));
+                        cgSolver.set_x0(initialAcq);
+                    }
+                    else
+                    {
+                        cgSolver.set_x0(acq);
+                    }
+
+                    if (ref_N == 1 && ref_S == 1)
+                    {
+                        spirit.compute_righ_hand_side(*acq, b);
+                        cgSolver.solve(&unwarppedKSpace, &b);
+                    }
+                    else
+                    {
+                        T* pKer = &(ker_Shifted(0, 0, 0, kernelN, kernelS));
+                        boost::shared_ptr<hoNDArray< T > > ker(new hoNDArray< T >(RO, E1, CHA, CHA, pKer));
+                        spirit.set_forward_kernel(*ker, false);
+
+                        spirit.compute_righ_hand_side(*acq, b);
+                        cgSolver.solve(&unwarppedKSpace, &b);
+                    }
+
+                    // restore the acquired points
+                    spirit.restore_acquired_kspace(*acq, unwarppedKSpace);
+                    memcpy(pRes, unwarppedKSpace.begin(), unwarppedKSpace.get_number_of_bytes());
+                }
+            }
+
+            Gadgetron::hoNDFFT<typename realType<T>::Type>::instance()->fftshift2D(res, kspace_Shifted);
+            res = kspace_Shifted;
+        }
+        catch(...)
+        {
+            GADGET_THROW("Exceptions happened in perform_spirit_recon_linear_2DT(...) ... ");
+        }
+    }
+
+    template EXPORTCMR void perform_spirit_recon_linear_2DT(const Gadgetron::hoNDArray< std::complex<float> >& kspace, const Gadgetron::hoNDArray< std::complex<float> >& kerIm, const Gadgetron::hoNDArray< std::complex<float> >& kspaceInitial, Gadgetron::hoNDArray< std::complex<float> >& res, size_t iter_max, double iter_thres, bool print_iter);
+    template EXPORTCMR void perform_spirit_recon_linear_2DT(const Gadgetron::hoNDArray< std::complex<double> >& kspace, const Gadgetron::hoNDArray< std::complex<double> >& kerIm, const Gadgetron::hoNDArray< std::complex<double> >& kspaceInitial, Gadgetron::hoNDArray< std::complex<double> >& res, size_t iter_max, double iter_thres, bool print_iter);
+
+    // ---------------------------------------------------------------------
+
+    template <typename T> 
+    class sCB : public hoGdSolverCallBack< hoNDArray< T >, hoWavelet2DTOperator< T > >
+    {
+    public:
+        typedef hoGdSolverCallBack< hoNDArray<T>, hoWavelet2DTOperator<T> > BaseClass;
+
+        sCB() : BaseClass() {}
+        virtual ~sCB() {}
+
+        void execute(const hoNDArray<T>& b, hoNDArray<T>& x)
+        {
+            typedef hoSPIRIT2DTDataFidelityOperator<T> SpiritOperType;
+            SpiritOperType* pOper = dynamic_cast<SpiritOperType*> (this->solver_->oper_system_);
+            pOper->restore_acquired_kspace(x);
+        }
+    };
+
+    template <typename T> 
+    void perform_spirit_recon_non_linear_2DT(const Gadgetron::hoNDArray<T>& kspace, const Gadgetron::hoNDArray<T>& kerIm, 
+                                            const Gadgetron::hoNDArray<T>& coil_map, const Gadgetron::hoNDArray<T>& kspaceLinear, Gadgetron::hoNDArray<T>& res, 
+                                            size_t iter_max, double iter_thres, double data_fidelity_lamda, double image_reg_lamda, double reg_N_weighting_ratio, 
+                                            bool reg_use_coil_sen_map, bool reg_with_approx_coeff, bool print_iter)
+    {
+        size_t RO = kspace.get_size(0);
+        size_t E1 = kspace.get_size(1);
+        size_t CHA = kspace.get_size(2);
+        size_t N = kspace.get_size(3);
+        size_t S = kspace.get_size(4);
+
+        size_t ref_N = kerIm.get_size(4);
+        size_t ref_S = kerIm.get_size(5);
+
+        res = kspace;
+
+        size_t s;
+
+        for (s=0; s<S; s++)
+        {
+            boost::shared_ptr< hoNDArray< T > > coilMap;
+
+            bool hasCoilMap = false;
+            if (coil_map.get_size(0) == RO && coil_map.get_size(1) == E1 && coil_map.get_size(2)==CHA)
+            {
+                if (ref_N < N)
+                {
+                    coilMap = boost::shared_ptr< hoNDArray< T > >(new hoNDArray< T >(RO, E1, CHA, const_cast<T*>(coil_map.begin()) ));
+                }
+                else
+                {
+                    coilMap = boost::shared_ptr< hoNDArray< T > >(new hoNDArray< T >(RO, E1, CHA, ref_N, const_cast<T*>(coil_map.begin()) ));
+                }
+
+                hasCoilMap = true;
+            }
+
+            size_t s_used = s;
+            if(s_used>=ref_S) s_used = ref_S;
+
+            boost::shared_ptr<hoNDArray< T > > ker(new hoNDArray< T >(RO, E1, CHA, CHA, ref_N, const_cast<T*>(kerIm.begin())+s_used*RO*E1*CHA*CHA*ref_N) );
+            boost::shared_ptr<hoNDArray< T > > acq(new hoNDArray< T >(RO, E1, CHA, N, const_cast<T*>(kspace.begin())+s*RO*E1*CHA*N) );
+            hoNDArray< T > kspaceInitial(RO, E1, CHA, N, const_cast<T*>(kspaceLinear.begin())+s*RO*E1*CHA*N );
+            hoNDArray< T > res2DT(RO, E1, CHA, N, res.begin()+s*RO*E1*CHA*N );
+
+            if (data_fidelity_lamda > 0)
+            {
+                GDEBUG_STREAM("Start the NonLinear SPIRIT data fidelity iteration - regularization strength : "
+                    << image_reg_lamda
+                    << " - number of iteration : "                      << iter_max
+                    << " - proximity across cha : "                     << false
+                    << " - redundant dimension weighting ratio : "      << reg_N_weighting_ratio
+                    << " - using coil sen map : "                       << reg_use_coil_sen_map
+                    << " - with approx coeff : "                        << reg_with_approx_coeff
+                    << " - iter thres : "                               << iter_thres);
+
+                typedef hoGdSolver< hoNDArray< T >, hoWavelet2DTOperator< T > > SolverType;
+                SolverType solver;
+                solver.iterations_ = iter_max;
+                solver.set_output_mode(print_iter ? SolverType::OUTPUT_VERBOSE : SolverType::OUTPUT_SILENT);
+                solver.grad_thres_ = iter_thres;
+                solver.proximal_strength_ratio_ = image_reg_lamda;
+
+                boost::shared_ptr< hoNDArray< T > > x0 = boost::make_shared< hoNDArray< T > >(kspaceInitial);
+                solver.set_x0(x0);
+
+                // parallel imaging term
+                std::vector<size_t> dims;
+                acq->get_dimensions(dims);
+                hoSPIRIT2DTDataFidelityOperator< T > spirit(&dims);
+                spirit.set_forward_kernel(*ker, false);
+                spirit.set_acquired_points(*acq);
+
+                // image reg term
+                hoWavelet2DTOperator< T > wav3DOperator(&dims);
+                wav3DOperator.set_acquired_points(*acq);
+                wav3DOperator.scale_factor_first_dimension_ = 1;
+                wav3DOperator.scale_factor_second_dimension_ = 1;
+                wav3DOperator.scale_factor_third_dimension_ = reg_N_weighting_ratio;
+                wav3DOperator.with_approx_coeff_ = reg_with_approx_coeff;
+                wav3DOperator.change_coeffcients_third_dimension_boundary_ = true;
+                wav3DOperator.proximity_across_cha_ = false;
+                wav3DOperator.no_null_space_ = true;
+                wav3DOperator.input_in_kspace_ = true;
+
+                if (reg_use_coil_sen_map && hasCoilMap)
+                {
+                    wav3DOperator.coil_map_ = *coilMap;
+                }
+
+                // set operators
+
+                solver.oper_system_ = &spirit;
+                solver.oper_reg_ = &wav3DOperator;
+
+                solver.solve(*acq, res2DT);
+            }
+            else
+            {
+                GDEBUG_STREAM("Start the NonLinear SPIRIT iteration with regularization strength : "
+                    << image_reg_lamda
+                    << " - number of iteration : " << iter_max
+                    << " - proximity across cha : " << false
+                    << " - redundant dimension weighting ratio : " << reg_N_weighting_ratio
+                    << " - using coil sen map : " << reg_use_coil_sen_map
+                    << " - with approx coeff : "  << reg_with_approx_coeff
+                    << " - iter thres : " << iter_thres);
+
+                typedef hoGdSolver< hoNDArray< T >, hoWavelet2DTOperator< T > > SolverType;
+                SolverType solver;
+                solver.iterations_ = iter_max;
+                solver.set_output_mode(print_iter ? SolverType::OUTPUT_VERBOSE : SolverType::OUTPUT_SILENT);
+                solver.grad_thres_ = iter_thres;
+                solver.proximal_strength_ratio_ = image_reg_lamda;
+
+                boost::shared_ptr< hoNDArray< T > > x0 = boost::make_shared< hoNDArray< T > >(kspaceInitial);
+                solver.set_x0(x0);
+
+                // parallel imaging term
+                std::vector<size_t> dims;
+                acq->get_dimensions(dims);
+
+                hoSPIRIT2DTOperator< T > spirit(&dims);
+                spirit.set_forward_kernel(*ker, false);
+                spirit.set_acquired_points(*acq);
+                spirit.no_null_space_ = true;
+                spirit.use_non_centered_fft_ = false;
+
+                // image reg term
+                std::vector<size_t> dim;
+                acq->get_dimensions(dim);
+
+                hoWavelet2DTOperator< T > wav3DOperator(&dim);
+                wav3DOperator.set_acquired_points(*acq);
+                wav3DOperator.scale_factor_first_dimension_ = 1;
+                wav3DOperator.scale_factor_second_dimension_ = 1;
+                wav3DOperator.scale_factor_third_dimension_ = reg_N_weighting_ratio;
+                wav3DOperator.with_approx_coeff_ = reg_with_approx_coeff;
+                wav3DOperator.change_coeffcients_third_dimension_boundary_ = true;
+                wav3DOperator.proximity_across_cha_ = false;
+                wav3DOperator.no_null_space_ = true;
+                wav3DOperator.input_in_kspace_ = true;
+
+                if (reg_use_coil_sen_map && hasCoilMap)
+                {
+                    wav3DOperator.coil_map_ = *coilMap;
+                }
+
+                // set operators
+                solver.oper_system_ = &spirit;
+                solver.oper_reg_ = &wav3DOperator;
+
+                // set call back
+                sCB<T> cb;
+                cb.solver_ = &solver;
+                solver.call_back_ = &cb;
+
+                hoNDArray< T > b(kspaceInitial);
+                Gadgetron::clear(b);
+
+                solver.solve(b, res2DT);
+                // if (!debug_folder_full_path_.empty()) gt_exporter_.export_array_complex(res2DT, debug_folder_full_path_ + "spirit_nl_2DT_res");
+
+                spirit.restore_acquired_kspace(*acq, res2DT);
+
+                // if (!debug_folder_full_path_.empty()) gt_exporter_.export_array_complex(res2DT, debug_folder_full_path_ + "spirit_nl_2DT_res_restored");
+            }
+        }
+    }
+
+    template EXPORTCMR void perform_spirit_recon_non_linear_2DT(const Gadgetron::hoNDArray< std::complex<float> >& kspace, const Gadgetron::hoNDArray< std::complex<float> >& kerIm, 
+        const Gadgetron::hoNDArray< std::complex<float> >& coilMap, const Gadgetron::hoNDArray< std::complex<float> >& kspaceInitial, Gadgetron::hoNDArray< std::complex<float> >& res, 
+        size_t iter_max, double iter_thres, double data_fidelity_lamda, double image_reg_lamda, double reg_N_weighting_ratio, 
+        bool reg_use_coil_sen_map, bool reg_with_approx_coeff, bool print_iter);
+
+    template EXPORTCMR void perform_spirit_recon_non_linear_2DT(const Gadgetron::hoNDArray< std::complex<double> >& kspace, const Gadgetron::hoNDArray< std::complex<double> >& kerIm, 
+        const Gadgetron::hoNDArray< std::complex<double> >& coilMap, const Gadgetron::hoNDArray< std::complex<double> >& kspaceInitial, Gadgetron::hoNDArray< std::complex<double> >& res, 
+        size_t iter_max, double iter_thres, double data_fidelity_lamda, double image_reg_lamda, double reg_N_weighting_ratio, 
+        bool reg_use_coil_sen_map, bool reg_with_approx_coeff, bool print_iter);
+}

--- a/toolboxes/cmr/cmr_spirit_recon.h
+++ b/toolboxes/cmr/cmr_spirit_recon.h
@@ -1,0 +1,29 @@
+/** \file   cmr_spirit_recon.h
+    \brief  Implement some functionalities commonly used in cmr applications for spirit recon
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include "cmr_export.h"
+#include "hoNDArray.h"
+
+namespace Gadgetron { 
+
+    /// perform spirit linear 2DT recon
+    /// kspace: input kspace [RO E1 CHA N S]
+    /// kerIm: kspace kernel image domain [RO E1 CHA CHA 1orN 1orS]
+    /// kspaceInitial: initial guess for the solution; if empty, zero initialization will be used
+    /// res: recon results
+    /// iter_max: maximal number of iterations
+    /// iter_thres: iteration stop threshold
+    /// print_iter: whether to print iteration information
+    template <typename T> EXPORTCMR void perform_spirit_recon_linear_2DT(const Gadgetron::hoNDArray<T>& kspace, const Gadgetron::hoNDArray<T>& kerIm, const Gadgetron::hoNDArray<T>& kspaceInitial, Gadgetron::hoNDArray<T>& res, size_t iter_max=90, double iter_thres=0.0015, bool print_iter=false);
+
+    /// perform spirit nonlinear 2DT recon
+    /// kspace: [RO E1 CHA N S]
+    /// kerIm: kspace kernel image domain [RO E1 CHA CHA 1orN 1orS]
+    /// coilMap: [RO E1 CHA 1orN 1orS]
+    template <typename T> EXPORTCMR void perform_spirit_recon_non_linear_2DT(const Gadgetron::hoNDArray<T>& kspace, const Gadgetron::hoNDArray<T>& kerIm, const Gadgetron::hoNDArray<T>& coilMap, const Gadgetron::hoNDArray<T>& kspaceInitial, Gadgetron::hoNDArray<T>& res, 
+        size_t iter_max=15, double iter_thres=0.004, double data_fidelity_lamda=1.0, double image_reg_lamda=0.0005, double reg_N_weighting_ratio=10.0, bool reg_use_coil_sen_map=false, bool reg_with_approx_coeff=false, bool print_iter=false);
+}


### PR DESCRIPTION
a) Complete the first version of kspace binning
b) The schemes of interpolating deformation field and solving moco recon equation are not implemented; but places are left to add them later
c) Add a cmr_spirit_recon.h/.cpp, implementing some functionalities commonly used in cmr applications for spirit recon

Next step is to build gadget.