### PR TITLE
BART Gadget improvements

### DIFF
--- a/gadgets/bart/bartgadget.cpp
+++ b/gadgets/bart/bartgadget.cpp
@@ -476,6 +476,9 @@ namespace Gadgetron {
 		{
 			while (getline(inputFile, Line))
 			{
+				// crop comment
+				Line = Line.substr(0, Line.find_first_of("#"));
+
 				trim(Line);
 				if (Line.empty() || Line.compare(0, 4, "bart") != 0)
 					continue;

--- a/gadgets/bart/bartgadget.cpp
+++ b/gadgets/bart/bartgadget.cpp
@@ -111,6 +111,17 @@ namespace Gadgetron {
 	{
 		str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int s) {return !std::isspace(s); }));
 	}
+
+	inline void BartGadget::rtrim(std::string &str)
+	{
+		str.erase(std::find_if(str.rbegin(), str.rend(), [](int s) {return !std::isspace(s);}).base(), str.end());
+	}
+
+	inline void BartGadget::trim(std::string &str)
+	{
+		ltrim(str);
+		rtrim(str);
+	}
 	
 	void BartGadget::replace_default_parameters(std::string & str)
 	{
@@ -465,7 +476,7 @@ namespace Gadgetron {
 		{
 			while (getline(inputFile, Line))
 			{
-				ltrim(Line);
+				trim(Line);
 				if (Line.empty() || Line.compare(0, 4, "bart") != 0)
 					continue;
 				

--- a/gadgets/bart/bartgadget.h
+++ b/gadgets/bart/bartgadget.h
@@ -97,6 +97,8 @@ namespace Gadgetron {
 		std::string &getOutputFilename(const std::string &bartCommandLine);
 		void cleanup(std::string &createdFiles);
 		void ltrim(std::string &str);
+		void rtrim(std::string &str);
+		void trim(std::string &str);
 		void replace_default_parameters(std::string &str);
 	};
 


### PR DESCRIPTION
Hi,

working with the BART Gadget, I figured out two problems:

1. platform dependent line endings of the BART Shell Script (gadgets/bart/Sample_Grappa_Recon.sh) leads to wrong file names for BART. I am working on a Linux based machine, but the line endings of the script are Windows style, wich leads to the fact that BART tries to load files named e.g. "maps\r.cfl".
Trimming the command line in the Gadget from both sides solves the problem for me.

2. The command line interpreter in the BART Gadget does not cope with inline comments. This is especially important when the output filename is determined.
Cropping the line is a simple solution, but obviously does not handle cases like:
`\#no comment`
or
`"#nocomment"`

Best regards,
Fabian