### PR TITLE
Fixing GadgetStreamController zombie thread.

### DIFF
--- a/apps/gadgetron/GadgetStreamController.cpp
+++ b/apps/gadgetron/GadgetStreamController.cpp
@@ -61,7 +61,7 @@ int GadgetStreamController::open (void)
 
   this->writer_task_.open();
 
-  return this->activate( THR_NEW_LWP | THR_JOINABLE, 1);
+  return this->activate( THR_NEW_LWP | THR_DETACHED, 1);
 
 }
 


### PR DESCRIPTION
GadgetStreamController service thread marked as joinable, but never joined, leading to zombie threads.

Tested on Fedora 28; everything looks well. 