### PR TITLE
fix a bug for multi-S NL spirit

### DIFF
--- a/gadgets/mri_core/GenericReconCartesianNonLinearSpirit2DTGadget.cpp
+++ b/gadgets/mri_core/GenericReconCartesianNonLinearSpirit2DTGadget.cpp
@@ -204,7 +204,8 @@ namespace Gadgetron {
                         hoNDArray< std::complex<float> > coilMap2DT;
                         if (recon_obj.coil_map_.get_size(6) == SLC)
                         {
-                            std::complex<float>* pCoilMap = &recon_obj.coil_map_(0, 0, 0, 0, 0, s, slc);
+                            size_t coil_S = recon_obj.coil_map_.get_size(5);
+                            std::complex<float>* pCoilMap = &recon_obj.coil_map_(0, 0, 0, 0, 0, ((s>=coil_S) ? coil_S-1 : s), slc);
                             coilMap2DT.create(RO, E1, E2, dstCHA, ref_N, 1, 1, pCoilMap);
                         }
 


### PR DESCRIPTION
fix a bug in NL spirit

if multi-S array is input into recon, but all S are combined to generate one set of coil map, then this check is needed to prevent memory exception