### PR TITLE
Remove obsolete property

### DIFF
--- a/gadgets/dicom/dicom.xml
+++ b/gadgets/dicom/dicom.xml
@@ -19,10 +19,6 @@
       <name>RemoveROOversampling</name>
         <dll>gadgetron_mricore</dll>
         <classname>RemoveROOversamplingGadget</classname>
-        <property>
-            <name>constant_noise_variance</name>
-            <value>false</value>
-        </property>
     </gadget>
 
     <gadget>


### PR DESCRIPTION
constant_noise_variance not deleted in dicom.xml yet - removed in all other xmls in previous commits