### PR TITLE
refine gadgetron python project creation; fix a return value missing …

### DIFF
--- a/gadgets/mri_core/RateLimitGadget.cpp
+++ b/gadgets/mri_core/RateLimitGadget.cpp
@@ -30,7 +30,7 @@ int RateLimitGadget::process(ACE_Message_Block* mb)
 
   mb->release();
 
-
+  return GADGET_OK;
 
 }
 

--- a/gadgets/python/CMakeLists.txt
+++ b/gadgets/python/CMakeLists.txt
@@ -20,6 +20,52 @@ include_directories(
   ${Boost_INCLUDE_DIR}
   )
 
+set(gadgetron_python_header_files 
+                            GadgetInstrumentationStreamController.h
+                            GadgetReference.h
+                            gadgetronpython_export.h
+                            PythonGadget.h )
+
+set(gadgetron_python_src_files GadgetronPythonMRI.cpp 
+                            GadgetReference.cpp 
+                            GadgetInstrumentationStreamController.cpp 
+                            PythonGadget.cpp )
+
+set(gadgetron_python_config_files 
+                            config/pseudoreplica.xml
+                            config/python.xml
+                            config/python_buckets.xml
+                            config/python_ideal_cg.xml
+                            config/python_short.xml
+                            config/python_tpat_snr_scale.xml )
+
+set(gadgetron_python_utils_files 
+                            utils/gadgetron_python_to_xml.py
+                            utils/gadgetron_run_python_chain.py
+                            utils/gadgetron_xml_to_python.py )
+
+set(gadgetron_python_gadgets_files 
+                            gadgets/accumulate_and_recon.py
+                            gadgets/bucket_recon.py
+                            gadgets/gadgetron.py
+                            gadgets/IDEAL.py
+                            gadgets/image_viewer.py
+                            gadgets/passthrough.py
+                            gadgets/pseudoreplicagather.py
+                            gadgets/remove_2x_oversampling.py
+                            gadgets/rms_coil_combine.py
+                            gadgets/tpat_snr_scale.py )
+
+set(gadgetron_python_examples_files 
+                            examples/mixed_gadgets.py
+                            examples/mixed_gadgets_gpu.py
+                            examples/pure_python_demo.py )
+
+source_group(config             FILES      ${gadgetron_python_config_files})
+source_group(utils              FILES      ${gadgetron_python_utils_files})
+source_group(gadgets            FILES      ${gadgetron_python_gadgets_files})
+source_group(examples           FILES      ${gadgetron_python_examples_files})
+
 add_library(GadgetronPythonMRI MODULE GadgetronPythonMRI.cpp 
   GadgetReference.cpp 
   GadgetInstrumentationStreamController.cpp)
@@ -28,10 +74,12 @@ add_library(GadgetronPythonMRI MODULE GadgetronPythonMRI.cpp
 #set_target_properties(GadgetronPythonMRI PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
 
 add_library(gadgetron_python SHARED
-	PythonGadget.cpp
-	GadgetReference.cpp
-	GadgetInstrumentationStreamController.cpp
-	GadgetronPythonMRI.cpp)
+    ${gadgetron_python_header_files}
+    ${gadgetron_python_src_files} 
+    ${gadgetron_python_config_files} 
+    ${gadgetron_python_utils_files} 
+    ${gadgetron_python_gadgets_files} 
+    ${gadgetron_python_examples_files} )
 
 set_target_properties(gadgetron_python PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
 

--- a/gadgets/python/GadgetronPythonMRI.cpp
+++ b/gadgets/python/GadgetronPythonMRI.cpp
@@ -8,7 +8,7 @@ using namespace boost::python;
 
 BOOST_PYTHON_MODULE(GadgetronPythonMRI)
 {
-    boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
+    // boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
 
     class_<Gadgetron::GadgetReference>("GadgetReference")
       .def("return_acquisition", &Gadgetron::GadgetReference::return_acquisition)

--- a/toolboxes/python/CMakeLists.txt
+++ b/toolboxes/python/CMakeLists.txt
@@ -10,10 +10,19 @@ include_directories(
     ${NUMPY_INCLUDE_DIRS}
     ${ACE_INCLUDE_DIR})
 
+set(gadgetron_toolbox_python_header_files python_converters.h
+                                        python_export.h
+                                        python_hoNDArray_converter.h
+                                        python_IsmrmrdReconData_converter.h
+                                        python_ismrmrd_converter.h
+                                        python_numpy_wrappers.h
+                                        python_toolbox.h
+                                        python_tuple_converter.h
+                                        python_vector_converter.h )
+
 add_library(gadgetron_toolbox_python SHARED
     python_toolbox.cpp
-    python_toolbox.h
-    python_export.h)
+    ${gadgetron_toolbox_python_header_files})
 
 target_link_libraries(gadgetron_toolbox_python
     gadgetron_toolbox_cpucore
@@ -32,13 +41,7 @@ endif ()
 install(TARGETS gadgetron_toolbox_python DESTINATION lib COMPONENT main)
 
 install(FILES
-    python_toolbox.h
-    python_converters.h
-    python_tuple_converter.h
-    python_hoNDArray_converter.h
-    python_ismrmrd_converter.h
-    python_numpy_wrappers.h
-    python_export.h
+    ${gadgetron_toolbox_python_header_files}
     DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH} COMPONENT main)
 
 add_subdirectory(example)


### PR DESCRIPTION
refine the python toolbox and gadget cmake file; so in IDE development, more files can be viewed and edited

fix a missing return value problem in gadgets/mri_core/RateLimitGadget.cpp