### PR TITLE
Further map sd fix

### DIFF
--- a/toolboxes/cmr/cmr_parametric_mapping.cpp
+++ b/toolboxes/cmr/cmr_parametric_mapping.cpp
@@ -281,7 +281,7 @@ void CmrParametricMapping<T>::perform_parametric_mapping()
                     pMaskCurr = pMask + s*RO*E1 + slc*S*RO*E1;
                 }
 
-#pragma omp parallel private(e1, ro, n) shared(RO, E1, pMask, pMaskCurr, pData, pMap, pMapSD, pPara, pParaSD, num_ti, NUM)
+// #pragma omp parallel private(e1, ro, n) shared(RO, E1, pMask, pMaskCurr, pData, pMap, pMapSD, pPara, pParaSD, num_ti, NUM)
                 {
                     std::vector<T> yi(num_ti, 0);
                     std::vector<T> guess(NUM + 1, 0);
@@ -290,7 +290,7 @@ void CmrParametricMapping<T>::perform_parametric_mapping()
 
                     T map_v(0), map_sd(0);
 
-#pragma omp for 
+// #pragma omp for 
                     for (e1 = 0; e1 < E1; e1++)
                     {
                         for (ro = 0; ro < RO; ro++)
@@ -324,7 +324,19 @@ void CmrParametricMapping<T>::perform_parametric_mapping()
                             // compute SD if needed
                             if (this->compute_SD_maps_)
                             {
-                                this->compute_sd(ti_, yi, bi, sd, map_sd);
+                                try
+                                {
+                                    this->compute_sd(ti_, yi, bi, sd, map_sd);
+                                }
+                                catch(...)
+                                {
+                                    for (n = 0; n < NUM; n++)
+                                    {
+                                        sd[n] = 0;
+                                    }
+
+                                    map_sd = 0;
+                                }
 
                                 pMapSD[offset] = map_sd;
                                 for (n = 0; n < NUM; n++)

--- a/toolboxes/cmr/cmr_parametric_mapping.cpp
+++ b/toolboxes/cmr/cmr_parametric_mapping.cpp
@@ -281,7 +281,7 @@ void CmrParametricMapping<T>::perform_parametric_mapping()
                     pMaskCurr = pMask + s*RO*E1 + slc*S*RO*E1;
                 }
 
-// #pragma omp parallel private(e1, ro, n) shared(RO, E1, pMask, pMaskCurr, pData, pMap, pMapSD, pPara, pParaSD, num_ti, NUM)
+#pragma omp parallel private(e1, ro, n) shared(RO, E1, pMask, pMaskCurr, pData, pMap, pMapSD, pPara, pParaSD, num_ti, NUM)
                 {
                     std::vector<T> yi(num_ti, 0);
                     std::vector<T> guess(NUM + 1, 0);
@@ -290,7 +290,7 @@ void CmrParametricMapping<T>::perform_parametric_mapping()
 
                     T map_v(0), map_sd(0);
 
-// #pragma omp for 
+#pragma omp for 
                     for (e1 = 0; e1 < E1; e1++)
                     {
                         for (ro = 0; ro < RO; ro++)


### PR DESCRIPTION
for ill-posed data points, compute sd may throw exceptions; do not stop computation for these pixels.