### PR TITLE
use connection to send jobs to local node for distribute gadget; fix …

### DIFF
--- a/apps/gadgetron/Gadget.h
+++ b/apps/gadgetron/Gadget.h
@@ -616,6 +616,8 @@ namespace Gadgetron{
           pass_on_undesired_data_ = pass_on_undesired_data.value();
         }
 
+        virtual ~BasicPropertyGadget() {}
+
       protected:
         GADGET_PROPERTY(using_cloudbus,bool,"Indicates whether the cloudbus is in use and available", false);
         GADGET_PROPERTY(pass_on_undesired_data,bool, "If true, data not matching the process function will be passed to next Gadget", false);

--- a/gadgets/cmr/config/BinningCine/CMR_2DT_RTCine_KspaceBinning_Cloud.xml
+++ b/gadgets/cmr/config/BinningCine/CMR_2DT_RTCine_KspaceBinning_Cloud.xml
@@ -39,7 +39,7 @@
       <dll>gadgetron_distributed</dll>
       <classname>IsmrmrdAcquisitionDistributeGadget</classname>
       <property><name>parallel_dimension</name><value>slice</value></property>
-      <property><name>use_this_node_for_compute</name><value>true</value></property>
+      <property><name>use_this_node_for_compute</name><value>false</value></property>
     </gadget>
 
     <!-- Data accumulation and trigger gadget -->

--- a/gadgets/distributed/CollectGadget.cpp
+++ b/gadgets/distributed/CollectGadget.cpp
@@ -17,6 +17,14 @@ namespace Gadgetron{
     }
   }
 
+  CollectGadget::CollectGadget()
+  {
+  }
+
+  CollectGadget::~CollectGadget()
+  {
+  }
+
   int CollectGadget::process(ACE_Message_Block* m)
   {
     if (pass_through_mode.value()) {

--- a/gadgets/distributed/CollectGadget.h
+++ b/gadgets/distributed/CollectGadget.h
@@ -11,7 +11,10 @@ namespace Gadgetron{
   class EXPORTDISTRIBUTEDGADGETS CollectGadget : public BasicPropertyGadget
   {
   public:
-    GADGET_DECLARE(DistributeGadget);
+    GADGET_DECLARE(CollectGadget);
+
+    CollectGadget();
+    virtual ~CollectGadget();
 
   protected:
     GADGET_PROPERTY(pass_through_mode, bool,
@@ -20,4 +23,4 @@ namespace Gadgetron{
     virtual int message_id(ACE_Message_Block* m);
   };
 }
-#endif //DISTRIBUTEGADGET_H
+#endif //COLLECTGADGET_H

--- a/gadgets/distributed/DistributeGadget.h
+++ b/gadgets/distributed/DistributeGadget.h
@@ -72,6 +72,7 @@ namespace Gadgetron{
     std::map<int,GadgetronConnector*> node_map_;
     std::vector<GadgetronConnector*> closed_connectors_;
     GadgetronConnector* prev_connector_; //Keeps track of previously used connector
+    std::vector<std::string> local_address_;
 
   };
 }

--- a/gadgets/distributed/IsmrmrdAcquisitionDistributeGadget.h
+++ b/gadgets/distributed/IsmrmrdAcquisitionDistributeGadget.h
@@ -14,6 +14,8 @@ namespace Gadgetron{
   {
   public:
     GADGET_DECLARE(IsmrmrdAcquisitionDistributeGadget);
+    IsmrmrdAcquisitionDistributeGadget() {}
+    virtual ~IsmrmrdAcquisitionDistributeGadget() {}
 
   protected:
     GADGET_PROPERTY_LIMITS(parallel_dimension, std::string,
@@ -43,4 +45,4 @@ namespace Gadgetron{
 
     };
   }
-  #endif //DISTRIBUTEGADGET_H
+#endif //ISMRMRDACQUISITIONDISTRIBUTEGADGET_H

--- a/gadgets/distributed/IsmrmrdImageDistributeGadget.h
+++ b/gadgets/distributed/IsmrmrdImageDistributeGadget.h
@@ -14,6 +14,8 @@ namespace Gadgetron{
   {
   public:
     GADGET_DECLARE(IsmrmrdImageDistributeGadget);
+    IsmrmrdImageDistributeGadget() {}
+    virtual ~IsmrmrdImageDistributeGadget() {}
 
   protected:
     GADGET_PROPERTY_LIMITS(parallel_dimension, std::string,
@@ -30,4 +32,4 @@ namespace Gadgetron{
     virtual int message_id(ACE_Message_Block* m);
   };
 }
-#endif //DISTRIBUTEGADGET_H
+#endif //ISMRMRDIMAGEDISTRIBUTEGADGET_H

--- a/gadgets/mri_core/Generic_Cartesian_NonLinear_Spirit_RealTimeCine_Cloud.xml
+++ b/gadgets/mri_core/Generic_Cartesian_NonLinear_Spirit_RealTimeCine_Cloud.xml
@@ -39,7 +39,7 @@
       <dll>gadgetron_distributed</dll>
       <classname>IsmrmrdAcquisitionDistributeGadget</classname>
       <property><name>parallel_dimension</name><value>slice</value></property>
-      <property><name>use_this_node_for_compute</name><value>true</value></property>
+      <property><name>use_this_node_for_compute</name><value>false</value></property>
     </gadget>
 
     <!-- Data accumulation and trigger gadget -->


### PR DESCRIPTION
…a few problems; set default behavior in binning and NL cine to not use local node

a) Change Distribute gadget, so if use_this_node_for_compute is true, the first incoming job is sent to current job with a new connection made

This functionality is implemented by first finding the ip address of current node. Then if use_this_node_for_compute==true, the first incoming job is sent to current node.

b) fix a few places in CollectGadget.h and DistributeGadget.h

c) change binning and NL RT cine cloud xml to disable use_this_node_for_compute