### PR TITLE
Made Armadillo a non-optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,10 +235,9 @@ if (NOT GTEST_FOUND)
   endif ()
 endif ()
 
-find_package(Armadillo 4.600)
+find_package(Armadillo 4.600 REQUIRED)
 # check whether ILP64 MKL should is used
 if(ARMADILLO_FOUND)
-  add_definitions(-DUSE_ARMADILLO)
   set(ARMADILLO_BLAS_LONG_LONG FALSE)
   if(EXISTS "${ARMADILLO_INCLUDE_DIR}/armadillo_bits/config.hpp")
     # Read and parse armadillo config.hpp to find out whether BLAS uses long long
@@ -251,8 +250,7 @@ if(ARMADILLO_FOUND)
     endif ()
     unset(_armadillo_blas_long_long)
   endif()
-else()
-  message("Armadillo not found. This will disable many toolboxes and gadgets.")
+
 endif()
 
 find_package(HDF5 1.8 COMPONENTS C CXX HL REQUIRED)

--- a/toolboxes/core/cpu/math/hoArmadillo.h
+++ b/toolboxes/core/cpu/math/hoArmadillo.h
@@ -2,7 +2,6 @@
 #define ARMA_64BIT_WORD
 #include "hoNDArray.h"
 
-#ifdef USE_ARMADILLO
 
 #include <armadillo>
 
@@ -86,4 +85,4 @@ namespace Gadgetron{
     }
 }
 
-#endif // USE_ARMADILLO
+

--- a/toolboxes/core/cpu/math/hoNDArray_linalg.h
+++ b/toolboxes/core/cpu/math/hoNDArray_linalg.h
@@ -4,9 +4,9 @@
 #include "cpucore_math_export.h"
 #include "hoNDArray.h"
 
-#ifdef USE_ARMADILLO
-    #include "hoArmadillo.h"
-#endif // USE_ARMADILLO
+
+#include "hoArmadillo.h"
+
 
 #ifndef lapack_int
     #define lapack_int int


### PR DESCRIPTION
Gadgetron is mostly useless without Armadillo, and having explicit checks for Armadillo throughout results in surprising behaviour. This makes Armadillo required, and removes the redundant checks.