### PR TITLE
Kubernetes prerequisites

### DIFF
--- a/docker/kubernetes/.gitignore
+++ b/docker/kubernetes/.gitignore
@@ -1,0 +1,1 @@
+gadgetron-ssh-secret.yaml

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -32,12 +32,27 @@ kubectl apply -f gadgetron-clusterrole.yaml
 kubectl create clusterrolebinding service-reader-pod --clusterrole=service-reader --serviceaccount=default:default
 ```
 
+5. Deploy SSH jump server:
+
+See [https://github.com/kubernetes-contrib/jumpserver](https://github.com/kubernetes-contrib/jumpserver) for details.
+
+```bash
+SSHKEY=$(cat ~/.ssh/id_rsa.pub |base64 -w 0)
+sed "s/PUBLIC_KEY/$SSHKEY/" gadgetron-ssh-secret.yaml.tmpl > gadgetron-ssh-secret.yaml
+kubectl create -f gadgetron-ssh-secret.yaml
+kubectl apply -f gadgetron-ssh-jump-server.yaml
+```
+
 To Do:
 ------
 
-* Add SSH server pod.
+* Update SSH jump box:
+    * Internalize Dockerfile and other artifacts in Gadgetron repository
+    * Generate Gadgetron specific Docker image (Ubuntu)
+    * Set "UseDNS no" in /etc/ssh/sshd_config to avoid slow login
 * Shared storage for dependencies (Azure Files)
 * Enable horizontal pod scaling
+    * Define resource requirements for the pods
 * Enable cluster scaling
 
 

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -1,0 +1,43 @@
+Gadgetron in Kubernetes
+=======================
+
+*NOTE* Support for running Gadgetron in Kubernetes is not fully supported. 
+
+The `CloudBus`, will utilize the [`gadgetron_kubernetes_node_info.sh`](gadgetron_kubernetes_node_info.sh) to make a list of available nodes and currently active recons on each node. This list is stored in file and consumed by the cloudbus when returning a list of nodes. 
+
+The [`gadgetron_kubernetes_prestop.sh`](gadgetron_kubernetes_prestop.sh) script is used as a PreStop lifecycle hook by Kubernetes. 
+
+Deployment Instructions
+-----------------------
+
+1. Set up Kubernets cluster 
+
+(TODO: Add detailed instructions)
+
+2. Deploy gadgetron kubernetes:
+
+```
+kubectl apply -f gadgetron_kubernetes.yaml
+```
+
+3. Create a cluster role to allow quering services information from the containers:
+
+```
+kubectl apply -f gadgetron-clusterrole.yaml
+```
+
+4. Create clusterrole binding
+
+```
+kubectl create clusterrolebinding service-reader-pod --clusterrole=service-reader --serviceaccount=default:default
+```
+
+To Do:
+------
+
+* Add SSH server pod.
+* Shared storage for dependencies (Azure Files)
+* Enable horizontal pod scaling
+* Enable cluster scaling
+
+

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -10,14 +10,12 @@ The [`gadgetron_kubernetes_prestop.sh`](gadgetron_kubernetes_prestop.sh) script 
 Deployment Instructions
 -----------------------
 
-1. Set up Kubernets cluster 
-
-(TODO: Add detailed instructions)
+1. Set up Kubernets cluster in Azure using `acs-engine`. See [detailed instructions](acs-engine/README.md).
 
 2. Deploy gadgetron kubernetes:
 
 ```
-kubectl apply -f gadgetron_kubernetes.yaml
+kubectl apply -f gadgetron-kubernetes.yaml
 ```
 
 3. Create a cluster role to allow quering services information from the containers:
@@ -37,9 +35,14 @@ kubectl create clusterrolebinding service-reader-pod --clusterrole=service-reade
 See [https://github.com/kubernetes-contrib/jumpserver](https://github.com/kubernetes-contrib/jumpserver) for details.
 
 ```bash
