### PR TITLE
Thread safe version of bart gadget (v2)

### DIFF
--- a/gadgets/bart/bartgadget.cpp
+++ b/gadgets/bart/bartgadget.cpp
@@ -174,6 +174,9 @@ namespace Gadgetron {
                 sscanf(threadId.c_str(), "%lx", &threadNumber);
                 outputFolderPath = workingDirectory.value() + "bart_" + time_id + "_" + std::to_string(threadNumber) + "/";
                 generatedFilesFolder = std::string(outputFolderPath);
+                
+		generatedFilesFolder.pop_back();
+	
 		boost::filesystem::path dir(generatedFilesFolder);
 		if (!boost::filesystem::exists(dir) || !boost::filesystem::is_directory(dir))
 			if (boost::filesystem::create_directories(dir))
@@ -182,6 +185,8 @@ namespace Gadgetron {
 				GERROR("Folder to store *.hdr & *.cfl files doesn't exist...\n");
 				return GADGET_FAIL;
 			}
+
+		generatedFilesFolder += "/";
 
 		/*USE WITH CAUTION*/
 		if (boost::filesystem::exists(generatedFilesFolder) && isBartFolderBeingCachedToVM.value() && !isBartFileBeingStored.value())


### PR DESCRIPTION
Added minor hack to circumvent the false-positive return boolean value of boost::filesystem::create_directories() version 1.58.0.1. 
Note: This bug was fixed in boost version 1.61.0 and higher