### PR TITLE
Coil sen dependency

### DIFF
--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -78,7 +78,9 @@ set( gadgetron_mricore_header_files GadgetMRIHeaders.h
                                     FFTGadget.h 
                                     ImageFinishGadget.h 
                                     CombineGadget.h
-                                    CropAndCombineGadget.h  
+                                    CropAndCombineGadget.h 
+                                    CoilSenMapGadget.h
+                                    DependencyDataSenderGadget.h
                                     ImageWriterGadget.h 
                                     MRIImageWriter.h
                                     MRIImageReader.h
@@ -129,6 +131,8 @@ set( gadgetron_mricore_src_files AcquisitionPassthroughGadget.cpp
                                 ImageFinishGadget.cpp 
                                 CombineGadget.cpp 
                                 CropAndCombineGadget.cpp 
+                                CoilSenMapGadget.cpp 
+                                DependencyDataSenderGadget.cpp 
                                 ImageWriterGadget.cpp 
                                 MRIImageWriter.cpp
                                 MRIImageReader.cpp
@@ -177,6 +181,7 @@ set( gadgetron_mricore_config_files
     config/default_optimized.xml
     config/default_measurement_dependencies.xml
     config/default_measurement_dependencies_ismrmrd_storage.xml
+    config/default_measurement_dependencies_Noise_CoilSen_SCC.xml
     config/isalive.xml
     config/gtquery.xml
     config/Generic_Cartesian_Grappa.xml

--- a/gadgets/mri_core/CoilSenMapGadget.cpp
+++ b/gadgets/mri_core/CoilSenMapGadget.cpp
@@ -61,7 +61,6 @@ namespace Gadgetron {
         // deserialize the ismrmrd header
         ISMRMRD::deserialize(mb->rd_ptr(), current_ismrmrd_header_);
 
-        // find the measurementID of this scan
         if (current_ismrmrd_header_.measurementInformation)
         {
             if (current_ismrmrd_header_.measurementInformation->measurementID)
@@ -69,34 +68,57 @@ namespace Gadgetron {
                 measurement_id_ = *current_ismrmrd_header_.measurementInformation->measurementID;
                 GDEBUG( "Measurement ID is %s\n", measurement_id_.c_str() );
             }
-
-            // find the noise depencies if any
-            if (current_ismrmrd_header_.measurementInformation->measurementDependency.size() > 0)
+            else
             {
-                measurement_id_of_coil_sen_dependency_.clear();
-
-                std::vector<ISMRMRD::MeasurementDependency>::const_iterator iter = current_ismrmrd_header_.measurementInformation->measurementDependency.begin();
-                for (; iter != current_ismrmrd_header_.measurementInformation->measurementDependency.end(); iter++)
-                {
-                    std::string dependencyType = iter->dependencyType;
-                    std::string dependencyID = iter->measurementID;
-
-                    GDEBUG( "Found dependency measurement : %s with ID %s\n", dependencyType.c_str(), dependencyID.c_str() );
-
-                    if (dependencyType == "SenMap" || dependencyType == "senmap") {
-                        measurement_id_of_coil_sen_dependency_ = dependencyID;
-                    }
-                }
-
-                if (!measurement_id_of_coil_sen_dependency_.empty())
-                {
-                    GDEBUG( "Measurement ID of coil sen dependency is %s\n", measurement_id_of_coil_sen_dependency_.c_str() );
-
-                    full_name_stored_coil_sen_dependency_ = this->generate_coil_sen_dependency_filename( measurement_id_of_coil_sen_dependency_ );
-                    GDEBUG( "Stored coil sen dependency is %s\n", full_name_stored_coil_sen_dependency_.c_str() );
-                }
+                GERROR_STREAM("Incoming ismrmrd header does not have measurementInformation.measurementID ... ");
+                return GADGET_FAIL;
             }
         }
+        else
+        {
+            GERROR_STREAM("Incoming ismrmrd header does not have measurementInformation ... ");
+            return GADGET_FAIL;
+        }
+
+        full_name_stored_coil_sen_dependency_ = this->generate_coil_sen_dependency_filename( measurement_id_ );
+        GDEBUG( "Stored coil sen dependency is %s\n", full_name_stored_coil_sen_dependency_.c_str() );
+
+        //// find the measurementID of this scan
+        //if (current_ismrmrd_header_.measurementInformation)
+        //{
+        //    if (current_ismrmrd_header_.measurementInformation->measurementID)
+        //    {
+        //        measurement_id_ = *current_ismrmrd_header_.measurementInformation->measurementID;
+        //        GDEBUG( "Measurement ID is %s\n", measurement_id_.c_str() );
+        //    }
+
+        //    // find the noise depencies if any
+        //    if (current_ismrmrd_header_.measurementInformation->measurementDependency.size() > 0)
+        //    {
+        //        measurement_id_of_coil_sen_dependency_.clear();
+
+        //        std::vector<ISMRMRD::MeasurementDependency>::const_iterator iter = current_ismrmrd_header_.measurementInformation->measurementDependency.begin();
+        //        for (; iter != current_ismrmrd_header_.measurementInformation->measurementDependency.end(); iter++)
+        //        {
+        //            std::string dependencyType = iter->dependencyType;
+        //            std::string dependencyID = iter->measurementID;
+
+        //            GDEBUG( "Found dependency measurement : %s with ID %s\n", dependencyType.c_str(), dependencyID.c_str() );
+
+        //            if (dependencyType == "SenMap" || dependencyType == "senmap") {
+        //                measurement_id_of_coil_sen_dependency_ = dependencyID;
+        //            }
+        //        }
+
+        //        if (!measurement_id_of_coil_sen_dependency_.empty())
+        //        {
+        //            GDEBUG( "Measurement ID of coil sen dependency is %s\n", measurement_id_of_coil_sen_dependency_.c_str() );
+
+        //            full_name_stored_coil_sen_dependency_ = this->generate_coil_sen_dependency_filename( measurement_id_of_coil_sen_dependency_ );
+        //            GDEBUG( "Stored coil sen dependency is %s\n", full_name_stored_coil_sen_dependency_.c_str() );
+        //        }
+        //    }
+        //}
 
         return GADGET_OK;
     }
@@ -133,6 +155,14 @@ namespace Gadgetron {
         {
             GADGET_CHECK_EXCEPTION_RETURN_FALSE(Gadgetron::save_dependency_data(xml_str, scc_array_, scc_header_[0], body_array_, body_header_[0], full_name_stored_coil_sen_dependency_));
         }
+
+        //std::string xml_loaded;
+        //ISMRMRD::AcquisitionHeader hs, hb;
+        //hoNDArray< std::complex<float> > sa, ba;
+        //Gadgetron::load_dependency_data(full_name_stored_coil_sen_dependency_, xml_loaded, sa, hs, ba, hb);
+
+        //if (!debug_folder_full_path_.empty()) gt_exporter_.export_array_complex(sa, debug_folder_full_path_ + "CoilSenMap_sa_array");
+        //if (!debug_folder_full_path_.empty()) gt_exporter_.export_array_complex(ba, debug_folder_full_path_ + "CoilSenMap_ba_array");
 
         // set the permission
 #ifndef _WIN32
@@ -195,7 +225,7 @@ namespace Gadgetron {
             }
         }
 
-        GDEBUG_CONDITION_STREAM(verbose.value(), "CoilSenMapGadget, received number of channel, set 0 and set 1 : " << CHA_1st_set << " " << CHA_2nd_set);
+        GDEBUG_CONDITION_STREAM(verbose.value(), "CoilSenMapGadget, received number of channel, set 0 and set 1 : " << CHA_1st_set << " and " << CHA_2nd_set);
 
         // allocate surface coil and body coil array
         std::vector<size_t> dim(11, 1);

--- a/gadgets/mri_core/CoilSenMapGadget.cpp
+++ b/gadgets/mri_core/CoilSenMapGadget.cpp
@@ -1,0 +1,303 @@
+
+#include "CoilSenMapGadget.h"
+#include "hoArmadillo.h"
+#include "hoNDArray_elemwise.h"
+#include "hoMatrix.h"
+#include "hoNDArray_linalg.h"
+#include "hoNDArray_reductions.h"
+
+#include "mri_core_dependencies.h"
+
+#ifdef USE_OMP
+    #include "omp.h"
+#endif // USE_OMP
+
+#ifndef _WIN32
+    #include <sys/types.h>
+    #include <sys/stat.h>
+#endif // _WIN32
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
+
+namespace Gadgetron {
+
+    CoilSenMapGadget::CoilSenMapGadget()
+    {
+    }
+
+    CoilSenMapGadget::~CoilSenMapGadget()
+    {
+
+    }
+
+    int CoilSenMapGadget::process_config( ACE_Message_Block* mb )
+    {
+        if (!debug_folder.value().empty())
+        {
+            Gadgetron::get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
+        }
+        else
+        {
+            GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is not set ... ");
+        }
+
+        if (!workingDirectory.value().empty())
+        {
+            coil_sen_dependency_folder_ = workingDirectory.value();
+        }
+        else
+        {
+#ifdef _WIN32
+            coil_sen_dependency_folder_ = std::string( "c:\\temp\\gadgetron\\" );
+#else
+            coil_sen_dependency_folder_ = std::string( "/tmp/gadgetron/" );
+#endif // _WIN32
+        }
+
+        GDEBUG( "Folder to store coil map dependencies is %s\n", coil_sen_dependency_folder_.c_str() );
+
+        // deserialize the ismrmrd header
+        ISMRMRD::deserialize(mb->rd_ptr(), current_ismrmrd_header_);
+
+        // find the measurementID of this scan
+        if (current_ismrmrd_header_.measurementInformation)
+        {
+            if (current_ismrmrd_header_.measurementInformation->measurementID)
+            {
+                measurement_id_ = *current_ismrmrd_header_.measurementInformation->measurementID;
+                GDEBUG( "Measurement ID is %s\n", measurement_id_.c_str() );
+            }
+
+            // find the noise depencies if any
+            if (current_ismrmrd_header_.measurementInformation->measurementDependency.size() > 0)
+            {
+                measurement_id_of_coil_sen_dependency_.clear();
+
+                std::vector<ISMRMRD::MeasurementDependency>::const_iterator iter = current_ismrmrd_header_.measurementInformation->measurementDependency.begin();
+                for (; iter != current_ismrmrd_header_.measurementInformation->measurementDependency.end(); iter++)
+                {
+                    std::string dependencyType = iter->dependencyType;
+                    std::string dependencyID = iter->measurementID;
+
+                    GDEBUG( "Found dependency measurement : %s with ID %s\n", dependencyType.c_str(), dependencyID.c_str() );
+
+                    if (dependencyType == "SenMap" || dependencyType == "senmap") {
+                        measurement_id_of_coil_sen_dependency_ = dependencyID;
+                    }
+                }
+
+                if (!measurement_id_of_coil_sen_dependency_.empty())
+                {
+                    GDEBUG( "Measurement ID of coil sen dependency is %s\n", measurement_id_of_coil_sen_dependency_.c_str() );
+
+                    full_name_stored_coil_sen_dependency_ = this->generate_coil_sen_dependency_filename( measurement_id_of_coil_sen_dependency_ );
+                    GDEBUG( "Stored coil sen dependency is %s\n", full_name_stored_coil_sen_dependency_.c_str() );
+                }
+            }
+        }
+
+        return GADGET_OK;
+    }
+
+    std::string CoilSenMapGadget::generate_coil_sen_dependency_filename( const std::string& measurement_id )
+    {
+        std::string full_name_stored_coil_sen_dependency;
+
+        full_name_stored_coil_sen_dependency = coil_sen_dependency_folder_;
+        full_name_stored_coil_sen_dependency.append( "/" );
+        full_name_stored_coil_sen_dependency.append( coil_sen_dependency_prefix.value() );
+        full_name_stored_coil_sen_dependency.append( "_" );
+        full_name_stored_coil_sen_dependency.append( measurement_id );
+
+        return full_name_stored_coil_sen_dependency;
+    }
+
+    bool CoilSenMapGadget::save_coil_sen_dependency()
+    {
+        // ismrmrd header
+        std::stringstream xml_ss;
+        ISMRMRD::serialize( current_ismrmrd_header_, xml_ss );
+        std::string xml_str = xml_ss.str();
+        uint32_t xml_length = static_cast<uint32_t>(xml_str.size());
+
+        if(body_header_.empty())
+        {
+            ISMRMRD::AcquisitionHeader header;
+            memset(&header, 0, sizeof(ISMRMRD::AcquisitionHeader));
+
+            GADGET_CHECK_EXCEPTION_RETURN_FALSE(Gadgetron::save_dependency_data(xml_str, scc_array_, scc_header_[0], body_array_, header, full_name_stored_coil_sen_dependency_));
+        }
+        else
+        {
+            GADGET_CHECK_EXCEPTION_RETURN_FALSE(Gadgetron::save_dependency_data(xml_str, scc_array_, scc_header_[0], body_array_, body_header_[0], full_name_stored_coil_sen_dependency_));
+        }
+
+        // set the permission
+#ifndef _WIN32
+        int res = chmod( full_name_stored_coil_sen_dependency_.c_str(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH );
+        if (res != 0)
+        {
+            GDEBUG( "Changing coil sen file permission failed ...\n" );
+        }
+#endif // _WIN32
+
+        return true;
+    }
+
+    int CoilSenMapGadget::process( GadgetContainerMessage<IsmrmrdAcquisitionBucket>* m1 )
+    {
+        // find the dimension limit of stored data
+
+        size_t RO(0), E1(0), E2(0), SLC(0), PHS(0), CON(0), REP(0), SET(0), SEG(0), AVE(0);
+
+        IsmrmrdAcquisitionBucket& bucket = *m1->getObjectPtr();
+
+        size_t N = bucket.data_.size();
+
+        RO = bucket.data_[0].head_->getObjectPtr()->number_of_samples;
+        E1 = *std::max_element(bucket.datastats_[0].kspace_encode_step_1.begin(), bucket.datastats_[0].kspace_encode_step_1.end()) + 1;
+        E2 = *std::max_element(bucket.datastats_[0].kspace_encode_step_2.begin(), bucket.datastats_[0].kspace_encode_step_2.end()) + 1;
+        SLC = *std::max_element(bucket.datastats_[0].slice.begin(), bucket.datastats_[0].slice.end()) + 1;
+        PHS = *std::max_element(bucket.datastats_[0].phase.begin(), bucket.datastats_[0].phase.end()) + 1;
+        CON = *std::max_element(bucket.datastats_[0].contrast.begin(), bucket.datastats_[0].contrast.end()) + 1;
+        REP = *std::max_element(bucket.datastats_[0].repetition.begin(), bucket.datastats_[0].repetition.end()) + 1;
+        SET = *std::max_element(bucket.datastats_[0].set.begin(), bucket.datastats_[0].set.end()) + 1;
+        SEG = *std::max_element(bucket.datastats_[0].segment.begin(), bucket.datastats_[0].segment.end()) + 1;
+        AVE = *std::max_element(bucket.datastats_[0].average.begin(), bucket.datastats_[0].average.end()) + 1;
+
+        GDEBUG_CONDITION_STREAM(verbose.value(), "CoilSenMapGadget, received buckert [RO E1 E2 SLC PHS CON REP SET SEG AVE] : [" 
+                                                                        << RO << " " << E1 << " " << E2 << " " 
+                                                                        << SLC << " " << PHS << " " << CON << " " 
+                                                                        << REP << " " << SET << " " << SEG << " " << SLC << "]");
+
+        // find max CHA for each SET
+        size_t CHA_1st_set(0), CHA_2nd_set(0);
+
+        size_t n;
+        for (n=0; n<N; n++)
+        {
+            if(bucket.data_[n].head_->getObjectPtr()->idx.set==0)
+            {
+                if(CHA_1st_set < bucket.data_[n].head_->getObjectPtr()->active_channels)
+                {
+                    CHA_1st_set = bucket.data_[n].head_->getObjectPtr()->active_channels;
+                }
+            }
+
+            if(bucket.data_[n].head_->getObjectPtr()->idx.set==1)
+            {
+                if(CHA_2nd_set < bucket.data_[n].head_->getObjectPtr()->active_channels)
+                {
+                    CHA_2nd_set = bucket.data_[n].head_->getObjectPtr()->active_channels;
+                }
+            }
+        }
+
+        GDEBUG_CONDITION_STREAM(verbose.value(), "CoilSenMapGadget, received number of channel, set 0 and set 1 : " << CHA_1st_set << " " << CHA_2nd_set);
+
+        // allocate surface coil and body coil array
+        std::vector<size_t> dim(11, 1);
+        dim[0] = RO;
+        dim[1] = E1;
+        dim[2] = E2;
+        dim[3] = CHA_1st_set;
+        dim[4] = SLC;
+        dim[5] = PHS;
+        dim[6] = CON;
+        dim[7] = REP;
+        dim[8] = 1;
+        dim[9] = 1;
+        dim[10] = AVE;
+
+        scc_array_.create(dim);
+        Gadgetron::clear(scc_array_);
+
+        if(CHA_2nd_set>0)
+        {
+            std::vector<size_t> dim_body(dim);
+            dim_body[3] = CHA_2nd_set;
+
+            body_array_.create(dim_body);
+            Gadgetron::clear(body_array_);
+        }
+
+        // fill the array
+
+        std::vector<size_t> ind(11);
+
+        size_t cha;
+        for (n=0; n<N; n++)
+        {
+            ind[0] = 0;
+            ind[1] = bucket.data_[n].head_->getObjectPtr()->idx.kspace_encode_step_1;
+            ind[2] = bucket.data_[n].head_->getObjectPtr()->idx.kspace_encode_step_2;
+
+            ind[4] = bucket.data_[n].head_->getObjectPtr()->idx.slice;
+            ind[5] = bucket.data_[n].head_->getObjectPtr()->idx.phase;
+            ind[6] = bucket.data_[n].head_->getObjectPtr()->idx.contrast;
+            ind[7] = bucket.data_[n].head_->getObjectPtr()->idx.repetition;
+            ind[8] = 0;
+            ind[9] = 0;
+            ind[10] = bucket.data_[n].head_->getObjectPtr()->idx.average;
+
+            if(bucket.data_[n].head_->getObjectPtr()->idx.set==0)
+            {
+                scc_header_.push_back(*bucket.data_[n].head_->getObjectPtr());
+
+                for (cha=0; cha<CHA_1st_set; cha++)
+                {
+                    ind[3] = cha;
+                    size_t array_index = scc_array_.calculate_offset(ind);
+                    std::complex<float>* pData = &(scc_array_(array_index));
+
+                    memcpy(pData, bucket.data_[n].data_->getObjectPtr()->begin() + cha*RO, sizeof(std::complex<float>)*RO);
+                }
+            }
+
+            if(bucket.data_[n].head_->getObjectPtr()->idx.set==1)
+            {
+                body_header_.push_back(*bucket.data_[n].head_->getObjectPtr());
+
+                for (cha=0; cha<CHA_2nd_set; cha++)
+                {
+                    ind[3] = cha;
+                    size_t array_index = body_array_.calculate_offset(ind);
+                    std::complex<float>* pData = &(body_array_(array_index));
+
+                    memcpy(pData, bucket.data_[n].data_->getObjectPtr()->begin() + cha*RO, sizeof(std::complex<float>)*RO);
+                }
+            }
+        }
+
+        if (!debug_folder_full_path_.empty()) gt_exporter_.export_array_complex(scc_array_, debug_folder_full_path_ + "CoilSenMap_scc_array");
+
+        if(CHA_2nd_set>0)
+        {
+            if (!debug_folder_full_path_.empty()) gt_exporter_.export_array_complex(body_array_, debug_folder_full_path_ + "CoilSenMap_body_array");
+        }
+
+        if (!this->save_coil_sen_dependency())
+        {
+            GERROR_STREAM("CoilSenMapGadget, save_coil_sen_dependency failed ... ");
+        }
+
+        m1->release();
+
+        return GADGET_OK;
+
+    }
+
+    int CoilSenMapGadget::close( unsigned long flags )
+    {
+        GDEBUG_CONDITION_STREAM(true, "CoilSenMapGadget - close(flags) : " << flags);
+
+        if (BaseClass::close( flags ) != GADGET_OK) return GADGET_FAIL;
+
+        return GADGET_OK;
+    }
+
+    GADGET_FACTORY_DECLARE( CoilSenMapGadget )
+
+} // namespace Gadgetron

--- a/gadgets/mri_core/CoilSenMapGadget.h
+++ b/gadgets/mri_core/CoilSenMapGadget.h
@@ -1,0 +1,72 @@
+/** \file   CoilSenMapGadget.h
+    \brief  This gadget is a part of the depedency handling chain.
+
+    This gadget will accumulate all received coil sensitivity data and buffer them into the gadgetron folder.
+    If the incoming data has two SETs, the second SET is considered as the body coil readouts
+
+    \author     Hui Xue
+*/
+
+#pragma once
+
+#include "Gadget.h"
+#include "hoNDArray.h"
+#include "gadgetron_mricore_export.h"
+#include "GadgetronTimer.h"
+
+#include <ismrmrd/ismrmrd.h>
+#include <ismrmrd/xml.h>
+#include <complex>
+
+#include "mri_core_def.h"
+#include "mri_core_data.h"
+#include "mri_core_utility.h"
+#include "mri_core_acquisition_bucket.h"
+
+#include "ImageIOAnalyze.h"
+
+namespace Gadgetron {
+
+    class EXPORTGADGETSMRICORE CoilSenMapGadget : public Gadget1<IsmrmrdAcquisitionBucket>
+    {
+    public:
+        GADGET_DECLARE( CoilSenMapGadget );
+
+        typedef Gadget1< IsmrmrdAcquisitionBucket > BaseClass;
+
+        CoilSenMapGadget();
+        virtual ~CoilSenMapGadget();
+
+    protected:
+
+        GADGET_PROPERTY(verbose, bool, "Whether to print more information", false);
+        GADGET_PROPERTY(debug_folder, std::string, "If set, the debug output will be written out", "");
+        GADGET_PROPERTY(perform_timing, bool, "Whether to perform timing on some computational steps", false);
+
+        GADGET_PROPERTY( coil_sen_dependency_prefix, std::string, "Prefix of noise depencency file", "GadgetronCoilSenMap" );
+        GADGET_PROPERTY( pass_nonconformant_data, bool, "Whether to pass data that does not conform", false );
+
+        virtual int process_config( ACE_Message_Block* mb );
+        virtual int process( GadgetContainerMessage<IsmrmrdAcquisitionBucket>* m1 );
+        virtual int close(unsigned long flags);
+
+        std::string generate_coil_sen_dependency_filename( const std::string& measurement_id );
+        bool save_coil_sen_dependency();
+
+        std::string coil_sen_dependency_folder_;
+        std::string measurement_id_;
+        std::string measurement_id_of_coil_sen_dependency_;
+        std::string full_name_stored_coil_sen_dependency_;
+        ISMRMRD::IsmrmrdHeader current_ismrmrd_header_;
+
+        Gadgetron::ImageIOAnalyze gt_exporter_;
+        std::string debug_folder_full_path_;
+
+        // array for surface coil and body coil
+        hoNDArray< std::complex<float> > scc_array_;
+        std::vector<ISMRMRD::AcquisitionHeader> scc_header_;
+
+        hoNDArray< std::complex<float> > body_array_;
+        std::vector<ISMRMRD::AcquisitionHeader> body_header_;
+    };
+}

--- a/gadgets/mri_core/DependencyDataSenderGadget.cpp
+++ b/gadgets/mri_core/DependencyDataSenderGadget.cpp
@@ -1,0 +1,53 @@
+#include "DependencyDataSenderGadget.h"
+#include "ismrmrd/xml.h"
+
+#ifdef USE_OMP
+    #include "omp.h"
+#endif // USE_OMP
+
+namespace Gadgetron {
+
+    DependencyDataSenderGadget::DependencyDataSenderGadget() : coil_sen_head_gadget_(NULL), scc_head_gadget_(NULL)
+    {
+    }
+
+    DependencyDataSenderGadget::~DependencyDataSenderGadget()
+    {
+    }
+
+    int DependencyDataSenderGadget::process_config( ACE_Message_Block* mb )
+    {
+        coil_sen_head_gadget_ = this->get_controller()->find_gadget(coil_sen_head_gadget.value());
+        scc_head_gadget_ = this->get_controller()->find_gadget(scc_head_gadget.value());
+
+        GADGET_CHECK_RETURN( (coil_sen_head_gadget_!=NULL || scc_head_gadget_!=NULL), GADGET_FAIL);
+
+        return GADGET_OK;
+    }
+
+    int DependencyDataSenderGadget::process( GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1, GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2 )
+    {
+        bool is_scc = m1->getObjectPtr()->isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_SURFACECOILCORRECTIONSCAN_DATA);
+
+        if(is_scc)
+        {
+            if (scc_head_gadget_->putq( m1 ) == -1)
+            {
+                GERROR( "DependencyDataSenderGadget::process, passing data on to scc gadget" );
+                return GADGET_FAIL;
+            }
+        }
+        else
+        {
+            if (coil_sen_head_gadget_->putq( m1 ) == -1)
+            {
+                GERROR( "DependencyDataSenderGadget::process, passing data on to coil sen gadget" );
+                return GADGET_FAIL;
+            }
+        }
+
+        return GADGET_OK;
+    }
+
+    GADGET_FACTORY_DECLARE( DependencyDataSenderGadget )
+}

--- a/gadgets/mri_core/DependencyDataSenderGadget.h
+++ b/gadgets/mri_core/DependencyDataSenderGadget.h
@@ -1,0 +1,44 @@
+
+/** \file   DependencyDataSenderGadget.h
+    \brief  This gadget is a part of the depedency handling chain.
+
+            This gadget will send coil sen map data and scc data to corresponding chains.
+
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include "Gadget.h"
+#include "hoNDArray.h"
+#include "gadgetron_mricore_export.h"
+
+#include "GadgetStreamController.h"
+#include "ismrmrd/ismrmrd.h"
+#include "ismrmrd/xml.h"
+
+#include <complex>
+
+namespace Gadgetron {
+
+    class EXPORTGADGETSMRICORE DependencyDataSenderGadget : public Gadget2<ISMRMRD::AcquisitionHeader, hoNDArray< std::complex<float> > >
+    {
+    public:
+        GADGET_DECLARE( DependencyDataSenderGadget );
+
+        DependencyDataSenderGadget();
+        virtual ~DependencyDataSenderGadget();
+
+    protected:
+
+        virtual int process_config( ACE_Message_Block* mb );
+        virtual int process( GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1, GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2 );
+
+        GADGET_PROPERTY(verbose, bool, "Whether to print more information", false);
+        GADGET_PROPERTY( coil_sen_head_gadget, std::string, "Head gadget of coil sen branch", "AccCoilSen" );
+        GADGET_PROPERTY( scc_head_gadget, std::string, "Head gadget of scc branch", "AccSCC" );
+
+        Gadget* coil_sen_head_gadget_;
+        Gadget* scc_head_gadget_;
+    };
+}

--- a/gadgets/mri_core/config/default_measurement_dependencies_Noise_CoilSen_SCC.xml
+++ b/gadgets/mri_core/config/default_measurement_dependencies_Noise_CoilSen_SCC.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+                  xmlns="http://gadgetron.sf.net/gadgetron"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <reader>
+        <slot>1008</slot>
+        <dll>gadgetron_mricore</dll>
+        <classname>GadgetIsmrmrdAcquisitionMessageReader</classname>
+    </reader>
+
+    <!-- SNR unit noise adjust gadget 
+         If the scan has asymmetric readout, the center of echo will shifted to the index 0
+         Zeros will be filled into the readout data
+    -->
+    <gadget>
+        <name>NoiseAdjust</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>NoiseAdjustGadget</classname>
+
+        <!-- File prefix for stored noise prewhitener matrix -->
+        <property><name>noise_dependency_prefix</name><value>GadgetronNoiseCovarianceMatrix</value></property>
+
+        <!-- Whether to pass the nonconformant data without applyting the prewhitening -->
+        <property><name>pass_nonconformant_data</name><value>true</value></property>
+    </gadget>
+
+    <!-- Data sender -->
+    <gadget>
+        <name>DataSender</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>DependencyDataSenderGadget</classname>
+        <property><name>head_coil_sen</name><value>AccCoilSen</value></property>
+        <property><name>head_scc</name><value>AccSCC</value></property>
+    </gadget>
+
+    <!-- Head of coil sen branch -->
+    <gadget>
+        <name>AccCoilSen</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value></value></property>
+        <property><name>sorting_dimension</name><value></value></property>
+    </gadget>
+
+    <gadget>
+        <name>CoilSen</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>CoilSenMapGadget</classname>
+
+        <property><name>coil_sen_dependency_prefix</name><value>GadgetronCoilSenMap</value></property>
+        <property><name>pass_nonconformant_data</name><value>false</value></property>
+
+        <property><name>verbose</name><value>true</value></property>
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+    </gadget>
+
+    <!-- Head of SCC branch -->
+    <gadget>
+        <name>AccSCC</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>AcquisitionAccumulateTriggerGadget</classname>
+        <property><name>trigger_dimension</name><value></value></property>
+        <property><name>sorting_dimension</name><value></value></property>
+    </gadget>
+
+    <gadget>
+        <name>SCC</name>
+        <dll>gadgetron_mricore</dll>
+        <classname>CoilSenMapGadget</classname>
+
+        <property><name>coil_sen_dependency_prefix</name><value>GadgetronSCCMap</value></property>
+        <property><name>pass_nonconformant_data</name><value>false</value></property>
+
+        <property><name>verbose</name><value>true</value></property>
+        <property><name>debug_folder</name><value></value></property>
+        <property><name>perform_timing</name><value>false</value></property>
+    </gadget>
+
+</gadgetronStreamConfiguration>

--- a/gadgets/mri_core/config/default_measurement_dependencies_Noise_CoilSen_SCC.xml
+++ b/gadgets/mri_core/config/default_measurement_dependencies_Noise_CoilSen_SCC.xml
@@ -30,8 +30,8 @@
         <name>DataSender</name>
         <dll>gadgetron_mricore</dll>
         <classname>DependencyDataSenderGadget</classname>
-        <property><name>head_coil_sen</name><value>AccCoilSen</value></property>
-        <property><name>head_scc</name><value>AccSCC</value></property>
+        <property><name>coil_sen_head_gadget</name><value>AccCoilSen</value></property>
+        <property><name>scc_head_gadget</name><value>AccSCC</value></property>
     </gadget>
 
     <!-- Head of coil sen branch -->

--- a/toolboxes/mri_core/CMakeLists.txt
+++ b/toolboxes/mri_core/CMakeLists.txt
@@ -34,6 +34,7 @@ set( mri_core_header_files
         mri_core_grappa.h 
         mri_core_spirit.h 
         mri_core_coil_map_estimation.h 
+        mri_core_dependencies.h 
         mri_core_acquisition_bucket.h 
         mri_core_partial_fourier.h )
 
@@ -43,6 +44,7 @@ set( mri_core_source_files
         mri_core_spirit.cpp 
         mri_core_kspace_filter.cpp
         mri_core_coil_map_estimation.cpp 
+        mri_core_dependencies.cpp 
         mri_core_partial_fourier.cpp )
 
 add_library(gadgetron_toolbox_mri_core SHARED 

--- a/toolboxes/mri_core/mri_core_dependencies.cpp
+++ b/toolboxes/mri_core/mri_core_dependencies.cpp
@@ -34,7 +34,7 @@ namespace Gadgetron
                 GADGET_CHECK_THROW(scc_array.serialize(buf_scc_array, len_scc_array));
 
                 size_t len_body_array = 0;
-                GADGET_CHECK_THROW(scc_array.serialize(buf_body_array, len_body_array));
+                GADGET_CHECK_THROW(body_array.serialize(buf_body_array, len_body_array));
 
                 outfile.write( reinterpret_cast<char*>(&len_ismrmrd_header), sizeof(size_t) );
                 outfile.write( ismrmrd_header.c_str(), len_ismrmrd_header );
@@ -106,7 +106,7 @@ namespace Gadgetron
                 std::vector<char> buf_body(len_body_array);
                 infile.read( &buf_body[0], len_body_array);
 
-                body_array.deserialize(&buf_scc[0], len_scc_array);
+                body_array.deserialize(&buf_body[0], len_body_array);
 
                 // -----------------------------
 

--- a/toolboxes/mri_core/mri_core_dependencies.cpp
+++ b/toolboxes/mri_core/mri_core_dependencies.cpp
@@ -1,0 +1,131 @@
+
+/** \file   mri_core_dependencies.cpp
+    \brief  Implementation useful utility functionalities for MRI dependency data handling
+    \author Hui Xue
+*/
+
+#include "mri_core_dependencies.h"
+#include "hoNDArray_elemwise.h"
+#include "hoNDArray_utils.h"
+#include <fstream>
+
+namespace Gadgetron
+{
+    template <typename T> 
+    void save_dependency_data(const std::string& ismrmrd_header, const hoNDArray<T>& scc_array, const ISMRMRD::AcquisitionHeader& scc_header, 
+                            const hoNDArray<T>& body_array, const ISMRMRD::AcquisitionHeader& body_header, const std::string& filename)
+    {
+        char* buf = NULL;
+        char* buf_scc_array = NULL;
+        char* buf_body_array = NULL;
+
+        try
+        {
+            std::ofstream outfile;
+            outfile.open( filename.c_str(), std::ios::out | std::ios::binary );
+
+            if (outfile.good())
+            {
+                GDEBUG_STREAM( "Write out the dependency data file : " << filename );
+
+                size_t len_ismrmrd_header = ismrmrd_header.length();
+
+                size_t len_scc_array = 0;
+                GADGET_CHECK_THROW(scc_array.serialize(buf_scc_array, len_scc_array));
+
+                size_t len_body_array = 0;
+                GADGET_CHECK_THROW(scc_array.serialize(buf_body_array, len_body_array));
+
+                outfile.write( reinterpret_cast<char*>(&len_ismrmrd_header), sizeof(size_t) );
+                outfile.write( ismrmrd_header.c_str(), len_ismrmrd_header );
+
+                outfile.write( reinterpret_cast<char*>(&len_scc_array), sizeof(size_t) );
+                outfile.write( buf_scc_array, len_scc_array );
+
+                outfile.write( reinterpret_cast<char*>(&len_body_array), sizeof(size_t) );
+                outfile.write( buf_body_array, len_body_array );
+
+                outfile.write( reinterpret_cast<const char*>(&scc_header), sizeof(ISMRMRD::AcquisitionHeader) );
+                outfile.write( reinterpret_cast<const char*>(&body_header), sizeof(ISMRMRD::AcquisitionHeader) );
+
+                outfile.close();
+            }
+            else
+            {
+                GERROR_STREAM("Failed to open dependency data file for writing : " << filename);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in save_dependency_data(...) ... ");
+
+            if(buf!=NULL) delete [] buf;
+            if(buf_scc_array!=NULL) delete [] buf_scc_array;
+            if(buf_body_array!=NULL) delete [] buf_body_array;
+        }
+    }
+
+    template EXPORTMRICORE void save_dependency_data(const std::string& ismrmd_header, const hoNDArray< std::complex<float> >& scc_array, const ISMRMRD::AcquisitionHeader& scc_header, const hoNDArray< std::complex<float> >& body_array, const ISMRMRD::AcquisitionHeader& body_header, const std::string& filename);
+    template EXPORTMRICORE void save_dependency_data(const std::string& ismrmd_header, const hoNDArray< std::complex<double> >& scc_array, const ISMRMRD::AcquisitionHeader& scc_header, const hoNDArray< std::complex<double> >& body_array, const ISMRMRD::AcquisitionHeader& body_header, const std::string& filename);
+
+    // ------------------------------------------------------------------------
+
+    template <typename T> 
+    void load_dependency_data(const std::string& filename, std::string& ismrmd_header, hoNDArray<T>& scc_array, ISMRMRD::AcquisitionHeader& scc_header, 
+                        hoNDArray<T>& body_array, ISMRMRD::AcquisitionHeader& body_header)
+    {
+        try
+        {
+            std::ifstream infile;
+            infile.open (filename.c_str(), std::ios::in|std::ios::binary);
+
+            if (infile.good())
+            {
+                size_t xml_length;
+                infile.read( reinterpret_cast<char*>(&xml_length), sizeof(size_t));
+
+                std::string xml_str(xml_length,'\0');
+                infile.read(const_cast<char*>(xml_str.c_str()), xml_length);
+                ismrmd_header = xml_str;
+
+                // -----------------------------
+
+                size_t len_scc_array = 0;
+                infile.read( reinterpret_cast<char*>(&len_scc_array), sizeof(size_t));
+
+                std::vector<char> buf_scc(len_scc_array);
+                infile.read( &buf_scc[0], len_scc_array);
+
+                scc_array.deserialize(&buf_scc[0], len_scc_array);
+
+                // -----------------------------
+
+                size_t len_body_array = 0;
+                infile.read( reinterpret_cast<char*>(&len_body_array), sizeof(size_t));
+
+                std::vector<char> buf_body(len_body_array);
+                infile.read( &buf_body[0], len_body_array);
+
+                body_array.deserialize(&buf_scc[0], len_scc_array);
+
+                // -----------------------------
+
+                infile.read( reinterpret_cast<char*>(&scc_header), sizeof(ISMRMRD::AcquisitionHeader));
+                infile.read( reinterpret_cast<char*>(&body_header), sizeof(ISMRMRD::AcquisitionHeader));
+
+                infile.close();
+            }
+            else
+            {
+                GERROR_STREAM("Failed to open dependency data file for reading : " << filename);
+            }
+        }
+        catch (...)
+        {
+            GADGET_THROW("Errors in save_dependency_data(...) ... ");
+        }
+    }
+
+    template EXPORTMRICORE void load_dependency_data(const std::string& filename, std::string& ismrmd_header, hoNDArray< std::complex<float> >& scc_array, ISMRMRD::AcquisitionHeader& scc_header, hoNDArray< std::complex<float> >& body_array, ISMRMRD::AcquisitionHeader& body_header);
+    template EXPORTMRICORE void load_dependency_data(const std::string& filename, std::string& ismrmd_header, hoNDArray< std::complex<double> >& scc_array, ISMRMRD::AcquisitionHeader& scc_header, hoNDArray< std::complex<double> >& body_array, ISMRMRD::AcquisitionHeader& body_header);
+}

--- a/toolboxes/mri_core/mri_core_dependencies.h
+++ b/toolboxes/mri_core/mri_core_dependencies.h
@@ -1,0 +1,30 @@
+
+/** \file   mri_core_dependencies.h
+    \brief  Implementation useful utility functionalities for MRI dependency scan handling
+    \author Hui Xue
+*/
+
+#pragma once
+
+#include "mri_core_export.h"
+#include "hoNDArray.h"
+#include "mri_core_data.h"
+#include "ismrmrd/xml.h"
+
+namespace Gadgetron
+{
+    /// data: [RO E1 E2 SLC PHS CON REP SET SEG AVE]
+
+    /// ismrmd_header : ismrmrd protocol
+    /// scc_array and body_array: surface coil and body coil data, can be empty
+    /// scc_header and body_header: acquisition header for surface coil and body coil data
+    /// filename: file full name to save the data
+    template <typename T> EXPORTMRICORE void save_dependency_data(const std::string& ismrmd_header, 
+        const hoNDArray<T>& scc_array, const ISMRMRD::AcquisitionHeader& scc_header, 
+        const hoNDArray<T>& body_array, const ISMRMRD::AcquisitionHeader& body_header,
+        const std::string& filename);
+
+    template <typename T> EXPORTMRICORE void load_dependency_data(const std::string& filename, 
+        std::string& ismrmd_header, hoNDArray<T>& scc_array, ISMRMRD::AcquisitionHeader& scc_header, 
+        hoNDArray<T>& body_array, ISMRMRD::AcquisitionHeader& body_header);
+}


### PR DESCRIPTION
add gadgets to save incoming coil map data or surface coil correction pre scan.

add default_measurement_dependencies_Noise_CoilSen_SCC.xml to allow process noise, saving coil map or scc dependency data

same naming convention like dependent noise is used. e.g. a saved SCC data is GadgetronSCCMap_41548_21533254_21533259_298

This PR will be used for further sense gadget and SCC gadget with generic chain.