### PR TITLE
basic node discovery implementation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/toolboxes/mri_image
   ${CMAKE_SOURCE_DIR}/toolboxes/pattern_recognition
   ${CMAKE_SOURCE_DIR}/toolboxes/python
+  ${CMAKE_SOURCE_DIR}/toolboxes/node_discovery
   ${Boost_INCLUDE_DIR}
   ${ARMADILLO_INCLUDE_DIRS}
   ${GTEST_INCLUDE_DIRS}
@@ -62,6 +63,7 @@ link_libraries(
     gadgetron_toolbox_cpu_image
     gadgetron_toolbox_cmr
     gadgetron_toolbox_pr
+    gadgetron_toolbox_node_discovery
     ${BOOST_LIBRARIES}
     ${GTEST_LIBRARIES} 
     ${ARMADILLO_LIBRARIES}
@@ -78,7 +80,8 @@ set(test_src_files tests.cpp
       curveFitting_test.cpp
       image_morphology_test.cpp 
       pattern_recognition_test.cpp 
-      cmr_mapping_test.cpp 
+      cmr_mapping_test.cpp
+      node_discovery_test.cpp
       )
 
 if (PYTHONLIBS_FOUND)

--- a/test/node_discovery_test.cpp
+++ b/test/node_discovery_test.cpp
@@ -1,0 +1,47 @@
+#include "gtest/gtest.h"
+
+#include "node_discovery.h"
+#include <vector>
+#include <fstream>
+
+TEST (NodeDiscoveryTest, ReadNodeDiscoveryList) {
+
+  //Create a file with node discovery data
+  
+  std::ofstream f("node_list.json");
+  f << "{" << std::endl;
+  f << "  \"version\": \"1.0.0\"," << std::endl;
+  f << "  \"nodes\": [" << std::endl;
+  f << "	{" << std::endl;
+  f << "	    \"id\": \"1993a160-6227-46be-872f-8719ee703eec\"," << std::endl;
+  f << "	    \"host\": \"10.0.0.1\"," << std::endl;
+  f << "	    \"port\": 9002," << std::endl;
+  f << "	    \"restPort\": 9080," << std::endl;
+  f << "	    \"activeReconstructions\": 0," << std::endl;
+  f << "	    \"hasGpu\": false" << std::endl;
+  f << "	}," << std::endl;
+  f << "	{" << std::endl;
+  f << "	    \"id\": \"794d8d45-e7f0-4c96-880e-8a6f09a18ce2\"," << std::endl;
+  f << "	    \"host\": \"10.0.0.2\"," << std::endl;
+  f << "	    \"port\": 9002," << std::endl;
+  f << "	    \"restPport\": 9080," << std::endl;
+  f << "	    \"activeReconstructions\": 0," << std::endl;
+  f << "	    \"hasGpu\": false" << std::endl;
+  f << "	}" << std::endl;
+  f << "    ]" << std::endl;
+  f << "}" << std::endl;
+  
+  
+  std::vector<Gadgetron::NodeDiscoveryEntry> nodes;
+
+#ifdef _WIN32
+  bool ret = DiscoverNodes(nodes, "type node_list.json");
+#else
+  bool ret = DiscoverNodes(nodes, "cat node_list.json");
+#endif
+  
+  ASSERT_EQ(true, ret);
+  ASSERT_EQ (2, nodes.size());
+  ASSERT_EQ ("794d8d45-e7f0-4c96-880e-8a6f09a18ce2", nodes[1].id);
+  ASSERT_EQ ("10.0.0.1", nodes[0].host);
+}

--- a/toolboxes/CMakeLists.txt
+++ b/toolboxes/CMakeLists.txt
@@ -9,6 +9,7 @@ if (MKL_FOUND)
 endif ()
 
 add_subdirectory(log)
+add_subdirectory(node_discovery)
 
 add_subdirectory(operators)
 add_subdirectory(solvers)

--- a/toolboxes/cloudbus/CMakeLists.txt
+++ b/toolboxes/cloudbus/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 include_directories(${ACE_INCLUDE_DIR}
                     ${Boost_INCLUDE_DIR}
 		    ${CMAKE_SOURCE_DIR}/toolboxes/rest
+		    ${CMAKE_SOURCE_DIR}/toolboxes/node_discovery
                     )
 
 add_library(gadgetron_toolbox_cloudbus SHARED
@@ -19,7 +20,8 @@ add_library(gadgetron_toolbox_cloudbus SHARED
 )
 
 target_link_libraries(gadgetron_toolbox_cloudbus
-		     gadgetron_toolbox_log
+                      gadgetron_toolbox_log
+                      gadgetron_toolbox_node_discovery  
                      optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY})
 
 set_target_properties(gadgetron_toolbox_cloudbus PROPERTIES COMPILE_DEFINITIONS "__BUILD_GADGETRON_CLOUDBUS__")

--- a/toolboxes/cloudbus/CloudBus.cpp
+++ b/toolboxes/cloudbus/CloudBus.cpp
@@ -1,4 +1,5 @@
 #include "CloudBus.h"
+#include "node_discovery.h"
 #include "log.h"
 
 namespace Gadgetron
@@ -264,6 +265,27 @@ namespace Gadgetron
         n.last_recon = 0;
         nodes.clear();
         nodes.push_back(n);
+    } else if (IsNodeDiscoveryConfigured()) {
+        std::vector<NodeDiscoveryEntry> node_entries;
+
+	nodes.clear();
+
+	if (DiscoverNodes(node_entries)) {
+	  for (const NodeDiscoveryEntry& e: node_entries) {
+	    GadgetronNodeInfo n;
+	    n.port = e.port;
+	    n.address = e.host;
+	    n.rest_port = e.restPort;
+	    n.compute_capability = 1;
+	    n.active_reconstructions = e.activeReconstructions;
+	    n.last_recon = 0;
+	    nodes.push_back(n);
+	  }
+	} else {
+	  GERROR("Failed to run NodeDiscovery\n");
+	  return;
+	}
+
     } else {
         update_node_info();
 	{

--- a/toolboxes/node_discovery/CMakeLists.txt
+++ b/toolboxes/node_discovery/CMakeLists.txt
@@ -1,0 +1,11 @@
+if (WIN32)
+    add_definitions(-D__BUILD_GADGETRON_NODEDISCOVERY__)
+endif ()
+
+add_library(gadgetron_toolbox_node_discovery SHARED node_discovery.cpp)
+target_link_libraries(gadgetron_toolbox_node_discovery ${Boost_LIBRARIES})
+set_target_properties(gadgetron_toolbox_node_discovery PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
+
+install(TARGETS gadgetron_toolbox_node_discovery DESTINATION lib COMPONENT main)
+install(FILES node_discovery.h node_discovery_export.h DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH} COMPONENT main)
+

--- a/toolboxes/node_discovery/examples/node_list.json
+++ b/toolboxes/node_discovery/examples/node_list.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0.0",
+    "nodes": [
+	{
+	    "id": "1993a160-6227-46be-872f-8719ee703eec",
+	    "host": "10.0.0.1",
+	    "port": 9002,
+	    "restPort": 9080,
+	    "activeReconstructions": 0,
+	    "hasGpu": false
+	},
+	{
+	    "id": "794d8d45-e7f0-4c96-880e-8a6f09a18ce2",
+	    "host": "10.0.0.2",
+	    "port": 9002,
+	    "restPport": 9080,
+	    "activeReconstructions": 0,
+	    "hasGpu": false
+	}
+    ]
+}

--- a/toolboxes/node_discovery/node_discovery.cpp
+++ b/toolboxes/node_discovery/node_discovery.cpp
@@ -1,0 +1,73 @@
+#include "node_discovery.h"
+
+#include <cstdlib>
+#include <sstream>
+#include <iostream>
+
+#include <boost/process.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+namespace pt = boost::property_tree;
+namespace bp = boost::process;
+
+namespace Gadgetron
+{
+  
+  bool IsNodeDiscoveryConfigured()
+  {
+    return std::getenv(NODEDISCOVERY_ENVIRONMENT_VARIABLE);
+  }
+
+  bool DiscoverNodes(std::vector<NodeDiscoveryEntry>& nodes)
+  {
+    if (IsNodeDiscoveryConfigured()) {
+      return DiscoverNodes(nodes, std::getenv(NODEDISCOVERY_ENVIRONMENT_VARIABLE));
+    } else {
+      GERROR("Unable to do node discovery. Environment variable %s not set\n");
+      nodes.clear();
+      return false;
+    }
+  }
+
+  bool DiscoverNodes(std::vector<NodeDiscoveryEntry>& nodes, const char* command)
+  {
+
+    //Setup and run command
+    bp::ipstream is; //reading pipe-stream
+    bp::child c(command, bp::std_out > is);
+
+    //Wait for completion
+    c.wait();
+
+    //Parse output
+    pt::ptree tree;
+    pt::read_json(is, tree);
+
+    //Version is a requirement
+    nodes.clear();
+    if (tree.get<std::string>("version") != "1.0.0")
+    {
+      GERROR("Version not found in json node list\n");
+      return false;
+    }
+
+    //Find as many nodes as we can (could be empty)
+    for (pt::ptree::value_type &node : tree.get_child("nodes"))
+    {
+	
+      NodeDiscoveryEntry entry;
+      entry.id = node.second.get<std::string>("id");
+      entry.host = node.second.get<std::string>("host");
+      entry.port = node.second.get<int>("port", 9002);
+      entry.restPort = node.second.get<int>("restPort", 9080);
+      entry.hasGpu = node.second.get<bool>("hasGpu", false);
+      entry.activeReconstructions = node.second.get<int>("activeReconstructions", 0);
+      
+      nodes.push_back(entry);
+    }
+
+    return true;
+  }
+  
+} //Namespace Gadgetron

--- a/toolboxes/node_discovery/node_discovery.h
+++ b/toolboxes/node_discovery/node_discovery.h
@@ -1,0 +1,32 @@
+#ifndef GADGETRON_NODEDISCOVERY_H
+#define GADGETRON_NODEDISCOVERY_H
+
+#include "node_discovery_export.h"
+#include "log.h"
+
+#include <string>
+#include <vector>
+
+#define NODEDISCOVERY_ENVIRONMENT_VARIABLE "GADGETRON_NODEDISCOVERY"
+
+namespace Gadgetron
+{
+  
+  struct NodeDiscoveryEntry
+  {
+    std::string id;
+    std::string host;
+    int port;
+    int restPort;
+    int activeReconstructions;
+    bool hasGpu;
+  };
+
+  
+  EXPORTGADGETRONNODEDISCOVERY bool IsNodeDiscoveryConfigured();
+  EXPORTGADGETRONNODEDISCOVERY bool DiscoverNodes(std::vector<NodeDiscoveryEntry>& nodes);
+  EXPORTGADGETRONNODEDISCOVERY bool DiscoverNodes(std::vector<NodeDiscoveryEntry>& nodes, const char* command);
+  
+}
+
+#endif //GADGETRON_NODEDISCOVERY_H

--- a/toolboxes/node_discovery/node_discovery_export.h
+++ b/toolboxes/node_discovery/node_discovery_export.h
@@ -1,0 +1,14 @@
+#ifndef NODEDISCOVERY_EXPORT_H_
+#define NODEDISCOVERY_EXPORT_H_
+
+#if defined (WIN32)
+   #if defined (__BUILD_GADGETRON_NODE_DISCOVERY__) || defined (gadgetron_toolbox_node_discovery__EXPORTS)
+      #define EXPORTGADGETRONNODEDISCOVERY __declspec(dllexport)
+   #else
+      #define EXPORTGADGETRONNODEDISCOVERY __declspec(dllimport)
+   #endif
+#else
+   #define EXPORTGADGETRONNODEDISCOVERY
+#endif
+
+#endif /* NODEDISCOVERY_EXPORT_H_ */


### PR DESCRIPTION
Adding `node_discovery` toolbox and tests. 

Toolbox is used in CloudBus when `GADGETRON_NODEDISCOVERY` environment is set. 

Closes #656 
