### PR TITLE
EPI navigator parameter filtering

### DIFF
--- a/gadgets/epi/EPICorrGadget.h
+++ b/gadgets/epi/EPICorrGadget.h
@@ -36,7 +36,7 @@ namespace Gadgetron{
                              "mean",
                              "linear",
                              "polynomial");
-      GADGET_PROPERTY(navigatorParameterFilterLength, int, "Number of repetitions to use to filter the navigator parameters (set to 0 or negative for no filtering)", 5);
+      GADGET_PROPERTY(navigatorParameterFilterLength, int, "Number of repetitions to use to filter the navigator parameters (set to 0 or negative for no filtering)", 0);
       GADGET_PROPERTY(navigatorParameterFilterExcludeVols, size_t, "Number of volumes/repetitions to exclude from the beginning of the run when filtering the navigator parameters (e.g., to take into account dummy acquisitions. Default: 0)", 0);
 
       virtual int process_config(ACE_Message_Block* mb);

--- a/gadgets/epi/EPICorrGadget.h
+++ b/gadgets/epi/EPICorrGadget.h
@@ -7,6 +7,7 @@
 #include "gadgetron_epi_export.h"
 
 #include <ismrmrd/ismrmrd.h>
+#include "ismrmrd/xml.h"
 #include <complex>
 
 #define _USE_MATH_DEFINES