+#Get an SSH key, here we are using the one for the current user
 SSHKEY=$(cat ~/.ssh/id_rsa.pub |base64 -w 0)
 sed "s/PUBLIC_KEY/$SSHKEY/" gadgetron-ssh-secret.yaml.tmpl > gadgetron-ssh-secret.yaml
+
+#Create a secret with the key
 kubectl create -f gadgetron-ssh-secret.yaml
+
+#Deploy the jump server
 kubectl apply -f gadgetron-ssh-jump-server.yaml
 ```
 

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -1,9 +1,15 @@
 Gadgetron in Kubernetes
 =======================
 
-*NOTE* Support for running Gadgetron in Kubernetes is not fully supported. 
+This folder contains a first initial setup for running a distributed Gadgetron in a Kubernetes cluster in Azure. 
 
-The `CloudBus`, will utilize the [`gadgetron_kubernetes_node_info.sh`](gadgetron_kubernetes_node_info.sh) to make a list of available nodes and currently active recons on each node. This list is stored in file and consumed by the cloudbus when returning a list of nodes. 
+*Note: This is only an initial implementation and some tuning and adjustment will be needed for scaling parameters, etc.*
+
+The setup uses [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to adjust the number of Gadgetron instances (pods) running in the cluster in response to cpu utilizaion and it uses [cluster-autoscaling](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to adjust the number of nodes. Specifically, an increase in cpu utilization will lead to the deployment of more Gadgetron instances and when the resources on existing nodes are exhausted more will be added. Idle nodes will be removed from the cluster after some idle time. 
+
+Shared files (dependencies and exported data) are stored in [Azure Files](https://azure.microsoft.com/en-us/services/storage/files/).
+
+Within the Gadgetron, the `CloudBus`, which is responsible for being aware of other Gadgetron instances in the cluser, will utilize the [`gadgetron_kubernetes_node_info.sh`](gadgetron_kubernetes_node_info.sh) to make a list of available instances and currently active recons on each node. This list is stored in file and consumed by the `CloudBus` when returning a list of nodes. 
 
 The [`gadgetron_kubernetes_prestop.sh`](gadgetron_kubernetes_prestop.sh) script is used as a PreStop lifecycle hook by Kubernetes. 
 
@@ -12,46 +18,59 @@ Deployment Instructions
 
 1. Set up Kubernets cluster in Azure using `acs-engine`. See [detailed instructions](acs-engine/README.md).
 
-2. Deploy gadgetron kubernetes:
+2. Create shared storage for dependencies and data. Use the convenience script [`create_shared_storage.sh`](create_shared_storage.sh):
+
+    ```bash
+    ./create_shared_storage.sh
+    ```
+
+    Or if you would like to specify the resource group, storage account name and location:
+
+    ```bash
+    ./create_shared_storage.sh -r mygroup -a mystorageaccountname -l eastus
+    ```
+
+3. Deploy gadgetron kubernetes:
+
+    ```
+    kubectl apply -f gadgetron-kubernetes.yaml
+    ```
+
+4. Create a cluster role to allow quering services information from the containers:
+
+    ```
+    kubectl apply -f gadgetron-clusterrole.yaml
+    ```
+
+5. Create clusterrole binding
+
+    ```
+    kubectl create clusterrolebinding service-reader-pod --clusterrole=service-reader --serviceaccount=default:default
+    ```
+
+6. Deploy SSH jump server:
+
+    See [https://github.com/kubernetes-contrib/jumpserver](https://github.com/kubernetes-contrib/jumpserver) for details.
+
+    ```bash
+    #Get an SSH key, here we are using the one for the current user
+    SSHKEY=$(cat ~/.ssh/id_rsa.pub |base64 -w 0)
+    sed "s/PUBLIC_KEY/$SSHKEY/" gadgetron-ssh-secret.yaml.tmpl > gadgetron-ssh-secret.yaml
+
+    #Create a secret with the key
+    kubectl create -f gadgetron-ssh-secret.yaml
+
+    #Deploy the jump server
+    kubectl apply -f gadgetron-ssh-jump-server.yaml
+    ```
+
+Updates and Maintenance
+-----------------------
+
+If you need to update the version (Docker image) for the Gadgetron, simply edit the [`gadgetron-kubernetes.yaml`](gadgetron-kubernetes.yaml) to change the image name and reapply:
 
 ```
 kubectl apply -f gadgetron-kubernetes.yaml
 ```
 
-3. Create a cluster role to allow quering services information from the containers:
-
-```
-kubectl apply -f gadgetron-clusterrole.yaml
-```
-
-4. Create clusterrole binding
-
-```
-kubectl create clusterrolebinding service-reader-pod --clusterrole=service-reader --serviceaccount=default:default
-```
-
-5. Deploy SSH jump server:
-
-See [https://github.com/kubernetes-contrib/jumpserver](https://github.com/kubernetes-contrib/jumpserver) for details.
-
-```bash
-#Get an SSH key, here we are using the one for the current user
-SSHKEY=$(cat ~/.ssh/id_rsa.pub |base64 -w 0)
-sed "s/PUBLIC_KEY/$SSHKEY/" gadgetron-ssh-secret.yaml.tmpl > gadgetron-ssh-secret.yaml
-
-#Create a secret with the key
-kubectl create -f gadgetron-ssh-secret.yaml
-
-#Deploy the jump server
-kubectl apply -f gadgetron-ssh-jump-server.yaml
-```
-
-To Do:
-------
-
-* Shared storage for dependencies (Azure Files)
-* Enable horizontal pod scaling
-    * Define resource requirements for the pods
-* Enable cluster scaling
-
-
+The new image will be applied as a rolling update keeping the cluster Gadgetron cluster running throughout the deployment process. 

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -64,6 +64,22 @@ Deployment Instructions
     kubectl apply -f gadgetron-ssh-jump-server.yaml
     ```
 
