### PR TITLE
Gadgetron Matlab Related

### DIFF
--- a/apps/gadgetron/Gadget.h
+++ b/apps/gadgetron/Gadget.h
@@ -465,6 +465,20 @@ namespace Gadgetron{
     T max_;
     std::string limits_desc_;
   };
+
+
+
+
+	template<typename T> inline void GadgetProperty_extract_value(const char* val, T& tmp)
+{
+      std::stringstream(val) >> std::boolalpha >> tmp;
+}
+
+	template<> inline void GadgetProperty_extract_value(const char* val, std::string& tmp)
+{
+     tmp = std::string(val);
+}
+
   template <typename T, typename L> class GadgetProperty
   : public GadgetPropertyBase
   {
@@ -508,11 +522,11 @@ namespace Gadgetron{
         if (!is_reference_)
         {
           T tmp;
-          std::stringstream(val) >> std::boolalpha >> tmp;
-          this->value(tmp);
+//          std::stringstream(val) >> std::boolalpha >> tmp;
+      	  GadgetProperty_extract_value(val,tmp);
+	  this->value(tmp);
         }
       }
-
 
       bool operator==(const T &v) const
       {
@@ -524,11 +538,12 @@ namespace Gadgetron{
         return limits_.limits_description();
       }
 
-    protected:
+   protected:
       T value_;
       L limits_;
       Gadget* g_;
     };
+
     template <typename T, typename L> class GadgetProperty<std::vector<T>,L >
     : public GadgetPropertyBase
     {

--- a/gadgets/epi/CMakeLists.txt
+++ b/gadgets/epi/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(
 add_library(gadgetron_epi SHARED 
   EPIReconXGadget.h EPIReconXGadget.cpp
   EPICorrGadget.h EPICorrGadget.cpp
+  EPIPackNavigatorGadget.h EPIPackNavigatorGadget.cpp
   FFTXGadget.h FFTXGadget.cpp
   CutXGadget.h CutXGadget.cpp
   OneEncodingGadget.h OneEncodingGadget.cpp
@@ -38,6 +39,7 @@ target_link_libraries(
 install(FILES 
   EPIReconXGadget.h
   EPICorrGadget.h
+  EPIPackNavigatorGadget.h
   FFTXGadget.h
   gadgetron_epi_export.h
   DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH} COMPONENT main)

--- a/gadgets/epi/EPIPackNavigatorGadget.cpp
+++ b/gadgets/epi/EPIPackNavigatorGadget.cpp
@@ -1,0 +1,138 @@
+#include "EPIPackNavigatorGadget.h"
+#include "ismrmrd/xml.h"
+
+namespace Gadgetron{
+
+  EPIPackNavigatorGadget::EPIPackNavigatorGadget() {}
+  EPIPackNavigatorGadget::~EPIPackNavigatorGadget() {}
+
+int EPIPackNavigatorGadget::process_config(ACE_Message_Block* mb)
+{
+  ISMRMRD::IsmrmrdHeader h;
+  ISMRMRD::deserialize(mb->rd_ptr(),h);
+
+  if (h.encoding.size() == 0) {
+    GDEBUG("Number of encoding spaces: %d\n", h.encoding.size());
+    GDEBUG("This Gadget needs an encoding description\n");
+    return GADGET_FAIL;
+  }
+
+  // Get the encoding space and trajectory description
+  ISMRMRD::TrajectoryDescription traj_desc;
+
+  if (h.encoding[0].trajectoryDescription) {
+    traj_desc = *h.encoding[0].trajectoryDescription;
+  } else {
+    GDEBUG("Trajectory description missing");
+    return GADGET_FAIL;
+  }
+
+  if (traj_desc.identifier != "ConventionalEPI") {
+    GDEBUG("Expected trajectory description identifier 'ConventionalEPI', not found.");
+    return GADGET_FAIL;
+  }
+
+
+  for (std::vector<ISMRMRD::UserParameterLong>::iterator i (traj_desc.userParameterLong.begin()); i != traj_desc.userParameterLong.end(); ++i) {
+    if (i->name == "numberOfNavigators") {
+      numNavigators_ = i->value;
+    }
+  }
+
+  verboseMode_ = verboseMode.value();
+
+  navNumber_ = -1;
+  epiEchoNumber_ = -1;
+
+  return 0;
+}
+
+int EPIPackNavigatorGadget::process(
+          GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1,
+      GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2)
+{
+
+  //GDEBUG_STREAM("Nav: " << navNumber_ << "    " << "Echo: " << epiEchoNumber_ << std::endl);
+
+  // Get a reference to the acquisition header
+  ISMRMRD::AcquisitionHeader &hdr = *m1->getObjectPtr();
+
+  // Pass on the non-EPI data (e.g. FLASH Calibration)
+  if (hdr.encoding_space_ref > 0) {
+    // It is enough to put the first one, since they are linked
+    if (this->next()->putq(m1) == -1) {
+      m1->release();
+      GERROR("EPIPackNavigatorGadget::process, passing data on to next gadget");
+      return -1;
+    }
+    return 0;
+  }
+
+  // We have data from encoding space 0.
+
+  // Make an armadillo matrix of the data
+  arma::cx_fmat adata = as_arma_matrix(m2->getObjectPtr());
+
+  // Check to see if the data is a navigator line or an imaging line
+  if (hdr.isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_PHASECORR_DATA))
+  {
+
+    // Increment the navigator counter
+    navNumber_ += 1;
+
+    // If the number of navigators per shot is exceeded, then
+    // we are at the beginning of the next shot
+    if (navNumber_ == numNavigators_) {
+      navNumber_ = 0;
+      epiEchoNumber_ = -1;
+    }
+    
+    // If we are at the beginning of a shot, then initialize
+    if (navNumber_==0) {
+      // Set the size of the storage array
+      navdata_.set_size( adata.n_rows, hdr.active_channels, numNavigators_);
+    }
+
+    // Store the navigator data
+    navdata_.slice(navNumber_) = adata;
+  }
+  else // imaging line
+  {
+      // Increment the echo number
+      epiEchoNumber_ += 1;
+
+      // Pack navigators into the integer component (c.f. msb) of early epi echo float data
+      // I am assuming for early epi echoes that max(abs(adata)) < 0.5e-2
+      // Matlab eventually unpacks with the following code
+      //            navs=round(dat(:,:,1:3,:,:)); %% EPI data component < 0.5
+      //            dat(:,:,1:3,:,:)=(dat(:,:,1:3,:,:)-navs)*1e-2;
+      //            navs=navs*1e-6;
+
+      if(epiEchoNumber_ < numNavigators_)
+      {
+	adata=1.0e2*adata+arma::round(1.0e6*navdata_.slice(epiEchoNumber_));
+      }
+
+  }
+
+  // Pass on the imaging data
+  // TODO: this should be controlled by a flag
+  if (hdr.isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_PHASECORR_DATA)) {
+    m1->release();
+  } 
+  else {
+    // It is enough to put the first one, since they are linked
+    if (this->next()->putq(m1) == -1) {
+      m1->release();
+      GERROR("EPIPackNavigatorGadget::process, passing data on to next gadget");
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+GADGET_FACTORY_DECLARE(EPIPackNavigatorGadget)
+}
+
+

--- a/gadgets/epi/EPIPackNavigatorGadget.h
+++ b/gadgets/epi/EPIPackNavigatorGadget.h
@@ -1,0 +1,45 @@
+#ifndef EPIPACKNAVIGATORGADGET_H
+#define EPIPACKNAVIGATORGADGET_H
+
+#include "Gadget.h"
+#include "hoNDArray.h"
+#include "hoArmadillo.h"
+#include "gadgetron_epi_export.h"
+
+#include <ismrmrd/ismrmrd.h>
+#include <complex>
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+namespace Gadgetron{
+
+  class  EXPORTGADGETS_EPI EPIPackNavigatorGadget :
+  public Gadget2<ISMRMRD::AcquisitionHeader,hoNDArray< std::complex<float> > >
+    {
+    public:
+      EPIPackNavigatorGadget();
+      virtual ~EPIPackNavigatorGadget();
+
+    protected:
+      GADGET_PROPERTY(verboseMode, bool, "Verbose output", false);
+
+      virtual int process_config(ACE_Message_Block* mb);
+      virtual int process(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1,
+              GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2);
+
+      // in verbose mode, more info is printed out
+      bool verboseMode_;
+
+      arma::cx_fcube navdata_;
+
+      // epi parameters
+      int numNavigators_;
+
+      // for a given shot
+      int navNumber_;
+      int epiEchoNumber_;
+
+    };
+}
+#endif //EPIPACKNAVIGATORGADGET_H

--- a/gadgets/matlab/BaseBufferGadget.m
+++ b/gadgets/matlab/BaseBufferGadget.m
@@ -26,15 +26,16 @@ classdef BaseBufferGadget < handle
         function [imageQ,bufferQ] = run_process(g, recon_data)
             g.emptyQ();
             %% Convert headers
-            for n = 1:numel(recon_data)
-                recon_data(n).data.headers = ismrmrd.AcquisitionHeader(recon_data(n).data.headers);
-                if isfield(recon_data(n),'reference')
-                    if isstruct(recon_data(n).reference)
-                        recon_data(n).reference.headers = ismrmrd.AcquisitionHeader(recon_data(n).reference.headers);
-                    end
-                end
-            end
-            
+% % % % % % %             tic
+% % % % % % %             for n = 1:numel(recon_data)
+% % % % % % %                 recon_data(n).data.headers = ismrmrd.AcquisitionHeader(recon_data(n).data.headers);
+% % % % % % %                 if isfield(recon_data(n),'reference')
+% % % % % % %                     if isstruct(recon_data(n).reference)
+% % % % % % %                         recon_data(n).reference.headers = ismrmrd.AcquisitionHeader(recon_data(n).reference.headers);
+% % % % % % %                     end
+% % % % % % %                 end
+% % % % % % %             end
+% % % % % % %             fprintf(2,'%f',toc);
             %% Process data
             g.process(recon_data);
             
@@ -59,7 +60,7 @@ classdef BaseBufferGadget < handle
         
          function putBufferQ(g,data,reference)
              idx = length(g.bufferQ)+1;
-             g.bufferQ(idx).data = data;
+             g.bufferQ(idx).data = data.data;
              g.bufferQ(idx).data.headers = g.bufferQ(idx).data.headers.toBytes();
              if (exist('reference','var'))
                  g.bufferQ(idx).reference = reference;

--- a/gadgets/matlab/MatlabBufferGadget.h
+++ b/gadgets/matlab/MatlabBufferGadget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include "gadgetron_matlab_export.h"
 #include "Gadget.h"
 #include "gadgetron_paths.h"
@@ -7,7 +8,7 @@
 #include "ismrmrd/ismrmrd.h"
 #include "engine.h"     // Matlab Engine header
 
-#include "ace/Synch.h"  // For the MatlabCommandServer
+//#include "ace/Synch.h"  // For the MatlabCommandServer
 #include "ace/SOCK_Connector.h"
 #include "ace/INET_Addr.h"
 
@@ -17,13 +18,13 @@
 #include <complex>
 #include <boost/lexical_cast.hpp>
 #include "mri_core_data.h"
+
 // TODO:
-//Make the port option work so that we can have multiple matlabs running, each with its own command server.
 //Create a debug option to use evalstring and get back the matlab output on every function call.
 //Finish the image stuff
-//Is there a better way to kill the command server?
 //Test on windows
 
+extern std::mutex mutex_;
 
 namespace Gadgetron{
 
@@ -33,15 +34,48 @@ class MatlabBufferGadget:
 public:
     MatlabBufferGadget(): Gadget1<IsmrmrdReconData >()
     {
-        // Open the Matlab Engine on the current host
-        GDEBUG("Starting MATLAB engine\n");
-        if (!(engine_ = engOpen("matlab -nodesktop -nosplash"))) {
-            // TODO: error checking!
-            GDEBUG("Can't start MATLAB engine\n");
-        } else {
-            // Add ISMRMRD Java bindings jar to Matlab's path
-            // TODO: this should be in user's Matlab path NOT HERE
+    }
 
+    ~MatlabBufferGadget()
+    {
+    std::lock_guard<std::mutex> lock(mutex_);   
+       // Close the Matlab engine
+        GDEBUG("Closing down Matlab\n");
+        engClose(engine_);
+    }
+
+    virtual int process(GadgetContainerMessage<IsmrmrdReconData> *);
+
+protected:
+    GADGET_PROPERTY(debug_mode, bool, "Debug mode", false);
+    GADGET_PROPERTY(matlab_path, std::string, "Path to Matlab code", "");
+    GADGET_PROPERTY(matlab_classname, std::string, "Name of Matlab gadget class", "");
+    GADGET_PROPERTY(matlab_startcmd, std::string, "Matlab engine startup command", "matlab -nosplash");
+
+    int process_config(ACE_Message_Block* mb)
+    {
+    	std::lock_guard<std::mutex> lock(mutex_);   
+        std::string cmd;
+
+        debug_mode_  = debug_mode.value();
+        path_        = matlab_path.value();
+        classname_   = matlab_classname.value();
+	startcmd_    = matlab_startcmd.value();
+
+        if (classname_.empty()) {
+            GERROR("Missing Matlab Gadget classname in config!");
+            return GADGET_FAIL;
+        }
+
+        GDEBUG("MATLAB Class Name : %s\n", classname_.c_str());
+
+
+		// Open the Matlab Engine on the current host
+		GDEBUG("Starting MATLAB engine with command: %s\n", startcmd_.c_str());
+		if (!(engine_ = engOpen(startcmd_.c_str()))) {
+			// TODO: error checking!
+			GDEBUG("Can't start MATLAB engine\n");
+		} else {
             // Prepare a buffer for collecting Matlab's output
             char matlab_buffer_[2049] = "\0";
             engOutputBuffer(engine_, matlab_buffer_, 2048);
@@ -54,46 +88,19 @@ public:
 	    engEvalString(engine_, add_path_cmd.c_str());
             // ISMRMRD matlab library
             engEvalString(engine_, "addpath(fullfile(getenv('ISMRMRD_HOME'), '/share/ismrmrd/matlab'));");
-
+  
 	    GDEBUG("%s", matlab_buffer_);
         }
-    }
 
-    ~MatlabBufferGadget()
-    {
-        // Close the Matlab engine
-        GDEBUG("Closing down Matlab\n");
-        engClose(engine_);
-    }
 
-    virtual int process(GadgetContainerMessage<IsmrmrdReconData> *);
 
-protected:
-    GADGET_PROPERTY(debug_mode, bool, "Debug mode", false);
-    GADGET_PROPERTY(matlab_path, std::string, "Path to Matlab code", "");
-    GADGET_PROPERTY(matlab_classname, std::string, "Name of Matlab gadget class", "");
 
-    int process_config(ACE_Message_Block* mb)
-    {
-        std::string cmd;
-
-        debug_mode_  = debug_mode.value();
-        path_        = matlab_path.value();
-        classname_   = matlab_classname.value();
-        if (classname_.empty()) {
-            GERROR("Missing Matlab Gadget classname in config!");
-            return GADGET_FAIL;
-        }
-
-        GDEBUG("MATLAB Class Name : %s\n", classname_.c_str());
 
         //char matlab_buffer_[2049] = "\0";
         char matlab_buffer_[20481] = "\0";
         engOutputBuffer(engine_, matlab_buffer_, 20480);
 
-   	// Instantiate the Java Command server
-        // TODO: we HAVE to pause in Matlab to allow the java command server thread to start
-                // add user specified path for this gadget
+        // add user specified path for this gadget
         if (!path_.empty()) {
             cmd = "addpath('" + path_ + "');";
             send_matlab_command(cmd);
@@ -115,7 +122,6 @@ protected:
         }
 
 	mxDestroyArray(xmlstring);
-
         return GADGET_OK;
     }
 
@@ -125,7 +131,9 @@ protected:
             char matlab_buffer_[8193] = "\0";
             engOutputBuffer(engine_, matlab_buffer_, 8192);
             engEvalString(engine_, command.c_str());
+	    if (debug_mode_) {
             GDEBUG("%s\n", matlab_buffer_);
+	    }
             return GADGET_OK;
 
     }
@@ -133,6 +141,7 @@ protected:
 
     std::string path_;
     std::string classname_;
+    std::string startcmd_;
     bool debug_mode_;
 
     Engine *engine_;

--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.cpp
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.cpp
@@ -317,7 +317,10 @@ namespace Gadgetron{
 
     uint16_t espace = m1->getObjectPtr()->encoding_space_ref;
 
-    if (!ISMRMRD::FlagBit(ISMRMRD::ISMRMRD_ACQ_IS_PARALLEL_CALIBRATION).isSet(m1->getObjectPtr()->flags))
+    if (!(
+	  ISMRMRD::FlagBit(ISMRMRD::ISMRMRD_ACQ_IS_PARALLEL_CALIBRATION).isSet(m1->getObjectPtr()->flags) ||
+	  ISMRMRD::FlagBit(ISMRMRD::ISMRMRD_ACQ_IS_PHASECORR_DATA).isSet(m1->getObjectPtr()->flags)
+	))
       {
 	bucket->data_.push_back(d);
         if (bucket->datastats_.size() < (espace+1)) {

--- a/toolboxes/matlab/CMakeLists.txt
+++ b/toolboxes/matlab/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(
 )
 
 if (UNIX AND CUDA_FOUND)
-add_subdirectory(@gadgetron)
+#add_subdirectory(@gadgetron)
 endif()
 
 install(TARGETS gadgetron_toolbox_matlab DESTINATION lib COMPONENT main)

--- a/toolboxes/matlab/MatlabUtils.cpp
+++ b/toolboxes/matlab/MatlabUtils.cpp
@@ -735,12 +735,6 @@ template EXPORTMATLAB void MatlabToHoNDArray(mxArray * data, hoNDArray<double_co
 template EXPORTMATLAB void MatlabToHoNDArray(mxArray * data, hoNDArray<std::complex<float> >& a);
 template EXPORTMATLAB void MatlabToHoNDArray(mxArray * data, hoNDArray<std::complex<double> >& a);
 
-template EXPORTMATLAB hoNDArray<vector_td<float,1> > MatlabToHoNDArray<vector_td<float,1> >(mxArray *);
-template EXPORTMATLAB hoNDArray<vector_td<float,2> > MatlabToHoNDArray<vector_td<float,2> >(mxArray *);
-template EXPORTMATLAB hoNDArray<vector_td<float,3> > MatlabToHoNDArray<vector_td<float,3> >(mxArray *);
-template EXPORTMATLAB hoNDArray<vector_td<float,4> > MatlabToHoNDArray<vector_td<float,4> >(mxArray *);
-
-
 template EXPORTMATLAB mxArray* hoNDArrayToMatlab<vector_td<float,1> >(hoNDArray<vector_td<float,1> > *);
 template EXPORTMATLAB mxArray* hoNDArrayToMatlab<vector_td<float,2> >(hoNDArray<vector_td<float,2> > *);
 template EXPORTMATLAB mxArray* hoNDArrayToMatlab<vector_td<float,3> >(hoNDArray<vector_td<float,3> > *);


### PR DESCRIPTION
Here's a horrible, big pull request including several unrelated topics. I'm sorry but don't know how to break it down. The changes to different files are more or less independent modifications. Comments file by file, as follows:

apps/gadgetron/Gadget.h
All of these changes relate to issue #196.
Allowing multi word strings as gadget parameters.

gadgets/epi/CMakeLists.txt
gadgets/epi/EPIPackNavigatorGadget.h
gadgets/epi/EPIPackNavigatorGadget.cpp
New gadget for packing EPI reference navigator echoes into the epi echo train data.
Workaround for getting navigator data (and epi data) efficiently into Matlab using the existing MatlabBufferGadget. (For me would be better to have the navigator data passed independently, in an analogous manner to reference data.)

gadgets/matlab/BaseBufferGadget.m
Commented out slow header translation code. Headers were unnecessary for our applications. But speed was necessary(!)
Fix for accessing data. (Line 62/63).

gadgets/matlab/MatlabBufferGadget.cpp
Attempt to introduce mutex's for running multiple matlab gadgets in the same chain. Not sure if effective, but at least a single matlab gadget does work completely stably with this code for our applications.
Memory leak fix (Line 103/110).

gadgets/matlab/MatlabBufferGadget.h
Allow for Matlab startup command to be specified as gadget parameter. (Issue #196)

gadgets/mri_core/AcquisitionAccumulateTriggerGadget.cpp
Allow for embedded reference data for grappa. (Multi-echo flash application.)

toolboxes/matlab/CMakeLists.txt
toolboxes/matlab/MatlabUtils.cpp
Workaround for compilation errors related to commit 40618e433290bc3e8ca504d27d32dfc803ccb282