### PR TITLE
Fixing ACE_Stream double-open memory leak.

### DIFF
--- a/apps/gadgetron/CMakeLists.txt
+++ b/apps/gadgetron/CMakeLists.txt
@@ -27,10 +27,12 @@ add_executable(gadgetron
   GadgetServerAcceptor.h
   GadgetServerAcceptor.cpp 
   GadgetStreamController.h
-  EndGadget.h 
+  EndGadget.h
+  EndGadget.cpp
+  GadgetStreamInterface.cpp
   Gadget.h 
   GadgetContainerMessage.h 
-  GadgetMessageInterface.h 
+  GadgetMessageInterface.h
   GadgetronExport.h 
   gadgetron_xml.h
   )
@@ -55,6 +57,8 @@ endif()
 
 add_executable(gadgetron_info
   gadgetron_info.cpp
+  EndGadget.cpp
+  GadgetStreamInterface.cpp
 )
 
 target_link_libraries(gadgetron_info 

--- a/apps/gadgetron/EndGadget.cpp
+++ b/apps/gadgetron/EndGadget.cpp
@@ -1,0 +1,43 @@
+
+#include "Gadget.h"
+#include "GadgetMessageInterface.h"
+#include "GadgetStreamInterface.h"
+
+#include "EndGadget.h"
+
+namespace Gadgetron {
+
+    int EndGadget::close(unsigned long flags)
+    {
+        GDEBUG("Close called in EndGadget with flags %d\n", flags);
+
+        GadgetContainerMessage<GadgetMessageIdentifier>* mb =
+                new GadgetContainerMessage<GadgetMessageIdentifier>();
+
+        mb->getObjectPtr()->id = GADGET_MESSAGE_CLOSE;
+
+        if (controller_->output_ready(mb) < 0) {
+            return GADGET_FAIL;
+        }
+
+        GDEBUG("Calling close in base class  with flags %d\n", flags);
+        return Gadget::close(flags);
+    }
+
+    int EndGadget::process(ACE_Message_Block *m)
+    {
+        m->release();
+        return 0;
+    }
+
+    int EndGadget::next_step(ACE_Message_Block *m)
+    {
+        m->release();
+        return 0;
+    }
+
+    int EndGadget::process_config(ACE_Message_Block * m) {
+        m->release();
+        return 0;
+    }
+}

--- a/apps/gadgetron/EndGadget.h
+++ b/apps/gadgetron/EndGadget.h
@@ -1,10 +1,3 @@
-/*
- * EndGadget.h
- *
- *  Created on: Nov 3, 2011
- *      Author: hansenms
- */
-
 #ifndef ENDGADGET_H_
 #define ENDGADGET_H_
 
@@ -12,44 +5,15 @@
 #include "GadgetMessageInterface.h"
 
 namespace Gadgetron{
-class EndGadget : public Gadget
-{
-	virtual int close(unsigned long flags)
-	{
-		GDEBUG("Close called in EndGadget with flags %d\n", flags);
+    class EndGadget : public Gadget
+    {
+        virtual int close(unsigned long flags);
 
-		GadgetContainerMessage<GadgetMessageIdentifier>* mb =
-				new GadgetContainerMessage<GadgetMessageIdentifier>();
-
-		mb->getObjectPtr()->id = GADGET_MESSAGE_CLOSE;
-
-		if (controller_->output_ready(mb) < 0) {
-			return GADGET_FAIL;
-		}
-
-		GDEBUG("Calling close in base class  with flags %d\n", flags);
-		return Gadget::close(flags);
-	}
-
-protected:
-	virtual int process(ACE_Message_Block *m)
-	{
-		m->release();
-		return 0;
-	}
-
-	virtual int next_step(ACE_Message_Block *m)
-	{
-		m->release();
-		return 0;
-	}
-
-	virtual int process_config(ACE_Message_Block * m) {
-		m->release();
-		return 0;
-	}
-
-};
+    protected:
+        virtual int process(ACE_Message_Block *m);
+        virtual int next_step(ACE_Message_Block *m);
+        virtual int process_config(ACE_Message_Block * m);
+    };
 }
 
 #endif /* ENDGADGET_H_ */

--- a/apps/gadgetron/GadgetServerAcceptor.cpp
+++ b/apps/gadgetron/GadgetServerAcceptor.cpp
@@ -5,6 +5,13 @@
 
 using namespace Gadgetron;
 
+GadgetServerAcceptor::GadgetServerAcceptor(std::map<std::string, std::string> parameters, ACE_Reactor *reactor) :
+    is_listening_(false),
+    global_gadget_parameters_(std::move(parameters))
+{
+    this->reactor(reactor);
+}
+
 GadgetServerAcceptor::~GadgetServerAcceptor ()
 {
   this->handle_close (ACE_INVALID_HANDLE, 0);
@@ -56,18 +63,17 @@ int GadgetServerAcceptor::handle_input (ACE_HANDLE)
 
   ACE_NEW_RETURN (controller, GadgetStreamController, -1);
 
-
   controller->set_global_gadget_parameters(global_gadget_parameters_);
 
   if (this->acceptor_.accept (controller->peer ()) == -1) {
     GERROR("Failed to accept controller connection\n"); 
+    delete controller;
     return -1;
   }
   
   controller->reactor (this->reactor ());
   if (controller->open () == -1)
     controller->handle_close (ACE_INVALID_HANDLE, 0);
-
   return 0;
 }
 

--- a/apps/gadgetron/GadgetServerAcceptor.h
+++ b/apps/gadgetron/GadgetServerAcceptor.h
@@ -11,6 +11,7 @@ namespace Gadgetron{
 class GadgetServerAcceptor : public ACE_Event_Handler
 {
 public:
+  GadgetServerAcceptor(std::map<std::string, std::string> parameters, ACE_Reactor *reactor = ACE_Reactor::instance());
   virtual ~GadgetServerAcceptor ();
 
   int open (const ACE_INET_Addr &listen_addr);

--- a/apps/gadgetron/GadgetStreamController.cpp
+++ b/apps/gadgetron/GadgetStreamController.cpp
@@ -58,22 +58,6 @@ int GadgetStreamController::open (void)
   readers_.insert(GADGET_MESSAGE_PARAMETER_SCRIPT,
 		  new GadgetMessageScriptReader());
 
-  GadgetModule *head = 0;
-  GadgetModule *tail = 0;
-
-  if (tail == 0) {
-    Gadget* eg = new EndGadget();
-    if (eg) {
-      eg->set_controller(this);
-    }
-		
-    ACE_NEW_RETURN(tail,
-		   ACE_Module<ACE_MT_SYNCH>( ACE_TEXT("EndGadget"),
-					     eg ),
-		   -1);
-
-    stream_.open(0,head,tail);
-  }
 
   this->writer_task_.open();
 

--- a/apps/gadgetron/GadgetStreamInterface.cpp
+++ b/apps/gadgetron/GadgetStreamInterface.cpp
@@ -1,0 +1,79 @@
+
+
+#include "ace/Stream.h"
+#include "ace/DLL.h"
+#include "ace/DLL_Manager.h"
+
+#include "gadgetron_paths.h"
+#include "gadgetron_xml.h"
+#include "Gadget.h"
+#include "EndGadget.h"
+
+#include "GadgetStreamInterface.h"
+
+namespace Gadgetron {
+
+    GadgetStreamInterface::GadgetStreamInterface()
+            : stream_configured_(false)
+            , stream_(nullptr, nullptr, default_end_module())
+    {
+        gadgetron_home_ = get_gadgetron_home();
+    }
+
+
+    Gadget* GadgetStreamInterface::find_gadget(std::string gadget_name)
+    {
+        GadgetModule* gm = stream_.find(gadget_name.c_str());
+
+        if (gm) {
+            Gadget* g = dynamic_cast<Gadget*>(gm->writer());
+            return g;
+        } else {
+            GDEBUG("Gadget with name %s not found! Returning null pointer\n", gadget_name.c_str());
+        }
+        return 0;
+    }
+
+    void GadgetStreamInterface::set_global_gadget_parameters(const std::map<std::string, std::string>& globalGadgetPara)
+    {
+        global_gadget_parameters_ = globalGadgetPara;
+    }
+
+    const GadgetronXML::GadgetStreamConfiguration& GadgetStreamInterface::get_stream_configuration()
+    {
+        return stream_configuration_;
+    }
+
+
+    GadgetModule *GadgetStreamInterface::create_gadget_module(const char* DLL, const char* gadget, const char* gadget_module_name)
+    {
+
+        Gadget* g = load_dll_component<Gadget>(DLL,gadget);
+
+        if (!g) {
+            GERROR("Failed to load gadget using factory\n");
+            return 0;
+        }
+
+        g->set_controller(this);
+
+        GadgetModule *module = 0;
+        ACE_NEW_RETURN (module,
+                        GadgetModule (gadget_module_name, g),
+                        0);
+
+        return module;
+    }
+
+    GadgetModule *GadgetStreamInterface::default_end_module(void)
+    {
+        Gadget *end_gadget = new EndGadget();
+        end_gadget->set_controller(this);
+
+        GadgetModule *end_module;
+        ACE_NEW_RETURN(end_module, GadgetModule(ACE_TEXT("EndGadget"), end_gadget), nullptr);
+
+        return end_module;
+    }
+}
+

--- a/apps/gadgetron/GadgetStreamInterface.h
+++ b/apps/gadgetron/GadgetStreamInterface.h
@@ -20,38 +20,16 @@ namespace Gadgetron {
   class GadgetStreamInterface
   {
   public:
-    GadgetStreamInterface()
-      : stream_configured_(false)
-    {  
-      gadgetron_home_ = get_gadgetron_home();
-    } 
+    GadgetStreamInterface();
 
     virtual int output_ready(ACE_Message_Block* mb) = 0;
 
-    virtual Gadget* find_gadget(std::string gadget_name)
-    {
-      GadgetModule* gm = stream_.find(gadget_name.c_str());
-      
-      if (gm) {
-	Gadget* g = dynamic_cast<Gadget*>(gm->writer());
-	return g;
-      } else {
-	GDEBUG("Gadget with name %s not found! Returning null pointer\n", gadget_name.c_str());
-      }
-      
-      return 0;
-    }
+    virtual Gadget* find_gadget(std::string gadget_name);
 
-    void set_global_gadget_parameters(const std::map<std::string, std::string>& globalGadgetPara)
-    {
-      global_gadget_parameters_ = globalGadgetPara;
-    }
+    void set_global_gadget_parameters(const std::map<std::string, std::string>& globalGadgetPara);
 
-    const GadgetronXML::GadgetStreamConfiguration& get_stream_configuration()
-    {
-      return stream_configuration_;
-    }
-    
+    const GadgetronXML::GadgetStreamConfiguration& get_stream_configuration();
+
     template <class T>  T* load_dll_component(const char* DLL, const char* component_name)
     {
       ACE_DLL_Manager* dllmgr = ACE_DLL_Manager::instance();
@@ -111,26 +89,10 @@ namespace Gadgetron {
     std::string gadgetron_home_;
     GadgetronXML::GadgetStreamConfiguration stream_configuration_;
 
-    virtual GadgetModule * create_gadget_module(const char* DLL, const char* gadget, const char* gadget_module_name)
-    {
+    virtual GadgetModule * create_gadget_module(const char* DLL, const char* gadget, const char* gadget_module_name);
 
-      Gadget* g = load_dll_component<Gadget>(DLL,gadget);
-      
-      if (!g) {
-	GERROR("Failed to load gadget using factory\n");
-	return 0;
-      }
-      
-      g->set_controller(this);
-      
-      GadgetModule *module = 0;
-      ACE_NEW_RETURN (module,
-		      GadgetModule (gadget_module_name, g),
-		      0);
-      
-      return module;
-    }
-
+  private:
+      GadgetModule *default_end_module(void);
   };
 }
 

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -257,14 +257,14 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   GINFO("Configuring services, Running on port %s\n", port_no);
 
+  auto reactor = ACE_Reactor::instance();
+
   ACE_INET_Addr port_to_listen (port_no);
-  GadgetServerAcceptor acceptor;
-  acceptor.global_gadget_parameters_ = gadget_parameters;
-  acceptor.reactor (ACE_Reactor::instance ());
+  GadgetServerAcceptor acceptor(gadget_parameters, reactor);
   if (acceptor.open (port_to_listen) == -1)
     return 1;
   
-  ACE_Reactor::instance()->run_reactor_event_loop ();
+  reactor->run_reactor_event_loop ();
 
   return 0;
 }

--- a/gadgets/python/GadgetInstrumentationStreamController.cpp
+++ b/gadgets/python/GadgetInstrumentationStreamController.cpp
@@ -28,23 +28,6 @@ namespace Gadgetron
   
   int GadgetInstrumentationStreamController::open()
   {
-    GadgetModule *head = 0;
-    GadgetModule *tail = 0;
-    
-    if (tail == 0) {
-      Gadget* eg = new EndGadget();
-      if (eg) {
-	eg->set_controller(this);
-      }
-      
-      ACE_NEW_RETURN(tail,
-		     ACE_Module<ACE_MT_SYNCH>( ACE_TEXT("EndGadget"),
-					       eg ),
-		     -1);
-      
-      stream_.open(0,head,tail);
-    }
-
     //Adding some gadgets to "capture data and return to the stream"
     if (this->prepend_gadget("ImageFinishFloat","gadgetron_mricore","ImageFinishGadget") != GADGET_OK) return GADGET_FAIL;
     this->find_gadget("ImageFinishFloat")->pass_on_undesired_data(true);


### PR DESCRIPTION
ACE_Stream no-arg constructor opened the stream in GadgetStreamInterface before we explicitly open it later. This double-open caused a leak of stream internals.

Fix involves refactoring code to use the stream constructor, in stead of explicit opens, to initialize the stream. 

Tested on Fedora 28, everything passes (at least the tests I have memory and GPU to run). 