+Connecting with SSH to the jump server
+--------------------------------------
+
+The jump sever enables the "standard" Gadgetron connection paradigm through an SSH tunnel. The Gadgetron instances themselves are not directly accessible. Discover the relvant IPs and open a tunnel with:
+
+```bash
+#Public (external) IP:
+EXTERNALIP=$(kubectl get svc sshd-jumpserver-svc --output=json | jq -r .status.loadBalancer.ingress[0].ip)
+
+#Internal (cluster) IP:
+GTCLUSTERIP=$(kubectl get svc gadgetron-frontend --output=json | jq -r .spec.clusterIP)
+
+#Open tunnel:
+ssh -L 9022:${GTCLUSTERIP}:9002 root@${EXTERNALIP}
+```
+
 Updates and Maintenance
 -----------------------
 

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -46,10 +46,6 @@ kubectl apply -f gadgetron-ssh-jump-server.yaml
 To Do:
 ------
 
-* Update SSH jump box:
-    * Internalize Dockerfile and other artifacts in Gadgetron repository
-    * Generate Gadgetron specific Docker image (Ubuntu)
-    * Set "UseDNS no" in /etc/ssh/sshd_config to avoid slow login
 * Shared storage for dependencies (Azure Files)
 * Enable horizontal pod scaling
     * Define resource requirements for the pods

--- a/docker/kubernetes/acs-engine/.gitignore
+++ b/docker/kubernetes/acs-engine/.gitignore
@@ -1,0 +1,3 @@
+_output/
+converted.json
+translations/

--- a/docker/kubernetes/acs-engine/README.md
+++ b/docker/kubernetes/acs-engine/README.md
@@ -35,7 +35,7 @@ sp=$(az ad sp create-for-rbac --role contributor --scopes $rgid)
 Convert API Template
 --------------------
 
