### PR TITLE
Added ZFP to Ubuntu 14.04 configurations. Also added Ubuntu 16.04 con…

### DIFF
--- a/docker/base/ubuntu_1604/Dockerfile
+++ b/docker/base/ubuntu_1604/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:16.04
+
+RUN apt-get update --quiet && \
+    apt-get install --no-install-recommends --no-install-suggests --yes  \
+    wget build-essential emacs python-pip libhdf5-serial-dev cmake git-core \
+    libboost-all-dev libfftw3-dev h5utils jq \
+    hdf5-tools liblapack-dev libxml2-dev libfreetype6-dev pkg-config \
+    libxslt-dev libarmadillo-dev libace-dev gcc-multilib  \
+    libgtest-dev liblapack-dev libatlas-base-dev libatlas-dev libplplot-dev libdcmtk-dev \
+    supervisor cython python-numpy python-h5py python-psutil python-twisted python-twisted-web python-twisted-mail \
+    python-lxml python-matplotlib python-setuptools python-pyxb
+
+#OpenBLAS with OpenMP
+RUN cd /opt && \
+    mkdir debsource && \
+    cd debsource && \
+    apt-get --no-install-recommends --no-install-suggests --yes build-dep libopenblas-base && \
+    apt-get install --no-install-recommends --no-install-suggests --yes build-essential fakeroot devscripts && \
+    apt-get source libopenblas-base && \
+    cd openblas-0.2.18/ && \
+    sed -i "s/NO_WARMUP=1/NO_WARMUP=1 OPENMP=1/g" debian/rules && \
+    debchange -i "Compiling with OpenMP support" && \
+    debuild -us -uc -i -I && \
+    debi && \
+    update-alternatives --set libblas.so.3 /usr/lib/openblas-base/libblas.so.3 && \
+    cd /opt && \
+    rm -rf debsource
+
+#ZFP
+RUN cd /opt && \
+    git clone https://github.com/hansenms/ZFP.git && \
+    cd ZFP && \
+    mkdir lib && \
+    make && \
+    make shared && \
+    make install
+
+#Set more environment variables in preparation for Gadgetron installation
+ENV GADGETRON_HOME=/usr/local \
+    ISMRMRD_HOME=/usr/local
+
+ENV PATH=$PATH:$GADGETRON_HOME/bin:$ISMRMRD_HOME/bin \
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ISMRMRD_HOME/lib:$GADGETRON_HOME/lib
+
+# Clean up packages.
+RUN  apt-get clean && \
+   rm -rf /var/lib/apt/lists/*
+

--- a/docker/base/ubuntu_1604_cuda55/Dockerfile
+++ b/docker/base/ubuntu_1604_cuda55/Dockerfile
@@ -1,0 +1,38 @@
+FROM gadgetron/ubuntu1604_base
+
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+#UNPACK THE CUDA INSTALLER
+ENV CUDA_DOWNLOAD_PATH http://developer.download.nvidia.com/compute/cuda/5_5/rel/installers 
+ENV CUDA_RUN cuda_5.5.22_linux_64.run
+ENV CUDA_INSTALL cuda-linux64-rel-5.5.22-16488124.run
+ENV CUDA_VERSION 5.5
+
+RUN cd /opt && \
+  wget ${CUDA_DOWNLOAD_PATH}/${CUDA_RUN} --no-verbose && \
+  chmod +x *.run && \
+  mkdir nvidia_installers && \
+  ./${CUDA_RUN} -silent -extract=`pwd`/nvidia_installers && \
+  rm ${CUDA_RUN}
+
+#INSTALL CUDA LIBRARIES, etc. 
+RUN cd /opt/nvidia_installers && \
+    ./${CUDA_INSTALL} -silent -noprompt && \
+    cd ../ && \
+    rm -rf nvidia_installers
+
+#SET SOME ENV variables for CUDA
+LABEL com.nvidia.cuda.version="5.5"
+RUN echo "/usr/local/cuda/lib" >> /etc/ld.so.conf.d/cuda.conf && \
+    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/cuda.conf && \
+    ldconfig
+
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
+# Clean up packages.
+RUN  apt-get clean && \
+   rm -rf /var/lib/apt/lists/*

--- a/docker/base/ubuntu_1604_cuda75/Dockerfile
+++ b/docker/base/ubuntu_1604_cuda75/Dockerfile
@@ -1,0 +1,38 @@
+FROM gadgetron/ubuntu1604_base
+
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
+#UNPACK THE CUDA INSTALLER
+ENV CUDA_DOWNLOAD_PATH http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers
+ENV CUDA_RUN cuda_7.5.18_linux.run
+ENV CUDA_INSTALL cuda-linux64-rel-7.5.18-19867135.run
+ENV CUDA_VERSION 7.5
+
+RUN cd /opt && \
+  wget ${CUDA_DOWNLOAD_PATH}/${CUDA_RUN} --no-verbose && \
+  chmod +x *.run && \
+  mkdir nvidia_installers && \
+  ./${CUDA_RUN} -silent -extract=`pwd`/nvidia_installers && \
+  rm ${CUDA_RUN}
+
+#INSTALL CUDA LIBRARIES, etc. 
+RUN cd /opt/nvidia_installers && \
+    ./${CUDA_INSTALL} -silent -noprompt && \
+    cd ../ && \
+    rm -rf nvidia_installers
+
+#SET SOME ENV variables for CUDA
+LABEL com.nvidia.cuda.version="7.5"
+RUN echo "/usr/local/cuda/lib" >> /etc/ld.so.conf.d/cuda.conf && \
+    echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/cuda.conf && \
+    ldconfig
+
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
+# Clean up packages.
+RUN  apt-get clean && \
+   rm -rf /var/lib/apt/lists/*

--- a/docker/incremental/ubuntu_1404_cuda55/Dockerfile
+++ b/docker/incremental/ubuntu_1404_cuda55/Dockerfile
@@ -1,5 +1,14 @@
 FROM gadgetron/ubuntu1404_cuda55_base
 
+#ZFP
+RUN cd /opt && \
+    git clone https://github.com/hansenms/ZFP.git && \
+    cd ZFP && \
+    mkdir lib && \
+    make && \
+    make shared && \
+    make install
+
 #ISMRMRD
 RUN mkdir /opt/code
 RUN cd /opt/code && \

--- a/docker/incremental/ubuntu_1404_cuda75/Dockerfile
+++ b/docker/incremental/ubuntu_1404_cuda75/Dockerfile
@@ -1,5 +1,14 @@
 FROM gadgetron/ubuntu1404_cuda75_base
 
+#ZFP
+RUN cd /opt && \
+    git clone https://github.com/hansenms/ZFP.git && \
+    cd ZFP && \
+    mkdir lib && \
+    make && \
+    make shared && \
+    make install
+
 #ISMRMRD
 RUN mkdir /opt/code
 RUN cd /opt/code && \

--- a/docker/incremental/ubuntu_1604_cuda55/Dockerfile
+++ b/docker/incremental/ubuntu_1604_cuda55/Dockerfile
@@ -1,13 +1,4 @@
-FROM gadgetron/ubuntu1404_base
-
-#ZFP
-RUN cd /opt && \
-    git clone https://github.com/hansenms/ZFP.git && \
-    cd ZFP && \
-    mkdir lib && \
-    make && \
-    make shared && \
-    make install
+FROM gadgetron/ubuntu1604_cuda55_base
 
 #ISMRMRD
 RUN mkdir /opt/code
@@ -19,6 +10,9 @@ RUN cd /opt/code && \
     cmake ../ && \
     make -j $(nproc) && \
     make install
+
+#Fix compiler error with CUDA for now
+RUN sed -i "s;#error -- unsupported GNU version! gcc 4.9 and up are not supported!;//error -- unsupported GNU version! gcc versions later than 4.9 are not supported!;g" /usr/local/cuda/include/host_config.h
 
 #GADGETRON
 RUN cd /opt/code && \
@@ -40,7 +34,7 @@ RUN cd /opt/code/ismrmrd && \
 RUN cd /opt/code && \
     git clone https://github.com/ismrmrd/ismrmrd-python.git &&  \
     cd ismrmrd-python && \
-    sudo python setup.py install && \
+    python setup.py install && \
     /opt/code/gadgetron/docker/manifest --key .io.gadgetron.ismrmrdpython.sha1 --value `git rev-parse HEAD` 
 
 
@@ -48,7 +42,7 @@ RUN cd /opt/code && \
 RUN cd /opt/code && \
     git clone https://github.com/ismrmrd/ismrmrd-python-tools.git &&  \
     cd ismrmrd-python-tools && \
-    sudo python setup.py install && \
+    python setup.py install && \
     /opt/code/gadgetron/docker/manifest --key .io.gadgetron.ismrmrdpythontools.sha1 --value `git rev-parse HEAD` 
 
 #SIEMENS_TO_ISMRMRD

--- a/docker/incremental/ubuntu_1604_cuda75/Dockerfile
+++ b/docker/incremental/ubuntu_1604_cuda75/Dockerfile
@@ -1,13 +1,4 @@
-FROM gadgetron/ubuntu1404_base
-
-#ZFP
-RUN cd /opt && \
-    git clone https://github.com/hansenms/ZFP.git && \
-    cd ZFP && \
-    mkdir lib && \
-    make && \
-    make shared && \
-    make install
+FROM gadgetron/ubuntu1604_cuda75_base
 
 #ISMRMRD
 RUN mkdir /opt/code
@@ -19,6 +10,10 @@ RUN cd /opt/code && \
     cmake ../ && \
     make -j $(nproc) && \
     make install
+
+#Fix compiler error with CUDA for now
+RUN sed -i "s;#error -- unsupported GNU version! gcc versions later than 4.9 are not supported!;//#error -- unsupported GNU version! gcc versions later than 4.9 are not supported!;g" /usr/local/cuda/include/host_config.h
+
 
 #GADGETRON
 RUN cd /opt/code && \
@@ -40,7 +35,7 @@ RUN cd /opt/code/ismrmrd && \
 RUN cd /opt/code && \
     git clone https://github.com/ismrmrd/ismrmrd-python.git &&  \
     cd ismrmrd-python && \
-    sudo python setup.py install && \
+    python setup.py install && \
     /opt/code/gadgetron/docker/manifest --key .io.gadgetron.ismrmrdpython.sha1 --value `git rev-parse HEAD` 
 
 
@@ -48,7 +43,7 @@ RUN cd /opt/code && \
 RUN cd /opt/code && \
     git clone https://github.com/ismrmrd/ismrmrd-python-tools.git &&  \
     cd ismrmrd-python-tools && \
-    sudo python setup.py install && \
+    python setup.py install && \
     /opt/code/gadgetron/docker/manifest --key .io.gadgetron.ismrmrdpythontools.sha1 --value `git rev-parse HEAD` 
 
 #SIEMENS_TO_ISMRMRD

--- a/docker/incremental/ubuntu_1604_no_cuda/Dockerfile
+++ b/docker/incremental/ubuntu_1604_no_cuda/Dockerfile
@@ -1,13 +1,4 @@
-FROM gadgetron/ubuntu1404_base
-
-#ZFP
-RUN cd /opt && \
-    git clone https://github.com/hansenms/ZFP.git && \
-    cd ZFP && \
-    mkdir lib && \
-    make && \
-    make shared && \
-    make install
+FROM gadgetron/ubuntu1604_base
 
 #ISMRMRD
 RUN mkdir /opt/code
@@ -40,7 +31,7 @@ RUN cd /opt/code/ismrmrd && \
 RUN cd /opt/code && \
     git clone https://github.com/ismrmrd/ismrmrd-python.git &&  \
     cd ismrmrd-python && \
-    sudo python setup.py install && \
+    python setup.py install && \
     /opt/code/gadgetron/docker/manifest --key .io.gadgetron.ismrmrdpython.sha1 --value `git rev-parse HEAD` 
 
 
@@ -48,7 +39,7 @@ RUN cd /opt/code && \
 RUN cd /opt/code && \
     git clone https://github.com/ismrmrd/ismrmrd-python-tools.git &&  \
     cd ismrmrd-python-tools && \
-    sudo python setup.py install && \
+    python setup.py install && \
     /opt/code/gadgetron/docker/manifest --key .io.gadgetron.ismrmrdpythontools.sha1 --value `git rev-parse HEAD` 
 
 #SIEMENS_TO_ISMRMRD


### PR DESCRIPTION
…figurations

Please note that the ZFP stuff is added to the incremental configurations in Ubuntu 14.04. They should really have been added to the base images, but there is a problem in Python with current Ubuntu 14.04 that makes rebuilding the 14.04 base images tricky. This is a better compromise. Moreover, the 14.04 images are will be phased out once the 16.04 images have been tested. 

@xueh2 I am pushing 16.04 images to docker hub. Could you test that the gadgetron/ubuntu_1604_cuda55 (https://hub.docker.com/r/gadgetron/ubuntu_1604_cuda55/) image works as a chroot image when you create a chroot from it.