### PR TITLE
[issue#448] set GADGETRON_INSTALL_CONFIG_PATH

### DIFF
--- a/cmake/FindGadgetron.cmake
+++ b/cmake/FindGadgetron.cmake
@@ -28,7 +28,7 @@ list(APPEND _check_list GADGETRON_LIB_DIR)
 
 set(GADGETRON_INSTALL_CONFIG_PATH  ${GADGETRON_HOME}/share/gadgetron/config)
 mark_as_advanced(GADGETRON_INSTALL_CONFIG_PATH)
-list(APPEND _check_list GADGETRON_LIB_DIR)
+list(APPEND _check_list GADGETRON_INSTALL_CONFIG_PATH)
 
 # Handle the QUIETLY and REQUIRED arguments and set FFTW_FOUND to TRUE if
 # all listed variables are TRUE

--- a/cmake/FindGadgetron.cmake
+++ b/cmake/FindGadgetron.cmake
@@ -26,6 +26,10 @@ set(GADGETRON_LIB_DIR ${GADGETRON_HOME}/lib)
 mark_as_advanced(GADGETRON_LIB_DIR)
 list(APPEND _check_list GADGETRON_LIB_DIR)
 
+set(GADGETRON_INSTALL_CONFIG_PATH  ${GADGETRON_HOME}/share/gadgetron/config)
+mark_as_advanced(GADGETRON_INSTALL_CONFIG_PATH)
+list(APPEND _check_list GADGETRON_LIB_DIR)
+
 # Handle the QUIETLY and REQUIRED arguments and set FFTW_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Set GADGETRON_INSTALL_CONFIG_PATH in FindGadgetron.cmake to enable installation of new libraries configuration file.