### PR TITLE
add study date in chroot/siemens_to_ismrmrd.sh.in and use study date …

### DIFF
--- a/chroot/siemens_to_ismrmrd.sh.in
+++ b/chroot/siemens_to_ismrmrd.sh.in
@@ -5,8 +5,9 @@ if [ $# -eq 3 ]; then
     DAT_FILENAME=${1}
     ISMRMRD_FILENAME=${2}
     SCAN_NO=${3}
+    DATE=`date +%Y-%m-%d`
 
-    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:@CMAKE_INSTALL_PREFIX@/bin LD_LIBRARY_PATH=@CMAKE_INSTALL_PREFIX@/lib:/usr/local/lib:/opt/intel/mkl/lib/intel64:/opt/intel/lib/intel64 /usr/local/bin/siemens_to_ismrmrd -f $DAT_FILENAME -o $ISMRMRD_FILENAME -z $SCAN_NO
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:@CMAKE_INSTALL_PREFIX@/bin LD_LIBRARY_PATH=@CMAKE_INSTALL_PREFIX@/lib:/usr/local/lib:/opt/intel/mkl/lib/intel64:/opt/intel/lib/intel64 /usr/local/bin/siemens_to_ismrmrd -f $DAT_FILENAME -o $ISMRMRD_FILENAME -z $SCAN_NO --studyDate $DATE
     exit $?
 else
     echo -e "\nUsage: $0 <dat filename> <ismrmrd filename> <scan number>\n"

--- a/gadgets/mri_core/default_measurement_dependencies_ismrmrd_storage.xml
+++ b/gadgets/mri_core/default_measurement_dependencies_ismrmrd_storage.xml
@@ -18,6 +18,7 @@
         <property><name>folder</name><value>/tmp/gadgetron_data</value></property>
         <property><name>append_id</name><value>true</value></property>
         <property><name>append_timestamp</name><value>true</value></property>
+        <property><name>use_data_timestamp</name><value>true</value></property>
     </gadget>
 
     <!-- SNR unit noise adjust gadget -->


### PR DESCRIPTION
…and time if avaiable to create IsmrmrdDumpGadget dump file name

a) Update chroot/siemens_to_ismrmrd.sh.in to use --studyDate option

b) Update gadgets/mri_core/IsmrmrdDumpGadget.cpp to use study date and/or study time for dump file name if available; otherwise, local time will be used

c) gadgets/mri_core/default_measurement_dependencies_ismrmrd_storage.xml, set use_data_timestamp=true
