### PR TITLE
Extend ho nd image

### DIFF
--- a/toolboxes/core/cpu/image/hoNDImage.h
+++ b/toolboxes/core/cpu/image/hoNDImage.h
@@ -14,6 +14,7 @@
 
 #include "hoNDPoint.h"
 #include "hoMatrix.h"
+#include "ismrmrd/ismrmrd.h"
 #include "ismrmrd/meta.h"
 
 namespace Gadgetron
@@ -474,6 +475,9 @@ namespace Gadgetron
 
         /// get the sub image
         void get_sub_image(const std::vector<size_t>& start, std::vector<size_t>& size, Self& out);
+
+        /// ismrmrd image header structure
+        ISMRMRD::ISMRMRD_ImageHeader header_;
 
         /// meta attributes
         ISMRMRD::MetaContainer attrib_;

--- a/toolboxes/core/cpu/image/hoNDImage.h
+++ b/toolboxes/core/cpu/image/hoNDImage.h
@@ -124,6 +124,7 @@ namespace Gadgetron
 
             this->create(dim, pixelSize, origin, axis);
 
+            this->header_ = im.header_;
             this->attrib_ = im.attrib_;
         }
 
@@ -170,6 +171,7 @@ namespace Gadgetron
             this->set_origin(origin);
             this->set_axis(axis);
 
+            this->header_ = im.header_;
             this->attrib_ = im.attrib_;
         }
 

--- a/toolboxes/core/cpu/image/hoNDImage.hxx
+++ b/toolboxes/core/cpu/image/hoNDImage.hxx
@@ -30,6 +30,8 @@ namespace Gadgetron
         image_orientation_patient_[0][0] = 1; image_orientation_patient_[0][1] = 0; image_orientation_patient_[0][2] = 0;
         image_orientation_patient_[1][0] = 0; image_orientation_patient_[1][1] = 1; image_orientation_patient_[1][2] = 0;
         image_orientation_patient_[2][0] = 0; image_orientation_patient_[2][1] = 0; image_orientation_patient_[2][2] = 1;
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 
@@ -331,6 +333,7 @@ namespace Gadgetron
         this->image_orientation_patient_[1] = rhs.image_orientation_patient_[1];
         this->image_orientation_patient_[2] = rhs.image_orientation_patient_[2];
 
+        this->header_ = rhs.header_;
         this->attrib_ = rhs.attrib_;
 
         return *this;
@@ -378,6 +381,7 @@ namespace Gadgetron
         image_orientation_patient_[1][0] = 0; image_orientation_patient_[1][1] = 1; image_orientation_patient_[1][2] = 0;
         image_orientation_patient_[2][0] = 0; image_orientation_patient_[2][1] = 0; image_orientation_patient_[2][2] = 1;
 
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
         this->attrib_ = ISMRMRD::MetaContainer();
     }
 
@@ -418,6 +422,8 @@ namespace Gadgetron
         image_orientation_patient_[0][0] = 1; image_orientation_patient_[0][1] = 0; image_orientation_patient_[0][2] = 0;
         image_orientation_patient_[1][0] = 0; image_orientation_patient_[1][1] = 1; image_orientation_patient_[1][2] = 0;
         image_orientation_patient_[2][0] = 0; image_orientation_patient_[2][1] = 0; image_orientation_patient_[2][2] = 1;
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 
@@ -463,6 +469,8 @@ namespace Gadgetron
         image_orientation_patient_[0][0] = 1; image_orientation_patient_[0][1] = 0; image_orientation_patient_[0][2] = 0;
         image_orientation_patient_[1][0] = 0; image_orientation_patient_[1][1] = 1; image_orientation_patient_[1][2] = 0;
         image_orientation_patient_[2][0] = 0; image_orientation_patient_[2][1] = 0; image_orientation_patient_[2][2] = 1;
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 
@@ -576,6 +584,8 @@ namespace Gadgetron
             image_orientation_patient_[1][0] = axis[1][0]; image_orientation_patient_[1][1] = axis[1][1]; image_orientation_patient_[1][2] = axis[1][2];
             image_orientation_patient_[2][0] = axis[2][0]; image_orientation_patient_[2][1] = axis[2][1]; image_orientation_patient_[2][2] = axis[2][2];
         }
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 
@@ -627,6 +637,8 @@ namespace Gadgetron
         image_orientation_patient_[0][0] = 1; image_orientation_patient_[0][1] = 0; image_orientation_patient_[0][2] = 0;
         image_orientation_patient_[1][0] = 0; image_orientation_patient_[1][1] = 1; image_orientation_patient_[1][2] = 0;
         image_orientation_patient_[2][0] = 0; image_orientation_patient_[2][1] = 0; image_orientation_patient_[2][2] = 1;
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 
@@ -678,6 +690,8 @@ namespace Gadgetron
         image_orientation_patient_[0][0] = 1; image_orientation_patient_[0][1] = 0; image_orientation_patient_[0][2] = 0;
         image_orientation_patient_[1][0] = 0; image_orientation_patient_[1][1] = 1; image_orientation_patient_[1][2] = 0;
         image_orientation_patient_[2][0] = 0; image_orientation_patient_[2][1] = 0; image_orientation_patient_[2][2] = 1;
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 
@@ -745,6 +759,8 @@ namespace Gadgetron
         image_orientation_patient_[0][0] = 1; image_orientation_patient_[0][1] = 0; image_orientation_patient_[0][2] = 0;
         image_orientation_patient_[1][0] = 0; image_orientation_patient_[1][1] = 1; image_orientation_patient_[1][2] = 0;
         image_orientation_patient_[2][0] = 0; image_orientation_patient_[2][1] = 0; image_orientation_patient_[2][2] = 1;
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 
@@ -815,6 +831,8 @@ namespace Gadgetron
             image_orientation_patient_[1][0] = axis[1][0]; image_orientation_patient_[1][1] = axis[1][1]; image_orientation_patient_[1][2] = axis[1][2];
             image_orientation_patient_[2][0] = axis[2][0]; image_orientation_patient_[2][1] = axis[2][1]; image_orientation_patient_[2][2] = axis[2][2];
         }
+
+        memset(&this->header_, 0, sizeof(ISMRMRD::ISMRMRD_ImageHeader));
     }
 
     template <typename T, unsigned int D> 


### PR DESCRIPTION
attach ismrmrd header to hoNDImage, so hoNDImage will carry all necessary information about ismrmrd image between the processing steps