### PR TITLE
Fixing a leak and cleaning up GadgetStreamController configuration.

### DIFF
--- a/apps/gadgetron/GadgetStreamController.h
+++ b/apps/gadgetron/GadgetStreamController.h
@@ -41,8 +41,8 @@ private:
   WriterTask writer_task_;
   ACE_Reactor_Notification_Strategy notifier_;
   GadgetMessageReaderContainer readers_;
-  virtual int configure(std::string config_xml_string);
-  virtual int configure_from_file(std::string config_xml_filename);
+  virtual int configure(std::istream &config_file_stream);
+  virtual int configure_from_file(std::string filename);
 };
 
 }

--- a/apps/gadgetron/GadgetStreamInterface.h
+++ b/apps/gadgetron/GadgetStreamInterface.h
@@ -6,6 +6,7 @@
 #include "ace/DLL_Manager.h"
 
 #include "gadgetron_paths.h"
+#include "gadgetron_xml.h"
 #include "Gadget.h"
 
 typedef ACE_Module<ACE_MT_SYNCH> GadgetModule;
@@ -46,9 +47,9 @@ namespace Gadgetron {
       global_gadget_parameters_ = globalGadgetPara;
     }
 
-    std::string get_xml_configuration()
+    const GadgetronXML::GadgetStreamConfiguration& get_stream_configuration()
     {
-      return config_xml_;
+      return stream_configuration_;
     }
     
     template <class T>  T* load_dll_component(const char* DLL, const char* component_name)
@@ -108,7 +109,7 @@ namespace Gadgetron {
     std::vector<ACE_DLL_Handle*> dll_handles_;
     std::map<std::string, std::string> global_gadget_parameters_;
     std::string gadgetron_home_;
-    std::string config_xml_; //Copy of the original XML configuration
+    GadgetronXML::GadgetStreamConfiguration stream_configuration_;
 
     virtual GadgetModule * create_gadget_module(const char* DLL, const char* gadget, const char* gadget_module_name)
     {

--- a/apps/gadgetron/gadgetron_xml.cpp
+++ b/apps/gadgetron/gadgetron_xml.cpp
@@ -1,14 +1,16 @@
 #include "gadgetron_xml.h"
+#include "log.h"
 #include "pugixml.hpp"
 #include <stdexcept>
 #include <cstdlib>
+#include <iostream>
 
 namespace GadgetronXML
 {
-  void deserialize(const char* xml_config, GadgetronConfiguration& h)
+  void deserialize(std::istream& stream, GadgetronConfiguration& h)
   {
     pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load(xml_config);
+    pugi::xml_parse_result result = doc.load(stream);
     pugi::xml_node root = doc.child("gadgetronConfiguration");
 
     if (!root) {
@@ -58,10 +60,17 @@ namespace GadgetronXML
     }
   }
 
-  void deserialize(const char* xml_config, GadgetStreamConfiguration& cfg)
+  void deserialize(std::istream& stream, GadgetStreamConfiguration& cfg)
   {
     pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load(xml_config);
+    pugi::xml_parse_result result = doc.load(stream);
+
+
+    if (result.status != pugi::status_ok) {
+        GERROR("Loading config file failed with following error: %s (%d)\n", result.description(), result.status);
+        throw std::invalid_argument(result.description());
+    }
+
     pugi::xml_node root = doc.child("gadgetronStreamConfiguration");
 
     if (!root) {

--- a/apps/gadgetron/gadgetron_xml.h
+++ b/apps/gadgetron/gadgetron_xml.h
@@ -95,8 +95,8 @@ namespace GadgetronXML
     Optional<ReST> rest;
   };
 
-  void EXPORTGADGETBASE deserialize(const char* xml_config, GadgetronConfiguration& h);
-  
+  void EXPORTGADGETBASE deserialize(std::istream& stream, GadgetronConfiguration& h);
+
   struct Reader
   {
     unsigned short slot;
@@ -121,7 +121,7 @@ namespace GadgetronXML
     std::vector<Gadget> gadget;
   };
 
-  void EXPORTGADGETBASE deserialize(const char* xml, GadgetStreamConfiguration& cfg);
+  void EXPORTGADGETBASE deserialize(std::istream& stream, GadgetStreamConfiguration& cfg);
   void EXPORTGADGETBASE serialize(const GadgetStreamConfiguration& cfg, std::ostream& o);
 
 };

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -126,11 +126,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
   GadgetronXML::GadgetronConfiguration c;
   try
     {
-      std::ifstream t(gcfg.c_str());
-      std::string gcfg_text((std::istreambuf_iterator<char>(t)),
-			    std::istreambuf_iterator<char>());
-      
-      GadgetronXML::deserialize(gcfg_text.c_str(), c);
+      std::ifstream config_stream(gcfg.c_str());
+
+      GadgetronXML::deserialize(config_stream, c);
       ACE_OS_String::strncpy(port_no, c.port.c_str(), 1024);
 
       if (c.cloudBus) {

--- a/gadgets/distributed/DistributeGadget.h
+++ b/gadgets/distributed/DistributeGadget.h
@@ -5,6 +5,8 @@
 #include "gadgetron_distributed_gadgets_export.h"
 #include "GadgetronConnector.h"
 
+#include "gadgetron_xml.h"
+
 #include <complex>
 
 namespace Gadgetron{
@@ -57,7 +59,7 @@ namespace Gadgetron{
       return 0; //This is an invalid ID.
     }
 
-    const char* get_node_xml_config();
+    const GadgetronXML::GadgetStreamConfiguration& get_node_stream_configuration();
 
     Gadget* collect_gadget_;
 
@@ -65,7 +67,7 @@ namespace Gadgetron{
     ACE_Thread_Mutex mtx_;
 
   private:
-    std::string node_xml_config_;
+    GadgetronXML::GadgetStreamConfiguration node_stream_configuration_;
     std::string node_parameters_;
     std::map<int,GadgetronConnector*> node_map_;
     std::vector<GadgetronConnector*> closed_connectors_;


### PR DESCRIPTION
The buffer allocated on line 222 in GadgetStreamController.cpp has an unreachable matching delete. Config files read from the filesystem were leaked by every chain. 

Cleanup involves the use of streams over strings, and saving the deserialized object in stead of raw strings (avoids later re-deserialization).

Tested on Fedora 28. I had some trouble with some unrelated python test cases, but I'm not too concerned as they also fail when I test current master. 