### PR TITLE
Speedup non local bayes

### DIFF
--- a/toolboxes/denoise/non_local_bayes.cpp
+++ b/toolboxes/denoise/non_local_bayes.cpp
@@ -223,7 +223,7 @@ namespace Gadgetron {
 
                 std::vector<ImagePatch<T>> all_patches(num_all_patches);
 
-#pragma omp parallel default(none) private(ky) shared(SX, SY, image, search_window, noise_std, result, count, mask, all_patches)
+#pragma omp parallel default(none) private(ky) shared(SX, SY, image, search_window, noise_std, result, count, mask, all_patches) num_threads(4)
                 {
                     std::vector<ImagePatch<T>> patches;
                     arma::Col<T> reference_patch;


### PR DESCRIPTION
In docker image, this filter got very slow; probably due to the big number of threads 

limit the max number of threads to keep performance stable