-The acs-engine ([acs-engine project](https://github.com/Azure/acs-engine)) api model needs to be populated with details, e.g. service principle, etc. In this repository, there is a [script](convert-api.sh) for that. You can use it like this:
+The acs-engine ([acs-engine project](https://github.com/Azure/acs-engine)) api model contains the definition of the cluster. You can edit the node vm types, etc., in the file [`kubernetes.json`](kubernetes.json). The file also needs to be populated with details, e.g. service principle, etc. In this repository, there is a [script](convert-api.sh) for that. You can use it like this:
 
 ```bash
 ./convert-api.sh -c $(echo $sp | jq -r .appId) \

--- a/docker/kubernetes/acs-engine/README.md
+++ b/docker/kubernetes/acs-engine/README.md
@@ -1,0 +1,86 @@
+Azure Kubernetes cluster for Gadgetron using `acs-engine`
+=========================================================
+
+This describes how to deploy a Kubernetes cluster in Azure using the [acs-engine](https://github.com/Azure/acs-engine)).
+
+The cluster will be deployed with cluster autoscaling enabled.
+
+In order to follow the instructions you need to have:
+
+* Bash shell (Linux or Linux subsystem in Windows)
+* Azure CLI 2.0
+* jq
+* git
+
+Rsource Group And Service Principal
+------------------------------------
+
+Make sure you are logged in with the Azure CLI and you have selected the subscription you would like to use. 
+
+```bash
+subscription=$(az account show | jq -r .id)
+
+#Name and Location
+rgname=gtkubernetes
+loc=eastus
+
+#Create Group
+rg=$(az group create --name $rgname --location $loc)
+rgid=$(echo $rg | jq -r .id)
+
+#Create the Service Principal and assign as contributor on group
+sp=$(az ad sp create-for-rbac --role contributor --scopes $rgid)
+```
+
+Convert API Template
+--------------------
+
+The acs-engine ([acs-engine project](https://github.com/Azure/acs-engine)) api model needs to be populated with details, e.g. service principle, etc. In this repository, there is a [script](convert-api.sh) for that. You can use it like this:
+
+```bash
+./convert-api.sh -c $(echo $sp | jq -r .appId) \
+-s $(echo $sp | jq -r .password) -f kubernetes.json -l $loc \
+-d myGadgetronClusterDNS | jq -M . > converted.json
+```
+
+This will take the file `kubernetes.json` and convert it to `converted.json` with the details added. 
+
+
+Deploying the cluster
+---------------------
+
+Last step is to deploy the cluster (per the `converted.json` definition):
+
+```bash
+acs-engine deploy --api-model converted.json \
+--subscription-id $subscription --resource-group $rgname \
+--location $loc --azure-env AzurePublicCloud
+```
+
+You will be prompted to perform device login with a browser. After authentication, the ARM deployment will start.
+
+Scaling the cluster
+--------------------
+
+If you need to "manually" rescale the cluster:
+
+```bash
+acs-engine scale --subscription-id $subscription \
+    --resource-group $rgname  --location $loc \
+    --deployment-dir _output/myGadgetronClusterDNS --new-node-count 1 \
+    --node-pool agentpool1 --master-FQDN myGadgetronClusterDNS.eastus.cloudapp.azure.com
+```
+
+Accessing Web Dashboard
+------------------------
+
+Kubernetes has a nice Web Dashboard (if installed). To access it, open a proxy:
+
+```bash
+kubectl proxy
+```
+
+Then open `http://localhost:PROXY-PORT/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/` in your browser. 
+
+You will need a token to access it. There is a script, [`get-token.sh`](get-token.sh), which will print a token in most cases.
+

--- a/docker/kubernetes/acs-engine/convert-api.sh
+++ b/docker/kubernetes/acs-engine/convert-api.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+FILENAME="kubernetes.json"
+DNSPREFIX="mycluster"
+LOCATION="eastus"
+CLIENTID=""
+CLIENTSECRET=""
+SSHKEY=""
+if [[ -f ~/.ssh/id_rsa.pub ]]; then
+    SSHKEY=$(cat ~/.ssh/id_rsa.pub)
+fi 
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -f|--file)
+    FILENAME="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -d|--dns-prefix)
+    DNSPREFIX="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -c|--client-id)
+    CLIENTID="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -s|--client-secret)
+    CLIENTSECRET="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -k|--ssh-key)
+    SSHKEY="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -l|--location)
+    LOCATION="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    echo "Unknown argument $1"
+    exit 1
+    ;;
+esac
+done
+
+
+[[ -z $CLIENTID ]] && echo "Please provide Client ID" && exit 1
+[[ -z $CLIENTSECRET ]] && echo "Please provide Client Secret" && exit 1
+[[ -z $SSHKEY ]] && echo "Please provide SSH Key" && exit 1
+
+json=$(cat $FILENAME)
+
+json=$(echo $json | jq ".location = \"${LOCATION}\"")
+json=$(echo $json | jq ".properties.masterProfile.dnsPrefix = \"${DNSPREFIX}\"")
+json=$(echo $json | jq ".properties.servicePrincipalProfile.clientId = \"${CLIENTID}\"")
+json=$(echo $json | jq ".properties.servicePrincipalProfile.secret = \"${CLIENTSECRET}\"")
+json=$(echo $json | jq ".properties.linuxProfile.ssh.publicKeys[0].keyData = \"${SSHKEY}\"")
+
+#Checking to see if we are deploying a jumpbox, in which case we should set the SSH key
+jbkey=$(echo $json | jq -r ".properties.orchestratorProfile.kubernetesConfig.privateCluster.jumpboxProfile.publicKey")
+
+if [ -z "$jbkey" ]; then
+    json=$(echo $json | jq ".properties.orchestratorProfile.kubernetesConfig.privateCluster.jumpboxProfile.publicKey = \"${SSHKEY}\"")
+fi
+
+echo $json

--- a/docker/kubernetes/acs-engine/get-token.sh
+++ b/docker/kubernetes/acs-engine/get-token.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+secret=$(kubectl -n kube-system get secrets | awk '/clusterrole-aggregation-controller/ {print $1}')
+kubectl -n kube-system describe secrets $secret | awk '/token:/ {print $2}'

--- a/docker/kubernetes/acs-engine/kubernetes.json
+++ b/docker/kubernetes/acs-engine/kubernetes.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "vlabs",
+  "location": "eastus",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.10",
+      "kubernetesConfig": {
+        "useManagedIdentity": false,
+        "addons": [
+          {
+            "name": "cluster-autoscaler",
+            "enabled": true,
+            "config": {
+              "minNodes": "1",
+              "maxNodes": "10"
+            }
+          }
+        ]
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 1,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/docker/kubernetes/create_shared_storage.sh
+++ b/docker/kubernetes/create_shared_storage.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Change these four parameters
+STORAGE_ACCOUNT_NAME=gadgetronstorage$RANDOM
+RESOURCE_GROUP=gadgetronstorage
+LOCATION=eastus
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -a|--storage-account-name)
+    STORAGE_ACCOUNT_NAME="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -r|--resource-group-name)
+    RESOURCE_GROUP="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -l|--location)
+    LOCATION="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    echo "Unknown argument $1"
+    exit 1
+    ;;
+esac
+done
+
+# Create the Resource Group
+az group create --name $RESOURCE_GROUP --location $LOCATION
+
+# Create the storage account
+az storage account create -n $STORAGE_ACCOUNT_NAME -g $RESOURCE_GROUP -l $LOCATION --sku Standard_LRS
+
+# Export the connection string as an environment variable, this is used when creating the Azure file share
+export AZURE_STORAGE_CONNECTION_STRING=`az storage account show-connection-string -n $STORAGE_ACCOUNT_NAME -g $RESOURCE_GROUP -o tsv`
+
+# Create the file shares
+az storage share create -n "gtdependencies"
+az storage share create -n "gtdata"
+
+# Get storage account key
+STORAGE_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP --account-name $STORAGE_ACCOUNT_NAME --query "[0].value" -o tsv)
+
+# Echo storage account name and key
+echo Storage account name: $STORAGE_ACCOUNT_NAME
+echo Storage account key: $STORAGE_KEY
+
+#Create Kubernetes secret for storage
+kubectl create secret generic azure-gtstorage-secret --from-literal=azurestorageaccountname=$STORAGE_ACCOUNT_NAME --from-literal=azurestorageaccountkey=$STORAGE_KEY

--- a/docker/kubernetes/gadgetron-clusterrole.yaml
+++ b/docker/kubernetes/gadgetron-clusterrole.yaml
@@ -1,0 +1,9 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: service-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["services", "pods", "endpoints"]
+  verbs: ["get", "watch", "list"]

--- a/docker/kubernetes/gadgetron-kubernetes.yaml
+++ b/docker/kubernetes/gadgetron-kubernetes.yaml
@@ -17,11 +17,12 @@ spec:
     spec:
       containers:
       - name: gadgetron
-        image: gadgetron/ubuntu_1804_no_cuda:latest
+        image: hansenms/gadgetron_ubuntu1804_no_cuda:kub1
         command: ["gadgetron"]
-        preStop:
-        exec:
-          command: ["bash","-C","/opt/code/gadgetron/docker/kubernetes/gadgetron_kubernetes_prestop.sh"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["bash","-C","/opt/code/gadgetron/docker/kubernetes/gadgetron_kubernetes_prestop.sh"]
         ports:
         - containerPort: 9002
         - containerPort: 9080

--- a/docker/kubernetes/gadgetron-kubernetes.yaml
+++ b/docker/kubernetes/gadgetron-kubernetes.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
       - name: gadgetron
         image: hansenms/gadgetron_ubuntu1804_no_cuda:kub1
+        resources:
+          requests:
+            cpu: 500m
         command: ["gadgetron"]
         lifecycle:
           preStop:
@@ -27,6 +30,19 @@ spec:
         - containerPort: 9002
         - containerPort: 9080
       terminationGracePeriodSeconds: 600
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gadgetron-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: gadgetron-service
+  minReplicas: 1
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 5
 ---
 apiVersion: v1
 kind: Service

--- a/docker/kubernetes/gadgetron-kubernetes.yaml
+++ b/docker/kubernetes/gadgetron-kubernetes.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: gadgetron-service
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: gadgetron-service
+    spec:
+      containers:
+      - name: gadgetron
+        image: gadgetron/ubuntu_1804_no_cuda:latest
+        command: ["gadgetron"]
+        preStop:
+        exec:
+          command: ["bash","-C","/opt/code/gadgetron/docker/kubernetes/gadgetron_kubernetes_prestop.sh"]
+        ports:
+        - containerPort: 9002
+        - containerPort: 9080
+      terminationGracePeriodSeconds: 600
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gadgetron-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: gadgetron-service
+  ports:
+    - name: gadgetron
+      protocol: TCP
+      port: 9002
+      targetPort: 9002

--- a/docker/kubernetes/gadgetron-kubernetes.yaml
+++ b/docker/kubernetes/gadgetron-kubernetes.yaml
@@ -29,7 +29,23 @@ spec:
         ports:
         - containerPort: 9002
         - containerPort: 9080
+        volumeMounts:
+        - mountPath: "/tmp/gadgetron"
+          name: gtdependencies
+        - mountPath: "/tmp/gadgetron_data"
+          name: gtdata
       terminationGracePeriodSeconds: 600
+      volumes:
+      - name: gtdependencies
+        azureFile:
+          secretName: azure-gtstorage-secret
+          shareName: gtdependencies
+          readOnly: false
+      - name: gtdata
+        azureFile:
+          secretName: azure-gtstorage-secret
+          shareName: gtdata
+          readOnly: false
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/docker/kubernetes/gadgetron-ssh-jump-server.yaml
+++ b/docker/kubernetes/gadgetron-ssh-jump-server.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: sshd-jumpserver
-        image: kubernetesio/sshd-jumpserver
+        image: hansenms/gadgetron_ssh_jumpserver
         ports:
           - containerPort: 22
         env:

--- a/docker/kubernetes/gadgetron-ssh-jump-server.yaml
+++ b/docker/kubernetes/gadgetron-ssh-jump-server.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: sshd-jumpserver-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sshd-jumpserver
+    spec:
+      containers:
+      - name: sshd-jumpserver
+        image: kubernetesio/sshd-jumpserver
+        ports:
+          - containerPort: 22
+        env:
+          - name: PUBLIC_KEY
+            valueFrom:
+              secretKeyRef:
+                name: sshkey
+                key: authorizedkeys
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sshd-jumpserver-svc
+  labels:
+    name: sshd-jumpserver-svc
+spec:
+  ports:
+    - name: ssh
+      port: 22
+  type: "LoadBalancer"
+  selector:
+    app: sshd-jumpserver
+

--- a/docker/kubernetes/gadgetron-ssh-secret.yaml.tmpl
+++ b/docker/kubernetes/gadgetron-ssh-secret.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sshkey
+type: Opaque
+data:
+  authorizedkeys: PUBLIC_KEY

--- a/docker/kubernetes/gadgetron_kubernetes_node_info.sh
+++ b/docker/kubernetes/gadgetron_kubernetes_node_info.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+nodeinfo=$(wget -O - -o /dev/null --ca-certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kubernetes/api/v1/namespaces/default/endpoints/gadgetron-frontend)
+
+nodeips=$( echo $nodeinfo | jq -r .subsets[0].addresses[].ip)
+
+for i in $nodeips
+do 
+    recons=$(wget -O - -o /dev/null "http://${i}:9080/cloudbus/active_recons")
+    echo "$i $recons"
+done

--- a/docker/kubernetes/gadgetron_kubernetes_prestop.sh
+++ b/docker/kubernetes/gadgetron_kubernetes_prestop.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#Close the acceptor.
+wget -O - -o /dev/null http://localhost:9080/acceptor/close
+
+#Now wait until all reconstructions are done
+active=$(wget -O - -o /dev/null http://localhost:9080/cloudbus/active_recons)
+while [ "$active" != "0" ]; do
+    echo "Waiting for $active reconstructions to finish..."
+    sleep 5
+done

--- a/docker/kubernetes/ssh-jump-server/Dockerfile
+++ b/docker/kubernetes/ssh-jump-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+RUN apt-get update --quiet && \
+    apt-get install --no-install-recommends --no-install-suggests --yes \
+    openssh-server openssh-client
+
+EXPOSE 22
+
+COPY entrypoint.sh /
+CMD ["/entrypoint.sh"]

--- a/docker/kubernetes/ssh-jump-server/entrypoint.sh
+++ b/docker/kubernetes/ssh-jump-server/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#Set new keys
+rm -rf /etc/ssh/ssh_host_*
+dpkg-reconfigure openssh-server
+
+#Switch off DNS checking
+sed -i.bak "s/#UseDNS no/UseDNS no/g" /etc/ssh/sshd_config
+
+#Import public key
+mkdir -p /root/.ssh
+touch /root/.ssh/authorized_keys
+echo ${PUBLIC_KEY} > /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+
+#Run SSH server
+mkdir -p /run/sshd
+/usr/sbin/sshd -D


### PR DESCRIPTION
This pull request adds some initial prerequisites for running distributed Gadgetron in a Kubernetes cluster. 
Specifically:

* CloudBus will detect (based on environment variables) if it is running in Kubernetes.
* Available nodes are determined with a bash script that queries the Kubernetes services instead.
* A PreStop script for Kubernetes has been added to allow orderly shutdown of nodes. 

Much work still to be done. See docker/kubernetes/README.md for details and progress. 