@@ -23,6 +24,7 @@ namespace Gadgetron{
 
     protected:
       GADGET_PROPERTY(verboseMode, bool, "Verbose output", false);
+      GADGET_PROPERTY(referenceNavigatorNumber, size_t, "Navigator number to be used as reference, both for phase correction and weights for filtering (default=1 -- second navigator)", 1);
       GADGET_PROPERTY_LIMITS(B0CorrectionMode, std::string, "B0 correction mode", "mean",
                              GadgetPropertyLimitsEnumeration,
                              "none",
@@ -34,6 +36,8 @@ namespace Gadgetron{
                              "mean",
                              "linear",
                              "polynomial");
+      GADGET_PROPERTY(navigatorParameterFilterLength, int, "Number of repetitions to use to filter the navigator parameters (set to 0 or negative for no filtering)", 5);
+      GADGET_PROPERTY(navigatorParameterFilterExcludeVols, size_t, "Number of volumes/repetitions to exclude from the beginning of the run when filtering the navigator parameters (e.g., to take into account dummy acquisitions. Default: 0)", 0);
 
       virtual int process_config(ACE_Message_Block* mb);
       virtual int process(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1,
@@ -41,6 +45,17 @@ namespace Gadgetron{
 
       // in verbose mode, more info is printed out
       bool verboseMode_;
+
+      void init_arrays_for_nav_parameter_filtering( ISMRMRD::EncodingLimits e_limits );
+      float filter_nav_correction_parameter( hoNDArray<float>& nav_corr_param_array,
+					     hoNDArray<float>& weights_array,
+					     size_t exc,  // current excitation number (for this set and slice)
+					     size_t set,  // set of the array to filter (current one)
+					     size_t slc,  // slice of the array to filter (current one)
+					     size_t Nt,   // number of e2/timepoints/repetitions to filter
+					     bool   filter_in_complex_domain = false);
+      void increase_no_repetitions( size_t delta_rep );
+
 
       // --------------------------------------------------                                                             
       // variables for navigator parameter computation                                                                  
@@ -62,6 +77,24 @@ irst RO echo (used for B0 correction)
       int navNumber_;
       int epiEchoNumber_;
       bool startNegative_;
+
+      // --------------------------------------------------
+      // variables for navigator parameter filtering
+      // --------------------------------------------------
+
+      arma::fvec       t_;        // vector with repetition numbers, for navigator filtering
+      size_t           E2_;       // number of kspace_encoding_step_2
+      std::vector< std::vector<size_t> >  excitNo_;  // Excitation number (for each set and slice)
+
+      // arrays for navigator parameter filtering:
+
+      hoNDArray<float>    Nav_mag_;      // array to store the average navigator magnitude
+      //hoNDArray<float>    Nav_phi_;      // array to store the average navigator phase (for 3D or multi-shot imaging)
+      hoNDArray<float>    B0_slope_;     // array to store the B0-correction linear   term (for filtering)
+      hoNDArray<float>    B0_intercept_; // array to store the B0-correction constant term (for filtering)
+      hoNDArray<float>    OE_phi_slope_;     // array to store the Odd-Even phase-correction linear   term (for filtering)
+      hoNDArray<float>    OE_phi_intercept_; // array to store the Odd-Even phase-correction constant term (for filtering)
+      std::vector< hoNDArray<float> > OE_phi_poly_coef_;   // vector of arrays to store the polynomial coefficients for Odd-Even phase correction
 
     };
 }


### PR DESCRIPTION
I have included a new option for the EPICorrGadget: you can now filter the navigator parameters over repetitions to get a more robust navigator correction.

For now, the filtering is a weighted linear fit of the corresponding navigator parameter from the last few volumes.  The exact number of volumes to use for the filtering is a gadget property.  It can be set to zero (or a negative number) to turn the filtering off.  If you want to exclude a few initial volumes to allow for the reach of a steady state, you can specify that too.  The weights for the linear fit are the average (across coils and across the RO dimension) magnitude of one of the navigators.

In principle, because of noise in the data, our estimates of the navigator parameters (e.g., B0 mean and slope, Odd-Even correction mean phase, slope, etc.) will also be noisy.  To improve the estimate of the correction, we can smooth it over repetitions.

For example, the data for the epi_2d integration test correspond to a phantom, so we would expect the navigator parameters to stay the same, for a given slice, from repetition to repetition.  If anything, there would be a slow drift.

The following figure shows the mean B0 (in units of echo spacing^(-1)) for three different slices, estimated from the navigators, across repetitions.  There is a clear linear trend.

![image](https://cloud.githubusercontent.com/assets/3638026/21115640/3946591c-c080-11e6-949e-2d26c9d27e05.png)

If we filter the parameter (using two different filter lengths, one in red, the other in black), we obtain a smoother curve:

![image](https://cloud.githubusercontent.com/assets/3638026/21115672/671b2cbe-c080-11e6-9a6c-ab54a172fd4f.png)

The images themselves don't change much, and when we take the mean over repetitions, they look very much the same:

![navfilt_0vols_tmean](https://cloud.githubusercontent.com/assets/3638026/21115744/b549d78c-c080-11e6-8788-5ab69709dced.png)
![navfilt_5vols_tmean](https://cloud.githubusercontent.com/assets/3638026/21115751/bae6e342-c080-11e6-88ce-793ff289dc36.png)
![navfilt_10vols_tmean](https://cloud.githubusercontent.com/assets/3638026/21115770/ce450bda-c080-11e6-9dcb-242bbd0621b7.png)
(Temporal mean of the unfiltered images (top) and of the images after filtering over 5 (middle) or 10 (bottom) volumes).

However, when we look at the standard deviation over time, we find that the filtered images have a smaller std, indicating that the reconstruction is more stable:
![navfilt_0vols_tstd](https://cloud.githubusercontent.com/assets/3638026/21115952/75ff6cb2-c081-11e6-83a1-820621a78795.png)
![navfilt_5vols_tstd](https://cloud.githubusercontent.com/assets/3638026/21115845/09508eac-c081-11e6-8779-bbf2d41e3ab7.png)
![navfilt_tstd_0_minus_5](https://cloud.githubusercontent.com/assets/3638026/21115871/2b0d0174-c081-11e6-8dd7-576a577e7a77.png)
(Standard deviation over repetitions of the unfiltered images (top) and of the images after filtering over 5 volumes (middle).  The bottom row shows the difference std-of-the-unfiltered-images minus std-of-the-filtered-images).

The color image above show in red-yellow voxels with higher std for the unfiltered images and in blue-light blue to higher std for the filtered images.  As the dominant color is red, it shows that the filtered images are more stable.