### PR TITLE
Sanity checks for debug_folder

### DIFF
--- a/gadgets/mri_core/GenericReconBase.cpp
+++ b/gadgets/mri_core/GenericReconBase.cpp
@@ -1,5 +1,6 @@
 
 #include "GenericReconBase.h"
+#include <boost/filesystem.hpp>
 
 namespace Gadgetron {
 
@@ -22,6 +23,18 @@ namespace Gadgetron {
         {
             Gadgetron::get_debug_folder_path(debug_folder.value(), debug_folder_full_path_);
             GDEBUG_CONDITION_STREAM(verbose.value(), "Debug folder is " << debug_folder_full_path_);
+
+            // Create debug folder if necessary
+            boost::filesystem::path boost_folder_path(debug_folder_full_path_);
+            try
+            {
+                boost::filesystem::create_directories(boost_folder_path);
+            }
+            catch (...)
+            {
+                GERROR("Error creating the debug folder.\n");
+                return false;
+            }
         }
         else
         {

--- a/toolboxes/image_io/CMakeLists.txt
+++ b/toolboxes/image_io/CMakeLists.txt
@@ -33,7 +33,7 @@ set( image_io_src_files
 
 add_library(gadgetron_toolbox_image_analyze_io SHARED ${image_io_header_files} ${image_io_src_files} )
 set_target_properties(gadgetron_toolbox_image_analyze_io PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
-target_link_libraries(gadgetron_toolbox_image_analyze_io gadgetron_toolbox_log)
+target_link_libraries(gadgetron_toolbox_image_analyze_io gadgetron_toolbox_log ${Boost_LIBRARIES})
 
 install(TARGETS gadgetron_toolbox_image_analyze_io DESTINATION lib COMPONENT main)
 

--- a/toolboxes/image_io/ImageIOAnalyze.h
+++ b/toolboxes/image_io/ImageIOAnalyze.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "ImageIOBase.h"
+#include <boost/filesystem.hpp>
 
 // the file input/output utility functions for the Analyze format
 
@@ -130,6 +131,15 @@ public:
     {
         try
         {
+            // Check if folder exists
+            boost::filesystem::path boost_folder_path(filename);
+            boost_folder_path.remove_filename();
+            if ( !boost::filesystem::is_directory(boost_folder_path) )
+            {
+                GWARN_STREAM("Failed to write " << filename << " because parent folder does not exist");
+                return;
+            }
+
             HeaderType header;
             GADGET_CHECK_THROW(this->array_to_header(a, header));
             GADGET_CHECK_THROW(this->write_header(filename, header));


### PR DESCRIPTION
Summary: In GenericReconBase::process_config, create debug_folder if it doesn’t exist.  Also verify folder existence prior to writing files in ImageIOAnalyze.

Discussion: Boost is used to provide easy cross-platform I/O functions, but this also means that boost is required for mri_core.