### PR TITLE
Bart embedding

### DIFF
--- a/docker/base/ubuntu_1604/Dockerfile
+++ b/docker/base/ubuntu_1604/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:16.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 #Fix default ceres package on 16.04 is broken
 
 RUN apt-get update --quiet && \
@@ -69,13 +72,15 @@ RUN cd /opt && \
     make shared && \
     make install
 
-#BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.4.03.tar.gz && \
-    tar -xzf v0.4.03.tar.gz && \
-    cd bart-0.4.03 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-v0.4.03/bart /usr/local/bin/bart
+    make install
 
 # Ceres
 RUN apt-get install --yes libgoogle-glog-dev libeigen3-dev libsuitesparse-dev

--- a/docker/base/ubuntu_1604_cuda80_cudnn6/Dockerfile
+++ b/docker/base/ubuntu_1604_cuda80_cudnn6/Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 RUN apt-get update --quiet && \
     apt-get install --no-install-recommends --no-install-suggests --yes software-properties-common
 RUN add-apt-repository ppa:lkoppel/ceres
@@ -74,13 +77,15 @@ RUN cd /opt && \
     make shared && \
     make -j $(nproc) install
 
-#BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.3.01.tar.gz && \
-    tar -xzf v0.3.01.tar.gz && \
-    cd bart-0.3.01 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-0.3.01/bart /usr/local/bin/bart 
+    make install
 
 #Set more environment variables in preparation for Gadgetron installation
 ENV GADGETRON_HOME=/usr/local \

--- a/docker/base/ubuntu_1604_cuda80_cudnn7/Dockerfile
+++ b/docker/base/ubuntu_1604_cuda80_cudnn7/Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 RUN apt-get update --quiet && \
     apt-get install --no-install-recommends --no-install-suggests --yes software-properties-common
 RUN add-apt-repository ppa:lkoppel/ceres
@@ -79,13 +82,15 @@ RUN cd /opt && \
     make shared && \
     make -j $(nproc) install
 
-#BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.3.01.tar.gz && \
-    tar -xzf v0.3.01.tar.gz && \
-    cd bart-0.3.01 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-0.3.01/bart /usr/local/bin/bart 
+    make install
 
 #Set more environment variables in preparation for Gadgetron installation
 ENV GADGETRON_HOME=/usr/local \

--- a/docker/base/ubuntu_1604_cuda90_cudnn7/Dockerfile
+++ b/docker/base/ubuntu_1604_cuda90_cudnn7/Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 #Fix default ceres package on 16.04 is broken
 
 RUN apt-get update --quiet && \
@@ -77,13 +80,15 @@ RUN cd /opt && \
     make shared && \
     make -j $(nproc) install
 
-#BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.3.01.tar.gz && \
-    tar -xzf v0.3.01.tar.gz && \
-    cd bart-0.3.01 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-0.3.01/bart /usr/local/bin/bart 
+    make install
 
 #Set more environment variables in preparation for Gadgetron installation
 ENV GADGETRON_HOME=/usr/local \

--- a/docker/base/ubuntu_1604_cuda92_cudnn7/Dockerfile
+++ b/docker/base/ubuntu_1604_cuda92_cudnn7/Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 #Fix default ceres package on 16.04 is broken
 
 RUN apt-get update --quiet && \
@@ -71,13 +74,15 @@ RUN cd /opt && \
     make shared && \
     make -j $(nproc) install
 
-#BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.3.01.tar.gz && \
-    tar -xzf v0.3.01.tar.gz && \
-    cd bart-0.3.01 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-0.3.01/bart /usr/local/bin/bart 
+    make install
 
 #Set more environment variables in preparation for Gadgetron installation
 ENV GADGETRON_HOME=/usr/local \

--- a/docker/base/ubuntu_1804/Dockerfile
+++ b/docker/base/ubuntu_1804/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:18.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 RUN apt-get update --quiet && \
     apt-get install --no-install-recommends --no-install-suggests --yes  \
     software-properties-common apt-utils wget build-essential cython emacs python-dev python-pip python3-dev python3-pip libhdf5-serial-dev cmake git-core libboost-all-dev libfftw3-dev h5utils jq hdf\
@@ -38,13 +41,15 @@ RUN cd /opt && \
     make shared && \
     make -j $(nproc) install
 
-#BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.4.03.tar.gz && \
-    tar -xzf v0.4.03.tar.gz && \
-    cd bart-0.4.03 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-v0.4.03/bart /usr/local/bin/bart 
+    make install
 
 # Ceres
 RUN apt-get install --yes libgoogle-glog-dev libeigen3-dev libsuitesparse-dev

--- a/docker/base/ubuntu_1804_cuda90/Dockerfile
+++ b/docker/base/ubuntu_1804_cuda90/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:18.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 RUN apt-get update --quiet && \
     apt-get install --no-install-recommends --no-install-suggests --yes  \
     software-properties-common apt-utils wget build-essential cython emacs python-dev python-pip python3-dev python3-pip libhdf5-serial-dev cmake git-core libboost-all-dev libfftw3-dev h5utils jq hdf\
@@ -104,13 +107,15 @@ RUN cd /opt && \
     make shared && \
     make -j $(nproc) install
 
-#BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.4.03.tar.gz && \
-    tar -xzf v0.4.03.tar.gz && \
-    cd bart-0.4.03 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-v0.4.03/bart /usr/local/bin/bart 
+    make install
 
 # ceres
 RUN apt-get install --yes libgoogle-glog-dev libeigen3-dev libsuitesparse-dev

--- a/docker/base/ubuntu_1804_cuda92_cudnn7/Dockerfile
+++ b/docker/base/ubuntu_1804_cuda92_cudnn7/Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
 
+ARG BART_URL=https://github.com/mrirecon/bart
+ARG BART_BRANCH=master
+
 RUN apt-get update --quiet && \
     apt-get install --no-install-recommends --no-install-suggests --yes  \
     software-properties-common apt-utils wget build-essential cython emacs python-dev python-pip python3-dev python3-pip libhdf5-serial-dev cmake git-core libboost-all-dev libfftw3-dev h5utils jq hdf\
@@ -46,12 +49,15 @@ RUN cd /opt && \
     make -j $(nproc) install
 
 #BART
-RUN cd /opt && \
-    wget https://github.com/mrirecon/bart/archive/v0.4.03.tar.gz && \
-    tar -xzf v0.4.03.tar.gz && \
-    cd bart-0.4.03 && \
+# BART
+RUN cd /opt/code && \
+    git clone ${BART_URL} --branch ${BART_BRANCH} --single-branch && \
+    cd bart && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBART_FPIC=ON -DBART_ENABLE_MEM_CFL=ON -DBART_REDEFINE_PRINTF_FOR_TRACE=ON -DBART_LOG_BACKEND=ON -DBART_LOG_GADGETRON_BACKEND=ON && \
     make -j $(nproc) && \
-    ln -s /opt/bart-v0.4.03/bart /usr/local/bin/bart 
+    make install
 
 # ceres
 RUN apt-get install --yes libgoogle-glog-dev libeigen3-dev libsuitesparse-dev

--- a/gadgets/CMakeLists.txt
+++ b/gadgets/CMakeLists.txt
@@ -30,15 +30,18 @@ if (ARMADILLO_FOUND)
   add_subdirectory(cmr)
 endif()
 
-find_program(BARTCMD bart)
-if (BARTCMD)
-	add_subdirectory(bart)
+
+
+option(USE_BART "Build support for BART using BartGadget" ON)
+if(USE_BART)
+  add_subdirectory(bart)
 endif()
 
+
 if (ARMADILLO_FOUND)
-    add_subdirectory(epi)
+  add_subdirectory(epi)
 elseif (ARMADILLO_FOUND)
-    message("Armadillo not found, NOT compiling EPI Gadgets")
+  message("Armadillo not found, NOT compiling EPI Gadgets")
 endif ()
 
 

--- a/gadgets/bart/BART_Recon.xml
+++ b/gadgets/bart/BART_Recon.xml
@@ -69,27 +69,33 @@
         <!-- whether always to prepare ref if no acceleration is used -->
         <property><name>prepare_ref_always</name><value>true</value></property>
     </gadget>
-	
-	<!-- This is where we insert our new Gadget -->
-	<gadget>
-	  <name>bartgadget</name>
-	  <dll>gadgetron_bart</dll>
-	  <classname>BartGadget</classname>
-	  <property><name>isVerboseON</name><value>true</value></property>
-          <property><name>BartCommandScript_name</name><value>Sample_Grappa_Recon.sh</value></property>
-          <!--Enable and provide the absolute path to the bart working directory different from the default path-->
-          <!--property><name>BartWorkingDirectory_path</name><value></value></property-->
-	  <property><name>isBartFileBeingStored</name><value>false</value></property>
-	  <property><name>image_series</name><value>0</value></property>
-	  <!--CACHE BART FILES FOR BETTER PERFORMANCE  -->
-          <!---THIS FEATURE SHOULD BE ENABLE ONLY IF THE USER HAS THE ROOT PRIVILEGE AND KNOWS HIS/HER HARDWIRE
-          WELL ENOUGH TO ALLOCATE VIRTUAL MEMORY -->
-	  <!--ONE HAS TO SET "isBartFileBeingStored" TO FALSE--> 
-	  <property><name>isBartFolderBeingCachedToVM</name><value>false</value></property>
-	  <property><name>AllocateMemorySizeInMegabytes</name><value>50</value></property>
-	</gadget>
-		
-	 <!-- Partial fourier handling -->
+    
+    <!-- This is where we insert our new Gadget -->
+    <gadget>
+      <name>bartgadget</name>
+      <dll>gadgetron_bart</dll>
+      <classname>BartGadget</classname>
+      <property><name>isVerboseON</name><value>true</value></property>
+      <property><name>BartCommandScript_name</name><value>Sample_Grappa_Recon.sh</value></property>
+      <!--Enable and provide the absolute path to the bart working directory different from the default path-->
+      <!--property><name>BartWorkingDirectory_path</name><value></value></property-->
+      <property><name>isBartFileBeingStored</name><value>false</value></property>
+      <property><name>image_series</name><value>0</value></property>
+      <!-- Controls the behaviour of BART with regards to files 
+	   Possible values are: 
+	   - BART_ALL_IN_MEM: store everything in memory (beware of large datasets!)
+	   - BART_ALL_ON_DISK: store everything on-disk (might not be available if BartGadget was compiled with -DMEMONLY_CFL)
+	   - BART_MIX_DISK_MEM: mixed on-disk/in-memory storage
+                                user can control whether a file is stored in-memory by appending
+                                the ".mem" extension to any BART output as well as using
+				the BartStoreIncomingInMemory property.
+	   NB: if BartGadget is compiled with -DMEMONLY_CFL, this setting has no effect -->
+      <property><name>BartFileBehaviour</name><value>BART_MIX_DISK_MEM</value></property>
+      <!-- This is ignored if BartFileBehaviour is not BART_MIX_DISK_MEM -->
+      <property><name>BartStoreGadgetronInputInMemory</name><value>false</value></property>
+    </gadget>
+    
+    <!-- Partial fourier handling -->
     <gadget>
         <name>PartialFourierHandling</name>
         <dll>gadgetron_mricore</dll>

--- a/gadgets/bart/BART_Recon_cloud.xml
+++ b/gadgets/bart/BART_Recon_cloud.xml
@@ -81,24 +81,30 @@
         <property><name>prepare_ref_always</name><value>true</value></property>
     </gadget>
 
-	<!-- This is where we insert our new Gadget -->
-	<gadget>
-	  <name>bartgadget</name>
-	  <dll>gadgetron_bart</dll>
-	  <classname>BartGadget</classname>
-	  <property><name>isVerboseON</name><value>false</value></property>
-	  <property><name>BartCommandScript_name</name><value>Sample_Grappa_Recon.sh</value></property>
-          <!--Enable and provide the absolute path to the bart working directory different from the default path-->
-          <!--property><name>BartWorkingDirectory_path</name><value></value></property-->
-	  <property><name>isBartFileBeingStored</name><value>false</value></property>
+    <!-- This is where we insert our new Gadget -->
+    <gadget>
+      <name>bartgadget</name>
+      <dll>gadgetron_bart</dll>
+      <classname>BartGadget</classname>
+      <property><name>isVerboseON</name><value>false</value></property>
+      <property><name>BartCommandScript_name</name><value>Sample_Grappa_Recon.sh</value></property>
+      <!--Enable and provide the absolute path to the bart working directory different from the default path-->
+      <!--property><name>BartWorkingDirectory_path</name><value></value></property-->
+      <property><name>isBartFileBeingStored</name><value>false</value></property>
       <property><name>image_series</name><value>0</value></property>
-	  <!--CACHE BART FILES FOR BETTER PERFORMANCE  -->
-      <!---THIS FEATURE SHOULD BE ENABLE ONLY IF THE USER HAS THE ROOT PRIVILEGE AND KNOWS HIS/HER HARDWIRE
-          WELL ENOUGH TO ALLOCATE VIRTUAL MEMORY -->
-	  <!--ONE HAS TO SET "isBartFileBeingStored" TO FALSE-->	  
-      <property><name>isBartFolderBeingCachedToVM</name><value>false</value></property>
-	  <property><name>AllocateMemorySizeInMegabytes</name><value>50</value></property>
-	</gadget>
+      <!-- Controls the behaviour of BART with regards to files 
+	   Possible values are: 
+	   - BART_ALL_IN_MEM: store everything in memory (beware of large datasets!)
+	   - BART_ALL_ON_DISK: store everything on-disk (might not be available if BartGadget was compiled with -DMEMONLY_CFL)
+	   - BART_MIX_DISK_MEM: mixed on-disk/in-memory storage
+                                user can control whether a file is stored in-memory by appending
+                                the ".mem" extension to any BART output as well as using
+				the BartStoreIncomingInMemory property.
+	   NB: if BartGadget is compiled with -DMEMONLY_CFL, this setting has no effect -->
+      <property><name>BartFileBehaviour</name><value>BART_MIX_DISK_MEM</value></property>
+      <!-- This is ignored if BartFileBehaviour is not BART_MIX_DISK_MEM -->
+      <property><name>BartStoreGadgetronInputInMemory</name><value>false</value></property>
+    </gadget>
 
     <!-- Partial fourier handling -->
     <gadget>

--- a/gadgets/bart/BART_Recon_cloud_Standard.xml
+++ b/gadgets/bart/BART_Recon_cloud_Standard.xml
@@ -81,24 +81,30 @@
         <property><name>prepare_ref_always</name><value>true</value></property>
     </gadget>
 
-	<!-- This is where we insert our new Gadget -->
-	<gadget>
-	  <name>bartgadget</name>
-	  <dll>gadgetron_bart</dll>
-	  <classname>BartGadget</classname>
-	  <property><name>isVerboseON</name><value>false</value></property>
-	  <property><name>BartCommandScript_name</name><value>Sample_Grappa_Recon_Standard.sh</value></property>
-          <!--Enable and provide the absolute path to the bart working directory different from the default path-->
-          <!--property><name>BartWorkingDirectory_path</name><value></value></property-->
-	  <property><name>isBartFileBeingStored</name><value>false</value></property>
+    <!-- This is where we insert our new Gadget -->
+    <gadget>
+      <name>bartgadget</name>
+      <dll>gadgetron_bart</dll>
+      <classname>BartGadget</classname>
+      <property><name>isVerboseON</name><value>false</value></property>
+      <property><name>BartCommandScript_name</name><value>Sample_Grappa_Recon_Standard.sh</value></property>
+      <!--Enable and provide the absolute path to the bart working directory different from the default path-->
+      <!--property><name>BartWorkingDirectory_path</name><value></value></property-->
+      <property><name>isBartFileBeingStored</name><value>false</value></property>
       <property><name>image_series</name><value>0</value></property>
-	  <!--CACHE BART FILES FOR BETTER PERFORMANCE  -->
-      <!---THIS FEATURE SHOULD BE ENABLE ONLY IF THE USER HAS THE ROOT PRIVILEGE AND KNOWS HIS/HER HARDWIRE
-          WELL ENOUGH TO ALLOCATE VIRTUAL MEMORY -->
-	  <!--ONE HAS TO SET "isBartFileBeingStored" TO FALSE-->	  
-      <property><name>isBartFolderBeingCachedToVM</name><value>false</value></property>
-	  <property><name>AllocateMemorySizeInMegabytes</name><value>50</value></property>
-	</gadget>
+      <!-- Controls the behaviour of BART with regards to files 
+	   Possible values are: 
+	   - BART_ALL_IN_MEM: store everything in memory (beware of large datasets!)
+	   - BART_ALL_ON_DISK: store everything on-disk (might not be available if BartGadget was compiled with -DMEMONLY_CFL)
+	   - BART_MIX_DISK_MEM: mixed on-disk/in-memory storage
+                                user can control whether a file is stored in-memory by appending
+                                the ".mem" extension to any BART output as well as using
+				the BartStoreIncomingInMemory property.
+	   NB: if BartGadget is compiled with -DMEMONLY_CFL, this setting has no effect -->
+      <property><name>BartFileBehaviour</name><value>BART_MIX_DISK_MEM</value></property>
+      <!-- This is ignored if BartFileBehaviour is not BART_MIX_DISK_MEM -->
+      <property><name>BartStoreGadgetronInputInMemory</name><value>false</value></property>
+    </gadget>
 
     <!-- Partial fourier handling -->
     <gadget>

--- a/gadgets/bart/CMakeLists.txt
+++ b/gadgets/bart/CMakeLists.txt
@@ -1,6 +1,33 @@
+
+cmake_policy(SET CMP0028 NEW) # double colon only for imported or alias libraries
+
+# ==============================================================================
+# First try to find either the BARTmain library or a path to the BART source code
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
+find_package(BART REQUIRED CONFIG)
+
+# ==============================================================================
+
+set(GADGET_FILES
+  bartgadget.h
+  bartgadget.cpp
+  bart_logger.cpp
+  BART_Recon.xml
+  BART_Recon_cloud.xml
+  BART_Recon_cloud_Standard.xml
+)
+
+# ------------------------------------------------------------------------------
+
 if (WIN32)
   add_definitions(-D__BUILD_GADGETRON_bartgadget__)
 endif ()
+
+if(BART_MEMONLY_CFL)
+  add_definitions(-DMEMONLY_CFL)
+endif()
 
 include_directories(
   ${CMAKE_SOURCE_DIR}/gadgets/mri_core
@@ -12,15 +39,21 @@ include_directories(
   ${Boost_INCLUDE_DIR}
   )
 
-add_library(gadgetron_bart SHARED 
-  bartgadget.h
-  bartgadget.cpp
-  BART_Recon.xml 
-  BART_Recon_cloud.xml
-  BART_Recon_cloud_Standard.xml
-)
+add_library(gadgetron_bart SHARED ${GADGET_FILES})
+target_link_libraries(gadgetron_bart BART::BARTMAIN)
 
-set_target_properties(gadgetron_bart PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
+if(USE_CUDA)
+  find_package(CUDA)
+  CUDA_ADD_CUFFT_TO_TARGET(gadgetron_bart)
+  CUDA_ADD_CUBLAS_TO_TARGET(gadgetron_bart)
+  target_link_libraries(gadgetron_bart ${CUDA_LIBRARIES})
+endif()
+
+
+set_target_properties(gadgetron_bart
+  PROPERTIES
+  VERSION ${GADGETRON_VERSION_STRING}
+  SOVERSION ${GADGETRON_SOVERSION})
 
 target_link_libraries(gadgetron_bart gadgetron_gadgetbase
   gadgetron_mricore 
@@ -33,17 +66,17 @@ target_link_libraries(gadgetron_bart gadgetron_gadgetbase
   optimized ${ACE_LIBRARIES} debug ${ACE_DEBUG_LIBRARY}   
   ${Boost_LIBRARIES}
   )
-  
+
 if(ARMADILLO_FOUND)
-    target_link_libraries(gadgetron_bart gadgetron_toolbox_cpucore_math )
+  target_link_libraries(gadgetron_bart gadgetron_toolbox_cpucore_math)
 endif()
 
-install (FILES  bartgadget.h
-                DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH} COMPONENT main)
+install(FILES  bartgadget.h
+  DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH} COMPONENT main)
 
-install (TARGETS gadgetron_bart DESTINATION lib COMPONENT main)
+install(TARGETS gadgetron_bart DESTINATION lib COMPONENT main)
 
 set(GADGETRON_INSTALL_BART_PATH share/gadgetron/bart)
-install (FILES Sample_Grappa_Recon.sh Sample_Grappa_Recon_Standard.sh DESTINATION ${GADGETRON_INSTALL_BART_PATH})
+install(FILES Sample_Grappa_Recon.sh Sample_Grappa_Recon_Standard.sh DESTINATION ${GADGETRON_INSTALL_BART_PATH})
 
 install(FILES BART_Recon.xml BART_Recon_cloud.xml BART_Recon_cloud_Standard.xml DESTINATION ${GADGETRON_INSTALL_CONFIG_PATH} COMPONENT main)

--- a/gadgets/bart/CMakeLists.txt
+++ b/gadgets/bart/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(BART REQUIRED CONFIG)
 set(GADGET_FILES
   bartgadget.h
   bartgadget.cpp
+  bart_helpers.h
+  bart_helpers.cpp
   bart_logger.cpp
   BART_Recon.xml
   BART_Recon_cloud.xml

--- a/gadgets/bart/Sample_Grappa_Recon.sh
+++ b/gadgets/bart/Sample_Grappa_Recon.sh
@@ -11,7 +11,9 @@
 # acc_factor_PE2;
 # reference_lines_PE1;
 # reference_lines_PE2;
-
+# input_data;
+# reference_data;
+# traj_data;
 
 debug=false
 
@@ -19,14 +21,24 @@ if "$debug"; then
 	set -x
 fi
 
-bart cc -S reference_data cc_mat
+# Those two lines will be ignored by the BartGadget but allow you to execute
+# the script outside of Gadgetron with little changes
+# Possible inputs provided by the BartGadget are:
+#   - $reference_data
+#   - $input_data
+#   - $traj_data
+
+input_data="path/to/a/file"
+reference_data="path/to/another/file"
+
+bart cc -S $reference_data cc_mat
 # Compress coils to 12 virtual channels
 bart extract 4 0 11 cc_mat cc_mat_P
 
-bart fmac -C -s 8 reference_data cc_mat_P reference_data_cc
+bart fmac -C -s 8 $reference_data cc_mat_P reference_data_cc
 bart transpose 3 4 reference_data_cc cc_reference_data
 
-bart fmac -C -s 8 input_data cc_mat_P input_data_cc
+bart fmac -C -s 8 $input_data cc_mat_P input_data_cc
 bart transpose 3 4 input_data_cc cc_input_data
 
 bart ecalib -c0.7 -k7 -r$reference_lines_PE1 -m4 -S cc_reference_data maps

--- a/gadgets/bart/Sample_Grappa_Recon_Standard.sh
+++ b/gadgets/bart/Sample_Grappa_Recon_Standard.sh
@@ -11,7 +11,9 @@
 # acc_factor_PE2;
 # reference_lines_PE1;
 # reference_lines_PE2;
-
+# input_data;
+# reference_data;
+# traj_data;
 
 debug=false
 
@@ -19,14 +21,24 @@ if "$debug"; then
 	set -x
 fi
 
-bart cc -S reference_data cc_mat
+# Those two lines will be ignored by the BartGadget but allow you to execute
+# the script outside of Gadgetron with little changes
+# Possible inputs provided by the BartGadget are:
+#   - $reference_data
+#   - $input_data
+#   - $traj_data
+
+input_data="path/to/a/file"
+reference_data="path/to/another/file"
+
+bart cc -S $reference_data cc_mat
 # Compress coils to 12 virtual channels
 bart extract 4 0 11 cc_mat cc_mat_P
 
-bart fmac -C -s 8 reference_data cc_mat_P reference_data_cc
+bart fmac -C -s 8 $reference_data cc_mat_P reference_data_cc
 bart transpose 3 4 reference_data_cc cc_reference_data
 
-bart fmac -C -s 8 input_data cc_mat_P input_data_cc
+bart fmac -C -s 8 $input_data cc_mat_P input_data_cc
 bart transpose 3 4 input_data_cc cc_input_data
 
 bart ecalib -c0.7 -k7 -r$reference_lines_PE1 -m4 -S cc_reference_data maps

--- a/gadgets/bart/bart_helpers.cpp
+++ b/gadgets/bart/bart_helpers.cpp
@@ -1,0 +1,221 @@
+#include "bart_helpers.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/thread.hpp>
+#include <boost/tokenizer.hpp>
+
+#include <random>
+
+// =============================================================================
+
+namespace fs = Gadgetron::fs;
+
+fs::path internal::generate_unique_folder(const fs::path& working_directory)
+{
+     typedef std::chrono::system_clock clock_t;
+	  
+     char buff[80];
+     auto now = clock_t::to_time_t(clock_t::now());
+     std::strftime(buff, sizeof(buff), "%H_%M_%S__", std::localtime(&now));
+     std::random_device rd;
+     auto time_id(buff + std::to_string(std::uniform_int_distribution<>(1, 10000)(rd)));
+     // Get the current process ID
+     auto threadId = boost::lexical_cast<std::string>(boost::this_thread::get_id());
+     auto threadNumber(0UL);
+     sscanf(threadId.c_str(), "%lx", &threadNumber);
+     return  working_directory / ("bart_"
+				  + time_id
+				  + "_"
+				  + std::to_string(threadNumber));
+}
+
+// ========================================================================
+
+void internal::ltrim(std::string &str)
+{
+     str.erase(str.begin(), std::find_if(str.begin(), str.end(),
+					 [](int s) {return !std::isspace(s); }));
+}
+
+void internal::rtrim(std::string &str)
+{
+     str.erase(std::find_if(str.rbegin(), str.rend(),
+			    [](int s) {return !std::isspace(s);}).base(),
+	       str.end());
+}
+
+void internal::trim(std::string &str)
+{
+     ltrim(str);
+     rtrim(str);
+}
+
+std::string internal::get_output_filename(const std::string& command_line)
+{
+     boost::char_separator<char> sep(" ");
+     std::vector<std::string> tokens;
+     boost::tokenizer<boost::char_separator<char>> tokenizer(command_line, sep);
+     for (auto& tok : tokenizer) {
+	  tokens.push_back(tok);
+     }
+
+     // Find begin of argument list
+     auto num_args(tokens.size()-1);
+     auto it(tokens.cbegin());
+     if (*it == "bart") {
+	  ++it;
+	  --num_args;
+     }
+     // it now points to the name of the BART command
+
+     if (*it == "bitmask"
+	 || *it == "estdelay"
+	 || *it == "estdims"
+	 || *it == "estshift"
+	 || *it == "estvar"
+	 || *it == "nrmse"
+	 || *it == "sdot"
+	 || *it == "show"
+	 || *it == "version") {
+	  return "";
+     }
+     else {
+	  const auto end(tokens.cend());
+	  const auto arg1(*(it+1));
+	  const auto arg1_not_option(arg1[0] != '-');
+
+	  /* 
+	   * Essentially, the algorithm considers only the BART functions where
+	   * the output argument might not be the last one.
+	   *
+	   * For these commands, if a sufficient number of argument is provided
+	   * there is no ambiguity possible since we can always find the last
+	   * "flag-like" looking argument on the command line and then infer
+	   * the position of the output from there.
+	   * If there might be an ambiguity, we look at the first argument of 
+	   * the BART command and depending on whether it is a flag or not, 
+	   * we can infer the position of the output argument on the command
+	   * line.
+	   */
+	  if (*it == "ecalib") {
+	       if (num_args > 3) {
+		    auto it2 = --tokens.cend();
+		    for (; it2 != it && (*it2)[0] != '-'; --it2);
+
+		    const char& first((*it2)[0]);
+		    const char& second((*it2)[1]);
+		    if (first == '-'
+			&& (it2->size() > 2 // handle cases like -t12 (ie. -t 12)
+			    || second == 'S'
+			    || second == 'W'
+			    || second == 'I'
+			    || second == '1'
+			    || second == 'P'
+			    || second == 'a')) {
+			 std::cout << "ecalib: flag\n";
+			 return *(it2 + 2);
+		    }
+		    else {
+			 return *(it2 + 3);
+		    }
+	       }
+	       else if (num_args == 3 && arg1_not_option) {
+		    return *(end - 2);			 
+	       }
+
+	       // Minimum arguments to ecalib
+	       // 2       kspace sens
+	       // 3 -I    kspace sens
+	       // 3       kspace sens ev-maps
+	       // 4 -t 11 kspace sens
+	       // 4 -P    kspace sens ev-maps
+	       // 4 -t11  kspace sens ev-maps
+	  }
+	  else if (*it == "ecaltwo") {
+	       if (num_args > 6) {
+		    auto it2 = --tokens.cend();
+		    for (; it2 != it && (*it2)[0] != '-'; --it2);
+		    
+		    const char& first((*it2)[0]);
+		    const char& second((*it2)[1]);
+		    if (first == '-'
+			&& (it2->size() > 2 // handle cases like -t12 (ie. -t 12)
+			    || second == 'S')) {
+			 return *(it2 + 5);
+		    }
+		    else {
+			 return *(it2 + 6);
+		    }
+	       }
+	       else if (num_args == 6 && arg1[0] != '-') {
+		    return *(end - 2);		 
+	       }
+	       // Minmum arguments to ecaltwo
+	       // 6      x y z <input> <sensitivities> [<ev_maps>]
+	       // 6 -S   x y z <input> <sensitivities>
+	       // 7 -m 3 x y z <input> <sensitivities>
+	       // 7 -S   x y z <input> <sensitivities> [<ev_maps>]
+	  }
+	  else if (*it == "nlinv") {
+	       if (num_args > 3) {
+		    auto it2 = --tokens.end();
+		    for (; it2 != it && (*it2)[0] != '-'; --it2);
+
+		    const char& first((*it2)[0]);
+		    const char& second((*it2)[1]);
+		    if (first == '-'
+			&& (it2->size() > 2 // handle cases like -t12 (ie. -t 12)
+			    || second == 'c'
+			    || second == 'N'
+			    || second == 'U'
+			    || second == 'g'
+			    || second == 'S')) {
+			 return *(it2 + 2);
+		    }
+		    else {
+			 return *(it2 + 3);
+		    }
+	       }
+	       else if (num_args == 3 && arg1[0] != '-') {
+		    return *(end - 2);
+	       }
+	       // Minmum arguments to nlinv
+	       // 2       kspace output
+	       // 3       kspace output sens
+	       // 3  -S   kspace output
+	       // 4  -i d kspace output
+	       // 4  -S   kspace output sens
+	  }
+	  else if (*it == "whiten") {
+	       if (num_args > 5) {
+		    auto it2 = --tokens.end();
+		    for (; it2 != it && (*it2)[0] != '-'; --it2);
+
+		    const char& first((*it2)[0]);
+		    const char& second((*it2)[1]);
+		    if (first == '-'
+			&& (it2->size() > 2 // handle cases like -t12 (ie. -t 12)
+			    || second == 'n')) {
+			 return *(it2 + 3);
+		    }
+		    else {
+			 return *(it2 + 4);
+		    }
+	       }
+	       else if(num_args == 5 && arg1_not_option) {
+		    return *(end - 3);
+	       }
+	       else if (num_args == 4 && arg1_not_option) {
+		    return *(end - 2);
+	       }
+	       // Minimum arguments to whiten
+	       // 3         input ndata output
+	       // 4         input ndata output optmat
+	       // 4 -n      input ndata output
+	       // 5 -o asd  input ndata output
+	       // 5 -n      input ndata output optmat
+	       // 5         input ndata output optmat covar_out
+	  }
+     }
+     return tokens.back();
+}

--- a/gadgets/bart/bart_helpers.h
+++ b/gadgets/bart/bart_helpers.h
@@ -1,0 +1,45 @@
+#ifndef BART_HELPERS_H_INCLUDED
+#define BART_HELPERS_H_INCLUDED
+
+#include "bartgadget.h"
+#include "bart/bart_embed_api.h"
+
+namespace internal {
+     namespace fs = Gadgetron::fs;
+     
+     class ScopeGuard
+     {
+     public:
+	  ScopeGuard(fs::path p) : p_(std::move(p))
+	       {
+		    char buf[1024] = { '\0' };
+		    auto* ptr = getcwd(buf, 1024);
+		    cwd_ = std::string(ptr);
+		    auto r = chdir(p_.c_str());
+	       }
+	  ~ScopeGuard()
+	       {
+		    if (is_active_) {
+			 fs::remove_all(p_);
+		    }
+		    auto r = chdir(cwd_.c_str());
+		    deallocate_all_mem_cfl();
+	       }
+
+	  void dismiss() { is_active_ = false; }
+     private:
+	  bool is_active_;
+	  const fs::path p_;
+	  fs::path cwd_;
+     };
+     
+     fs::path generate_unique_folder(const fs::path& working_directory);
+
+     void ltrim(std::string &str);
+     void rtrim(std::string &str);
+     void trim(std::string &str);
+	
+     std::string get_output_filename(const std::string& command_line);
+} // namespace internal
+
+#endif //BART_HELPERS_H_INCLUDED

--- a/gadgets/bart/bart_logger.cpp
+++ b/gadgets/bart/bart_logger.cpp
@@ -1,0 +1,37 @@
+#include "log.h"
+
+#include "bart/bart_embed_api.h"
+
+enum debug_levels { DP_ERROR, DP_WARN, DP_INFO, DP_DEBUG1, DP_DEBUG2, DP_DEBUG3, DP_DEBUG4, DP_TRACE, DP_ALL };
+
+extern "C"
+void vendor_log(int level,
+		const char* func_name,
+		const char* file,
+		unsigned int line,
+		const char* message)
+{
+     const auto fname(file + std::string(" (BART)"));
+     const auto msg (message + std::string("\n"));
+     
+     if (-1 == debug_level) {
+	  char* str = getenv("DEBUG_LEVEL");
+	  debug_level = (NULL != str) ? atoi(str) : DP_INFO;
+     }
+
+     if (level <= debug_level) {
+	  switch(level) {
+	  case DP_ERROR:
+	       Gadgetron::GadgetronLogger::instance()->log(Gadgetron::GADGETRON_LOG_LEVEL_ERROR, fname.c_str(), line, msg.c_str());
+	       break;
+	  case DP_WARN:
+	       Gadgetron::GadgetronLogger::instance()->log(Gadgetron::GADGETRON_LOG_LEVEL_WARNING, fname.c_str(), line, msg.c_str());
+	       break;
+	  case DP_INFO:
+	       Gadgetron::GadgetronLogger::instance()->log(Gadgetron::GADGETRON_LOG_LEVEL_INFO, fname.c_str(), line, msg.c_str());
+	       break;
+	  default:
+	       Gadgetron::GadgetronLogger::instance()->log(Gadgetron::GADGETRON_LOG_LEVEL_DEBUG, fname.c_str(), line, msg.c_str());
+	  }
+     }
+}

--- a/gadgets/bart/bartgadget.cpp
+++ b/gadgets/bart/bartgadget.cpp
@@ -1,11 +1,16 @@
-/****************************************************************************************************************************
-* Description: Gadget using the Berkeley Advanced Reconstruction Toolbox (BART)
-* Author: Mahamadou Diakite, PhD.
-* Institution: National Institutes of Health (NIH)
-* Lang: C++
-* Date: 10/15/2017
-* Version: 1.0.0
-****************************************************************************************************************************/
+/******************************************************************************
+ * Description: Gadget using the Berkeley Advanced Reconstruction Toolbox (BART)
+ * Authors: 
+ *   Mahamadou Diakite, PhD. [1]
+ *   Nguyen Damien, PhD. [2]
+ *   Francesco Santini, PhD. [2]
+ * Institutions: 
+ *   [1] National Institutes of Health (NIH)
+ *   [2] University of Basel, Switzerland
+ * Lang: C++
+ * Date: 08/10/2018
+ * Version: 1.5.0
+ ******************************************************************************/
 
 #include "bartgadget.h"
 #include <boost/tokenizer.hpp>
@@ -14,6 +19,7 @@
 #include <numeric>
 #include <cstdlib>
 #include <ctime>
+#include <chrono>
 #include <memory>
 #include <random>
 #include <functional>
@@ -21,561 +27,657 @@
 #include <boost/thread.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <errno.h>
+#ifdef _WIN32
+    #include <direct.h>
+    #define getcwd _getcwd
+    #define chdir _chdir
+#else
+    #include <unistd.h>
+#endif
 
+#include "bart/bart_embed_api.h"
+
+enum bart_debug_levels { BART_DP_ERROR, BART_DP_WARN, BART_DP_INFO, BART_DP_DEBUG1, BART_DP_DEBUG2, BART_DP_DEBUG3, BART_DP_DEBUG4, BART_DP_TRACE, BART_DP_ALL };
+
+namespace internal {
+     namespace fs = Gadgetron::fs;
+     
+     class ScopeGuard
+     {
+     public:
+	  ScopeGuard(fs::path p) : p_(std::move(p))
+	       {
+		    char buf[1024] = { '\0' };
+		    auto* ptr = getcwd(buf, 1024);
+		    cwd_ = std::string(ptr);
+		    auto r = chdir(p_.c_str());
+	       }
+	  ~ScopeGuard()
+	       {
+		    if (is_active_) {
+			 fs::remove_all(p_);
+		    }
+		    auto r = chdir(cwd_.c_str());
+		    deallocate_all_mem_cfl();
+	       }
+
+	  void dismiss() { is_active_ = false; }
+     private:
+	  bool is_active_;
+	  const fs::path p_;
+	  fs::path cwd_;
+     };
+     
+     // ========================================================================
+
+     fs::path generate_unique_folder(const fs::path& working_directory)
+     {
+	  typedef std::chrono::system_clock clock_t;
+	  
+	  char buff[80];
+	  auto now = clock_t::to_time_t(clock_t::now());
+	  std::strftime(buff, sizeof(buff), "%H_%M_%S__", std::localtime(&now));
+	  std::random_device rd;
+	  auto time_id(buff + std::to_string(std::uniform_int_distribution<>(1, 10000)(rd)));
+	  // Get the current process ID
+	  auto threadId = boost::lexical_cast<std::string>(boost::this_thread::get_id());
+	  auto threadNumber(0UL);
+	  sscanf(threadId.c_str(), "%lx", &threadNumber);
+	  return  working_directory / ("bart_"
+				       + time_id
+				       + "_"
+				       + std::to_string(threadNumber));
+     }
+
+     // ========================================================================
+
+     void ltrim(std::string &str)
+     {
+	  str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int s) {return !std::isspace(s); }));
+     }
+
+     void rtrim(std::string &str)
+     {
+	  str.erase(std::find_if(str.rbegin(), str.rend(), [](int s) {return !std::isspace(s);}).base(), str.end());
+     }
+
+     void trim(std::string &str)
+     {
+	  ltrim(str);
+	  rtrim(str);
+     }
+	
+     std::string get_output_filename(const std::string& bartCommandLine)
+     {
+	  boost::char_separator<char> sep(" ");
+#if 1
+	  boost::tokenizer<boost::char_separator<char>,
+			   std::string::const_reverse_iterator> tokens(bartCommandLine.crbegin(),
+								       bartCommandLine.crend(),
+								       sep);
+	  const auto tok(*tokens.begin());
+	  return std::string(tok.crbegin(), tok.crend());
+#else 
+	  std::string outputFile;
+	  boost::tokenizer<boost::char_separator<char> > tokens(bartCommandLine, sep);
+	  for (auto tok: tokens)
+	       outputFile = tok;
+	  return outputFile;
+#endif /* 1 */
+     }
+}
+
+// =============================================================================
+
+std::vector<size_t> Gadgetron::read_BART_hdr(fs::path filename)
+{
+     return read_BART_hdr<size_t>(filename);
+}
+
+std::pair<std::vector<size_t>, std::vector<std::complex<float>>>
+Gadgetron::read_BART_files(fs::path filename)
+{
+     return read_BART_files<size_t>(filename);
+}
+
+// =============================================================================
 
 namespace Gadgetron {
 
-	BartGadget::BartGadget() :
-		BaseClass(),
-		dp{}
-	{}
+     BartGadget::BartGadget() :
+	  BaseClass(),
+	  dp{}
+     {}
 
-	std::vector<size_t> BartGadget::read_BART_hdr(const std::string& filename)
-	{
-		std::vector<size_t> DIMS;
-
-		std::ifstream infile(filename + ".hdr");
-		if (infile)
-		{
-			std::vector<std::string> tokens;
-			std::string line;
-
-			while (std::getline(infile, line, '\n'))
-			{
-				tokens.push_back(line);
-			}
-
-			// Parse the dimensions
-			std::stringstream ss(tokens[1]);
-			std::string items;
-			while (getline(ss, items, ' ')) {
-				DIMS.push_back(std::stoi(items));
-			}
-		}
-		else
-		{
-			GERROR("Failed to open file: %s\n", filename.c_str());
-		}
-
-		return DIMS;
-	}
-
-
-	std::pair< std::vector<size_t>, std::vector<std::complex<float> > >
-		BartGadget::read_BART_files(const std::string& filename)
-	{
-		// Load the header file
-		auto DIMS = read_BART_hdr(filename);
-
-		// Load the cfl file
-		std::ifstream infile(filename + ".cfl", std::ifstream::binary);
-		if (!infile)
-		{
-			GERROR("Failed to open data of file: %s\n", filename.c_str());
-			return std::make_pair(DIMS, std::vector<std::complex<float>>());
-		}
-		else
-		{
-			// First determine data size
-			infile.seekg(0, infile.end);
-			size_t size(infile.tellg());
-			
-			// Now read data from file
-			infile.seekg(0);
-			std::vector<std::complex<float>> Data(size/sizeof(float)/2.);
-			infile.read(reinterpret_cast<char*>(Data.data()), size);
-			
-			return std::make_pair(DIMS, Data);
-		}
-	}
-
-	std::string & BartGadget::getOutputFilename(const std::string & bartCommandLine)
-	{
-		static std::vector<std::string> outputFile;
-		boost::char_separator<char> sep(" ");
-		boost::tokenizer<boost::char_separator<char> > tokens(bartCommandLine, sep);
-		for (auto itr = tokens.begin(), tokens_end = tokens.end(); itr != tokens_end; ++itr)
-			outputFile.push_back(*itr);
-		return (outputFile.back());
-	}
-
-	inline void BartGadget::cleanup(std::string &createdFiles)
-	{
-		boost::filesystem::remove_all(createdFiles);
-	}
-
-	inline void BartGadget::ltrim(std::string &str)
-	{
-		str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int s) {return !std::isspace(s); }));
-	}
-
-	inline void BartGadget::rtrim(std::string &str)
-	{
-		str.erase(std::find_if(str.rbegin(), str.rend(), [](int s) {return !std::isspace(s);}).base(), str.end());
-	}
-
-	inline void BartGadget::trim(std::string &str)
-	{
-		ltrim(str);
-		rtrim(str);
-	}
+     void BartGadget::replace_default_parameters(std::string & str)
+     {
+	  std::string::size_type pos = 0u;
+	  while ((pos = str.find('$', pos)) != std::string::npos)
+	  {
+	       auto pos_end = str.find(' ', pos);
+	       auto pos_diff = pos_end - pos;
+	       std::string tmp = str.substr(pos, pos_diff);
+	       tmp.erase(0, 1);
+	       if (tmp == std::string("recon_matrix_x"))
+		    str.replace(pos, pos_diff, std::to_string(dp.recon_matrix_x));
+	       else if (tmp == std::string("recon_matrix_y"))
+		    str.replace(pos, pos_diff, std::to_string(dp.recon_matrix_y));
+	       else if (tmp == std::string("recon_matrix_z"))
+		    str.replace(pos, pos_diff, std::to_string(dp.recon_matrix_z));
+	       else if (tmp == std::string("FOV_x"))
+		    str.replace(pos, pos_diff, std::to_string(dp.FOV_x));
+	       else if (tmp == std::string("FOV_y"))
+		    str.replace(pos, pos_diff, std::to_string(dp.FOV_y));
+	       else if (tmp == std::string("FOV_z"))
+		    str.replace(pos, pos_diff, std::to_string(dp.FOV_z));
+	       else if (tmp == std::string("acc_factor_PE1"))
+		    str.replace(pos, pos_diff, std::to_string(dp.acc_factor_PE1));
+	       else if (tmp == std::string("acc_factor_PE2"))
+		    str.replace(pos, pos_diff, std::to_string(dp.acc_factor_PE2));
+	       else if (tmp == std::string("reference_lines_PE1"))
+		    str.replace(pos, pos_diff, std::to_string(dp.reference_lines_PE1));
+	       else if (tmp == std::string("reference_lines_PE2"))
+		    str.replace(pos, pos_diff, std::to_string(dp.reference_lines_PE2));
+	       else {
+		    GERROR( "Unknown default parameter, please see the complete list of available parameters...");
+	       }
+	       pos = pos_end;
+	  }
+     }
+     
 	
-	void BartGadget::replace_default_parameters(std::string & str)
-	{
-		std::string::size_type pos = 0u;
-		while ((pos = str.find('$', pos)) != std::string::npos)
-		{
-			auto pos_end = str.find(' ', pos);
-			auto pos_diff = pos_end - pos;
-			std::string tmp = str.substr(pos, pos_diff);
-			tmp.erase(0, 1);
-			if (tmp == std::string("recon_matrix_x"))
-				str.replace(pos, pos_diff, std::to_string(dp.recon_matrix_x));
-			else if (tmp == std::string("recon_matrix_y"))
-				str.replace(pos, pos_diff, std::to_string(dp.recon_matrix_y));
-			else if (tmp == std::string("recon_matrix_z"))
-				str.replace(pos, pos_diff, std::to_string(dp.recon_matrix_z));
-			else if (tmp == std::string("FOV_x"))
-				str.replace(pos, pos_diff, std::to_string(dp.FOV_x));
-			else if (tmp == std::string("FOV_y"))
-				str.replace(pos, pos_diff, std::to_string(dp.FOV_y));
-			else if (tmp == std::string("FOV_z"))
-				str.replace(pos, pos_diff, std::to_string(dp.FOV_z));
-			else if (tmp == std::string("acc_factor_PE1"))
-				str.replace(pos, pos_diff, std::to_string(dp.acc_factor_PE1));
-			else if (tmp == std::string("acc_factor_PE2"))
-				str.replace(pos, pos_diff, std::to_string(dp.acc_factor_PE2));
-			else if (tmp == std::string("reference_lines_PE1"))
-				str.replace(pos, pos_diff, std::to_string(dp.reference_lines_PE1));
-			else if (tmp == std::string("reference_lines_PE2"))
-				str.replace(pos, pos_diff, std::to_string(dp.reference_lines_PE2));
-			else {
-                GERROR( "Unknown default parameter, please see the complete list of available parameters...");
-			}
-			pos = pos_end;
-		}
-	}
-	
-	int BartGadget::process_config(ACE_Message_Block * mb)
-	{
-		GADGET_CHECK_RETURN(BaseClass::process_config(mb) == GADGET_OK, GADGET_FAIL);
+     int BartGadget::process_config(ACE_Message_Block * mb)
+     {
+	  GADGET_CHECK_RETURN(BaseClass::process_config(mb) == GADGET_OK, GADGET_FAIL);
 
-		/** Let's get some information about the incoming data **/
-		ISMRMRD::IsmrmrdHeader h;
-		try
-		{
-			deserialize(mb->rd_ptr(), h);
-		}
-		catch (...)
-		{
-			GDEBUG("BartGadget::process_config: Failed to parse incoming ISMRMRD Header");
-		}
+	  /** Let's get some information about the incoming data **/
+	  ISMRMRD::IsmrmrdHeader h;
+	  try {
+	       deserialize(mb->rd_ptr(), h);
+	  }
+	  catch (...) {
+	       GDEBUG("BartGadget::process_config: Failed to parse incoming ISMRMRD Header");
+	  }
 
+	  // ===================================================================
+	  // Adjust BART's debug level
+	  
+	  GDEBUG_STREAM("BartGadget::process_config: setting BART debug level to "
+			<< BartPrintfDebugLevel.value());
+	  
+	  auto& bart_debug_level(debug_level);
+	  if (BartPrintfDebugLevel.value() == "DP_ERROR") {
+	       bart_debug_level = BART_DP_ERROR;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_WARN") {
+	       bart_debug_level = BART_DP_WARN;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_INFO") {
+	       bart_debug_level = BART_DP_INFO;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_DEBUG1") {
+	       bart_debug_level = BART_DP_DEBUG1;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_DEBUG2") {
+	       bart_debug_level = BART_DP_DEBUG2;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_DEBUG3") {
+	       bart_debug_level = BART_DP_DEBUG3;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_DEBUG4") {
+	       bart_debug_level = BART_DP_DEBUG4;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_TRACE") {
+	       bart_debug_level = BART_DP_TRACE;
+	  }
+	  else if (BartPrintfDebugLevel.value() == "DP_ALL") {
+	       bart_debug_level = BART_DP_ALL;
+	  }
+	  else {
+	       GWARN("Unknown debug level! defaulting to BART_DP_INFO");
+	       bart_debug_level = BART_DP_INFO;
+	  }
 
-		for (size_t ii = 0, h_encoding_size = h.encoding.size(); ii < h_encoding_size; ++ii)
-		{
-			ISMRMRD::EncodingSpace recon_space = h.encoding[ii].reconSpace;
+	  // ===================================================================
+	  // Check status of bart commands script
+	  
+	  command_script_ = AbsoluteBartCommandScript_path.value();
+	  command_script_ /= BartCommandScript_name.value();
 
-			GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Encoding matrix size: " << recon_space.matrixSize.x << " " << recon_space.matrixSize.y << " " << recon_space.matrixSize.z);
-			GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Encoding field_of_view : " << recon_space.fieldOfView_mm.x << " " << recon_space.fieldOfView_mm.y << " " << recon_space.fieldOfView_mm.z);
-			dp.recon_matrix_x = recon_space.matrixSize.x;
-			dp.recon_matrix_y = recon_space.matrixSize.y;
-			dp.recon_matrix_z = recon_space.matrixSize.z;
-			dp.FOV_x = static_cast<uint16_t>(recon_space.fieldOfView_mm.x);
-			dp.FOV_y = static_cast<uint16_t>(recon_space.fieldOfView_mm.y);
-			dp.FOV_z = static_cast<uint16_t>(recon_space.fieldOfView_mm.z);
+	  if (!fs::exists(command_script_)) {
+	       GERROR("Can't find bart commands script: %s!\n", command_script_.c_str());
+	       return GADGET_FAIL;
+	  }
 
-			if (!h.encoding[ii].parallelImaging)
-			{
-				GDEBUG_STREAM("BartGadget::process_config: Parallel Imaging not enable...");
-			}
-			else
-			{
-				ISMRMRD::ParallelImaging p_imaging = *h.encoding[0].parallelImaging;
-				GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: acceleration Factor along PE1 is " << p_imaging.accelerationFactor.kspace_encoding_step_1);
-				GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: acceleration Factor along PE2 is " << p_imaging.accelerationFactor.kspace_encoding_step_2);
-				dp.acc_factor_PE1 = p_imaging.accelerationFactor.kspace_encoding_step_1;
-				dp.acc_factor_PE2 = p_imaging.accelerationFactor.kspace_encoding_step_2;
+	  // ===================================================================
 
-				if (p_imaging.accelerationFactor.kspace_encoding_step_2 > 1) {
-					GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Limits of the size of the calibration region (PE1) " << h.userParameters->userParameterLong[0].name << " is " << h.userParameters->userParameterLong[0].value);
-					GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Limits of the size of the calibration region (PE2) " << h.userParameters->userParameterLong[1].name << " is " << h.userParameters->userParameterLong[1].value);
-					dp.reference_lines_PE1 = h.userParameters->userParameterLong[0].value;
-					dp.reference_lines_PE2 = h.userParameters->userParameterLong[1].value;
-				}
-				else if (p_imaging.accelerationFactor.kspace_encoding_step_1 > 1) {
-					GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Limits of the size of the calibration region (PE1) " << h.userParameters->userParameterLong[0].name << " is " << h.userParameters->userParameterLong[0].value);
-					dp.reference_lines_PE1 = h.userParameters->userParameterLong[0].value;
-				}
+	  memory_behaviour_ = BART_MIX_DISK_MEM;
+	  if (BartFileBehaviour.value() == "BART_ALL_IN_MEM") {
+	       memory_behaviour_ = BART_ALL_IN_MEM;
+	  }
+	  else if (BartFileBehaviour.value() == "BART_MIX_DISK_MEM") {
+	       memory_behaviour_ = BART_MIX_DISK_MEM;
+	  }
+	  else {
+	       GERROR_STREAM("Invalid value specified for BartFileBehaviour: " << BartFileBehaviour.value());
+	       return GADGET_FAIL;
+	  }
 
-				std::string calib = *p_imaging.calibrationMode;
+	  // ===================================================================
 
-				auto separate = (calib.compare("separate") == 0);
-				auto embedded = (calib.compare("embedded") == 0);
-				auto external = (calib.compare("external") == 0);
-				auto interleaved = (calib.compare("interleaved") == 0);
-				auto other = (calib.compare("other") == 0);
+	  for (const auto& enc: h.encoding) {
+	       auto recon_space = enc.reconSpace;
 
-				if (p_imaging.accelerationFactor.kspace_encoding_step_1 > 1 || p_imaging.accelerationFactor.kspace_encoding_step_2 > 1)
-				{
-					if (interleaved) {
-						GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode INTERLEAVE ");
-					}
-					else if (embedded) {
-						GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode EMBEDDED");
-					}
-					else if (separate) {
-						GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode SEPERATE");
-					}
-					else if (external) {
-						GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode EXTERNAL");
-					}
-					else if (other) {
-						GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode OTHER");
-					}
-					else {
-						GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Something went terribly wrong, this should never happen!");
-						return GADGET_FAIL;
-					}
-				}
+	       GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Encoding matrix size: " << recon_space.matrixSize.x << " " << recon_space.matrixSize.y << " " << recon_space.matrixSize.z);
+	       GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Encoding field_of_view : " << recon_space.fieldOfView_mm.x << " " << recon_space.fieldOfView_mm.y << " " << recon_space.fieldOfView_mm.z);
+	       dp.recon_matrix_x = recon_space.matrixSize.x;
+	       dp.recon_matrix_y = recon_space.matrixSize.y;
+	       dp.recon_matrix_z = recon_space.matrixSize.z;
+	       dp.FOV_x = static_cast<uint16_t>(recon_space.fieldOfView_mm.x);
+	       dp.FOV_y = static_cast<uint16_t>(recon_space.fieldOfView_mm.y);
+	       dp.FOV_z = static_cast<uint16_t>(recon_space.fieldOfView_mm.z);
 
-			}
+	       if (!enc.parallelImaging)
+	       {
+		    GDEBUG_STREAM("BartGadget::process_config: Parallel Imaging not enable...");
+	       }
+	       else
+	       {
+		    auto p_imaging = *h.encoding.front().parallelImaging;
+		    GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: acceleration Factor along PE1 is " << p_imaging.accelerationFactor.kspace_encoding_step_1);
+		    GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: acceleration Factor along PE2 is " << p_imaging.accelerationFactor.kspace_encoding_step_2);
+		    dp.acc_factor_PE1 = p_imaging.accelerationFactor.kspace_encoding_step_1;
+		    dp.acc_factor_PE2 = p_imaging.accelerationFactor.kspace_encoding_step_2;
 
-		}
-		return GADGET_OK;
-	}
+		    if (p_imaging.accelerationFactor.kspace_encoding_step_2 > 1) {
+			 GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Limits of the size of the calibration region (PE1) " << h.userParameters->userParameterLong[0].name << " is " << h.userParameters->userParameterLong[0].value);
+			 GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Limits of the size of the calibration region (PE2) " << h.userParameters->userParameterLong[1].name << " is " << h.userParameters->userParameterLong[1].value);
+			 dp.reference_lines_PE1 = h.userParameters->userParameterLong[0].value;
+			 dp.reference_lines_PE2 = h.userParameters->userParameterLong[1].value;
+		    }
+		    else if (p_imaging.accelerationFactor.kspace_encoding_step_1 > 1) {
+			 GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Limits of the size of the calibration region (PE1) " << h.userParameters->userParameterLong[0].name << " is " << h.userParameters->userParameterLong[0].value);
+			 dp.reference_lines_PE1 = h.userParameters->userParameterLong[0].value;
+		    }
 
-	int BartGadget::process(GadgetContainerMessage<IsmrmrdReconData>* m1)
-	{        
-                static std::mutex mtx;
-		std::lock_guard<std::mutex> guard(mtx);
+		    auto calib = *p_imaging.calibrationMode;
+		    auto separate = (calib.compare("separate") == 0);
+		    auto embedded = (calib.compare("embedded") == 0);
+		    auto external = (calib.compare("external") == 0);
+		    auto interleaved = (calib.compare("interleaved") == 0);
+		    auto other = (calib.compare("other") == 0);
 
-		// Check status of bart commands script
-		std::string CommandScript = AbsoluteBartCommandScript_path.value() + "/" + BartCommandScript_name.value();
-		if (!boost::filesystem::exists(CommandScript))
-		{
-			GERROR("Can't find bart commands script: %s!\n", CommandScript.c_str());
-			return GADGET_FAIL;
-		}
+		    if (p_imaging.accelerationFactor.kspace_encoding_step_1 > 1 || p_imaging.accelerationFactor.kspace_encoding_step_2 > 1)
+		    {
+			 if (interleaved) {
+			      GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode INTERLEAVE ");
+			 }
+			 else if (embedded) {
+			      GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode EMBEDDED");
+			 }
+			 else if (separate) {
+			      GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode SEPERATE");
+			 }
+			 else if (external) {
+			      GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode EXTERNAL");
+			 }
+			 else if (other) {
+			      GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Calibration mode OTHER");
+			 }
+			 else {
+			      GDEBUG_CONDITION_STREAM(isVerboseON.value(), "BartGadget::process_config: Something went terribly wrong, this should never happen!");
+			      return GADGET_FAIL;
+			 }
+		    }
 
-		// set the permission for the script
-#ifdef _WIN32
-		try
-		{
-			boost::filesystem::permissions(CommandScript, boost::filesystem::all_all);
-		}
-		catch (...)
-		{
-			GERROR("Error changing the permission of the command script.\n");
-			return GADGET_FAIL;
-		}
+	       }
+
+	  }
+	  return GADGET_OK;
+     }
+
+     int BartGadget::process(GadgetContainerMessage<IsmrmrdReconData>* m1)
+     {
+	  static std::mutex mtx;
+	  std::lock_guard<std::mutex> guard(mtx);
+
+	  constexpr auto memonly_cfl = 
+#ifdef MEMONLY_CFL
+	       true
 #else
-		// in case an older version of boost is used in non-win system
-		// the system call is used
-		int res = chmod(CommandScript.c_str(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH);
-		if (res != 0)
-		{
-			GERROR("Error changing the permission of the command script.\n");
-			return GADGET_FAIL;
-		}
-#endif // _WIN32
+	       false
+#endif /* MEMONLY_CFL */
+	       ;
+	  
+	  auto generated_files_folder(internal::generate_unique_folder(BartWorkingDirectory_path.value()));
 
-		// Check status of the folder containing the generated files (*.hdr & *.cfl)
-		std::string generatedFilesFolder;
-		static std::string outputFolderPath;
-        if (BartWorkingDirectory_path.value().empty()){
-            GERROR("Error: No BART working directory provided!");
-            return GADGET_FAIL;
-        }
+	  bool create_folder(!memonly_cfl
+			     || memory_behaviour_ != BART_ALL_IN_MEM);
+	  if (create_folder) {
+	       if (!(fs::exists(generated_files_folder)
+		     && fs::is_directory(generated_files_folder))) {
+		    if (fs::create_directories(generated_files_folder)){
+			 GDEBUG_STREAM("Folder to store *.hdr & *.cfl files is " << generated_files_folder);
+		    }
+		    else {
+			 GERROR("Folder to store *.hdr & *.cfl files doesn't exist...\n");
+			 return GADGET_FAIL;
+		    }
+	       }
+	  }
+	  	  
+	  internal::ScopeGuard cleanup_guard(generated_files_folder);
+	  if (!create_folder) {
+	       cleanup_guard.dismiss();	       
+	  }
 
-		time_t rawtime;
-		char buff[80];
-		time(&rawtime);
-		strftime(buff, sizeof(buff), "%H_%M_%S__", localtime(&rawtime));
-		std::mt19937::result_type seed = static_cast<unsigned long>(time(0));
-		auto dice_rand = std::bind(std::uniform_int_distribution<int>(1, 10000), std::mt19937(seed));
-		std::string time_id(buff + std::to_string(dice_rand()));
-                // Get the current process ID
- 		std::string threadId = boost::lexical_cast<std::string>(boost::this_thread::get_id());
-                unsigned long threadNumber = 0;
-                sscanf(threadId.c_str(), "%lx", &threadNumber);
-                outputFolderPath = BartWorkingDirectory_path.value() + "bart_" + time_id + "_" + std::to_string(threadNumber) + "/";
-                generatedFilesFolder = std::string(outputFolderPath);
-                
-		generatedFilesFolder.pop_back();
-	
-		boost::filesystem::path dir(generatedFilesFolder);
-		if (!boost::filesystem::exists(dir) || !boost::filesystem::is_directory(dir)){
-			if (boost::filesystem::create_directories(dir)){
-				GDEBUG("Folder to store *.hdr & *.cfl files is %s\n", generatedFilesFolder.c_str());
-                        }
-			else {
-				GERROR("Folder to store *.hdr & *.cfl files doesn't exist...\n");
-				return GADGET_FAIL;
-			}
-                }
-
-		generatedFilesFolder += "/";
-
-		/*USE WITH CAUTION*/
-		if (boost::filesystem::exists(generatedFilesFolder) && isBartFolderBeingCachedToVM.value() && !isBartFileBeingStored.value())
-		{
-			std::ostringstream cmd;
-			cmd << "mount -t tmpfs -o size" << AllocateMemorySizeInMegabytes.value() << "M, mode=0755 tmpfs " << generatedFilesFolder;
-			if (system(cmd.str().c_str())) {
-				cleanup(outputFolderPath);
-				return GADGET_FAIL;
-			}
-		}
+	  // Gadgetron data is always in-memory
+	  const auto ref_filename_src  = std::string("meas_gadgetron_ref")   + (!memonly_cfl ? ".mem" : "");
+	  const auto data_filename_src = std::string("meas_gadgetron_input") + (!memonly_cfl ? ".mem" : "");
+	  const auto traj_filename_src = std::string("meas_gadgetron_traj")  + (!memonly_cfl ? ".mem" : "");
 
 
-		std::vector<uint16_t> DIMS_ref, DIMS;
+	  /* Data provided to the user might or might not be in-memory
+	   *
+	   * - if -DMEMONLY_CFL then we're always in-memory without extension
+	   * - otherwise we add the *.mem extension if
+	   *     + if the memory behaviour is BART_ALL_IN_MEM
+	   *     + or if the memory behaviour is BART_MIX_DISK_MEM and the user requests it
+	   */
+	  const auto append_mem_ext_in(!memonly_cfl
+				       && (memory_behaviour_ == BART_ALL_IN_MEM
+					   || (memory_behaviour_ == BART_MIX_DISK_MEM
+					       && BartStoreGadgetronInputInMemory.value())));
+	  
+	  const auto ref_filename  = std::string("reference_data") + (append_mem_ext_in ? ".mem" : "");
+	  const auto data_filename = std::string("input_data")     + (append_mem_ext_in ? ".mem" : "");
+	  const auto traj_filename = std::string("traj_data")      + (append_mem_ext_in ? ".mem" : "");
 
-		/*** WRITE REFERENCE AND RAW DATA TO FILES ***/
+	  
+	  /*** PROCESS EACH DATASET ***/
+	  	  
+	  auto it(0UL);
+	  for(auto& recon_bit: m1->getObjectPtr()->rbit_) {
 
-		size_t encoding = 0;
-		for (std::vector<IsmrmrdReconBit>::iterator it = m1->getObjectPtr()->rbit_.begin(), rbit_end =  m1->getObjectPtr()->rbit_.end(); it != rbit_end; ++it)
-		{
-			std::stringstream os;
-			os << "_encoding_" << encoding;
+	       bool has_traj(recon_bit.data_.trajectory_);
+	       
+	       // Grab a reference to the buffer containing the reference data
+	       auto& input_ref = (*recon_bit.ref_).data_;
+	       // Data 7D, fixed order [E0, E1, E2, CHA, N, S, LOC]
+	       std::vector<long> DIMS_ref{static_cast<long>(input_ref.get_size(0)),
+					  static_cast<long>(input_ref.get_size(1)),
+					  static_cast<long>(input_ref.get_size(2)),
+					  static_cast<long>(input_ref.get_size(3)),
+					  static_cast<long>(input_ref.get_size(4)),
+					  static_cast<long>(input_ref.get_size(5)),
+					  static_cast<long>(input_ref.get_size(6))};
 
-			// Grab a reference to the buffer containing the reference data
-			auto  & dbuff_ref = it->ref_;
-			hoNDArray< std::complex<float> >& ref = (*dbuff_ref).data_;
-			// Data 7D, fixed order [E0, E1, E2, CHA, N, S, LOC]
-			uint16_t E0_ref = static_cast<uint16_t>(ref.get_size(0));
-			uint16_t E1_ref = static_cast<uint16_t>(ref.get_size(1));
-			uint16_t E2_ref = static_cast<uint16_t>(ref.get_size(2));
-			uint16_t CHA_ref = static_cast<uint16_t>(ref.get_size(3));
-			uint16_t N_ref = static_cast<uint16_t>(ref.get_size(4));
-			uint16_t S_ref = static_cast<uint16_t>(ref.get_size(5));
-			uint16_t LOC_ref = static_cast<uint16_t>(ref.get_size(6));
-			DIMS_ref = { E0_ref, E1_ref, E2_ref, CHA_ref, N_ref, S_ref, LOC_ref };
+	       // Grab a reference to the buffer containing the image data
+	       auto& input = recon_bit.data_.data_;
+	       // Data 7D, fixed order [E0, E1, E2, CHA, N, S, LOC]
+	       std::vector<long> DIMS{static_cast<long>(input.get_size(0)),
+				      static_cast<long>(input.get_size(1)),
+				      static_cast<long>(input.get_size(2)),
+				      static_cast<long>(input.get_size(3)),
+				      static_cast<long>(input.get_size(4)),
+				      static_cast<long>(input.get_size(5)),
+				      static_cast<long>(input.get_size(6))};
 
-			// Grab a reference to the buffer containing the image data
-			IsmrmrdDataBuffered & dbuff = it->data_;
-			// Data 7D, fixed order [E0, E1, E2, CHA, N, S, LOC]
-			uint16_t E0 = static_cast<uint16_t>(dbuff.data_.get_size(0));
-			uint16_t E1 = static_cast<uint16_t>(dbuff.data_.get_size(1));
-			uint16_t E2 = static_cast<uint16_t>(dbuff.data_.get_size(2));
-			uint16_t CHA = static_cast<uint16_t>(dbuff.data_.get_size(3));
-			uint16_t N = static_cast<uint16_t>(dbuff.data_.get_size(4));
-			uint16_t S = static_cast<uint16_t>(dbuff.data_.get_size(5));
-			uint16_t LOC = static_cast<uint16_t>(dbuff.data_.get_size(6));
-			// Set up data to be written into files
-			DIMS = { E0, E1, E2, CHA, N, S, LOC };
+	       // Grab a reference to the buffer containing the image trajectory data (if present)
+	       std::unique_ptr<hoNDArray<std::complex<float>>> traj(nullptr);
+	       if (has_traj) {
+		    auto& traj_real = *recon_bit.data_.trajectory_;
+		    traj = std::make_unique<hoNDArray<std::complex<float>>>(traj_real.get_dimensions());
+		    // Data 7D, fixed order [E0, E1, E2, CHA, N, S, LOC]
+		    std::vector<long> DIMS_traj{static_cast<long>(traj_real.get_size(0)),
+						static_cast<long>(traj_real.get_size(1)),
+						static_cast<long>(traj_real.get_size(2)),
+						static_cast<long>(traj_real.get_size(3)),
+						static_cast<long>(traj_real.get_size(4)),
+						static_cast<long>(traj_real.get_size(5)),
+						static_cast<long>(traj_real.get_size(6))};
+		    std::transform(traj_real.begin(), traj_real.end(), 
+				   traj->begin(), 
+				   [] (float r) { return std::complex<float>(r, 0.); });
 
-			/* The reference data will be pointing to the image data if there is
-				no reference scan. Therefore, we won't write the reference data
-				into files if it's pointing to the raw data.*/
-			if (DIMS_ref != DIMS) {
-				std::vector<float> Temp_ref;
-				Temp_ref.reserve(2 * E0_ref*E1_ref*E2_ref*CHA_ref*N_ref*S_ref*LOC_ref);
+		    register_mem_cfl_non_managed(traj_filename_src.c_str(), DIMS_traj.size(), &DIMS_traj[0], &(*traj)[0]);
+	       }
 
-				for (uint16_t loc = 0; loc < LOC_ref; ++loc) {
-					for (uint16_t s = 0; s < S_ref; ++s) {
-						for (uint16_t n = 0; n < N_ref; ++n) {
+	       /* The reference data will be pointing to the image data if there is
+		  no reference scan. Therefore, we won't write the reference data
+		  into files if it's pointing to the raw data.*/
+	       if (DIMS_ref != DIMS)
+	       {
+		    register_mem_cfl_non_managed(ref_filename_src.c_str(), DIMS_ref.size(), &DIMS_ref[0], &input_ref[0]);
+	       }
 
-							//Grab a wrapper around the relevant chunk of data [E0,E1,E2,CHA] for this loc, n, and s
-							//Each chunk will be [E0,E1,E2,CHA] big
-							std::vector<size_t> chunk_dims(4);
-							chunk_dims[0] = E0_ref;
-							chunk_dims[1] = E1_ref;
-							chunk_dims[2] = E2_ref;
-							chunk_dims[3] = CHA_ref;
-							hoNDArray<std::complex<float> > chunk = hoNDArray<std::complex<float> >(chunk_dims, &(*dbuff_ref).data_(0, 0, 0, 0, n, s, loc));
-							std::vector<size_t> new_chunk_dims(1);
-							new_chunk_dims[0] = E0_ref*E1_ref*E2_ref*CHA_ref;
-							chunk.reshape(new_chunk_dims);
-							// Fill BART container
-							for (auto e : chunk) {
-								Temp_ref.push_back(std::move(e.real()));
-								Temp_ref.push_back(std::move(e.imag()));
-							}
-						}
-					}
-				}
+	       register_mem_cfl_non_managed(data_filename_src.c_str(), DIMS.size(), &DIMS[0], &input[0]);
 
-				write_BART_Files(std::string(generatedFilesFolder + "meas_gadgetron_ref").c_str(), DIMS_ref, Temp_ref);
-			}
+	       
+	       if (DIMS_ref != DIMS)
+	       {
+		    std::ostringstream cmd;
+		    cmd << "bart resize -c 0 " << DIMS[0] << " 1 " << DIMS[1] << " 2 " << DIMS[2]
+			<< " " << ref_filename_src << " " << ref_filename;
 
-			auto cm1 = std::make_unique<GadgetContainerMessage<IsmrmrdImageArray>>();
-			std::vector<float> Temp;
-			Temp.reserve(2 * E0*E1*E2*CHA*N*S*LOC);
+		    GDEBUG_STREAM("Gadgetron data is loaded to " << ref_filename_src);
+		    GDEBUG_STREAM("BART filename for reference data is " << ref_filename);
+		    
+		    if (!call_BART(cmd.str()))
+		    {
+			 return GADGET_FAIL;
+		    }
+	       }
 
-			for (uint16_t loc = 0; loc < LOC; loc++) {
-				for (uint16_t s = 0; s < S; s++) {
-					for (uint16_t n = 0; n < N; n++) {
+	       std::ostringstream cmd2;
+	       if (DIMS[4] != 1)
+		    cmd2 << "bart reshape 1023 " << DIMS[0] << " " << DIMS[1] << " " << DIMS[2] << " " << DIMS[3] << " 1 1 1 " << DIMS[5] << " " << DIMS[6] << " " << DIMS[4];
+	       else	
+		    cmd2 << "bart copy";
 
-						//Grab a wrapper around the relevant chunk of data [E0,E1,E2,CHA] for this loc, n, and s
-						//Each chunk will be [E0,E1,E2,CHA] big
-						std::vector<size_t> chunk_dims(4);
-						chunk_dims[0] = E0;
-						chunk_dims[1] = E1;
-						chunk_dims[2] = E2;
-						chunk_dims[3] = CHA;
-						hoNDArray<std::complex<float> > chunk = hoNDArray<std::complex<float> >(chunk_dims, &dbuff.data_(0, 0, 0, 0, n, s, loc));
+	       cmd2 << " " << data_filename_src << " " << data_filename;
+	       
+	       GDEBUG_STREAM("Gadgetron data is loaded to " << data_filename_src);
+	       GDEBUG_STREAM("BART filename for data is " << data_filename);
+	       
+	       if (!call_BART(cmd2.str()))
+	       {
+		    return GADGET_FAIL;
+	       }
 
-						std::vector<size_t> new_chunk_dims(1);
-						new_chunk_dims[0] = E0*E1*E2*CHA;
-						chunk.reshape(new_chunk_dims);
-						// Fill BART container
-						for (auto e : chunk) {
-							Temp.push_back(std::move(e.real()));
-							Temp.push_back(std::move(e.imag()));
-						}
-					}
-				}
-			}
+	       if (has_traj) {
+		    std::ostringstream cmd3;
+		    if (DIMS[4] != 1)
+			 cmd3 << "bart reshape 1023 " << DIMS[0] << " " << DIMS[1] << " " << DIMS[2] << " " << DIMS[3] << " 1 1 1 " << DIMS[5] << " " << DIMS[6] << " " << DIMS[4];
+		    else	
+			 cmd3 << "bart copy";
+		    
+		    cmd3 << " " << traj_filename_src << " " << traj_filename;
+	       
+		    GDEBUG_STREAM("Gadgetron trajectory is loaded to " << traj_filename_src);
+		    GDEBUG_STREAM("BART filename for trajectory is " << traj_filename);
+		    
+		    if (!call_BART(cmd3.str()))
+		    {
+			 return GADGET_FAIL;
+		    }
+	       }
 
-			write_BART_Files(std::string(generatedFilesFolder + "meas_gadgetron").c_str(), DIMS, Temp);
+	       /*** CALL BART COMMAND LINE from the scripting file ***/
+	       GDEBUG("Starting processing user script\n");
 
-			encoding++;
-		}
+	       std::string Commands_Line;
+	       std::fstream inputFile(command_script_.string());
+	       if (inputFile)
+	       {
+		    std::string Line;
+		    while (getline(inputFile, Line))
+		    {
+			 // crop comment
+			 Line = Line.substr(0, Line.find_first_of("#"));
 
-		/* Before calling Bart let's do some bookkeeping */
-		std::ostringstream cmd1, cmd2, cmd3;
-		std::replace(generatedFilesFolder.begin(), generatedFilesFolder.end(), '\\', '/');
-
-		if (DIMS_ref != DIMS)
-		{
-			cmd1 << "bart resize -c 0 " << DIMS[0] << " 1 " << DIMS[1] << " 2 " << DIMS[2] << " meas_gadgetron_ref reference_data";
-			// Pass commands to Bart
-			if (system(std::string("cd " + generatedFilesFolder + "&&" + cmd1.str()).c_str())) {
-				cleanup(outputFolderPath);
-				return GADGET_FAIL;
-			}
-		}
-
-		if (DIMS[4] != 1)
-			cmd2 << "bart reshape 1023 " << DIMS[0] << " " << DIMS[1] << " " << DIMS[2] << " " << DIMS[3] << " 1 1 1 " << DIMS[5] << " " << DIMS[6] << " " << DIMS[4] << " meas_gadgetron input_data";
-		else	
-			cmd2 << "bart scale 1.0 meas_gadgetron input_data";
-
-		if (system(std::string("cd " + generatedFilesFolder + "&&" + cmd2.str()).c_str())) {
-			cleanup(outputFolderPath);
-			return GADGET_FAIL;
-		}
-
-		/*** CALL BART COMMAND LINE from the scripting file***/
-
-		std::string Line, Commands_Line;
-		std::fstream inputFile(CommandScript);
-		if (inputFile.is_open())
-		{
-			while (getline(inputFile, Line))
-			{
-				// crop comment
-				Line = Line.substr(0, Line.find_first_of("#"));
-
-				trim(Line);
-				if (Line.empty() || Line.compare(0, 4, "bart") != 0)
-					continue;
+			 internal::trim(Line);
+			 if (Line.empty() || Line.compare(0, 4, "bart") != 0)
+			      continue;
 				
-				replace_default_parameters(Line);
-				GDEBUG("%s\n", Line.c_str());
-				
-				auto ret = system(std::string("cd " + generatedFilesFolder + "&&" + Line).c_str());
-				(void)ret;
-				
-				Commands_Line = Line;
-			}
-			inputFile.close();
-		}
-		else
-		{
-			GERROR("Unable to open %s\n", CommandScript.c_str());
-			cleanup(outputFolderPath);
-			return GADGET_FAIL;
-		}
+			 replace_default_parameters(Line);
+			 if (!call_BART(Line))
+			 {
+			      return GADGET_FAIL;
+			 }
 
-		std::string outputFile = getOutputFilename(Commands_Line);
+			 Commands_Line = Line;
+		    }
+	       }
+	       else
+	       {
+		    GERROR("Unable to open %s\n", command_script_.c_str());
+		    return GADGET_FAIL;
+	       }
 
-		// Reformat the data back to gadgetron format
-		auto header = read_BART_hdr(std::string(generatedFilesFolder + outputFile).c_str());
-		cmd3 << "bart reshape 1023 " << header[0] << " " << header[1] << " " << header[2] << " " << header[3] << " " << header[9] * header[4] <<
-			" " << header[5] << " " << header[6] << " " << header[7] << " " << header[8] << " 1 " << outputFile << " " << outputFile + std::string("_reshape");
-		const auto cmd_s = cmd3.str();
-		GDEBUG("%s\n", cmd_s.c_str());
-		if (system(std::string("cd " + generatedFilesFolder + "&&" + cmd_s).c_str())) {
-			cleanup(outputFolderPath);
-			return GADGET_FAIL;
-		}
+	       // ==============================================================
+	       
+	       fs::path outputFile(internal::get_output_filename(Commands_Line));
+	       GDEBUG_STREAM("Detected last output file: " << outputFile);
 
-		std::string outputfile_2 = getOutputFilename(cmd_s);
-		/**** READ FROM BART FILES ***/
-		std::pair< std::vector<size_t>, std::vector<std::complex<float> > > BART_DATA = read_BART_files(std::string(generatedFilesFolder + outputfile_2).c_str());
+	       // Reshaped data is always in-memory
+	       fs::path outputFileReshape(outputFile);
 
-		if (!isBartFileBeingStored.value())
-			cleanup(outputFolderPath);
+	       // Remove the extension from the user's output if needed
+	       if (outputFileReshape.extension() == ".mem") {
+		    outputFileReshape.replace_extension();
+	       }
+	       outputFileReshape += std::string("_reshape") + (!memonly_cfl ? ".mem" : "");
+	       
+	       // Reformat the data back to Gadgetron format
+	       std::vector<long> header(16);
+	       if (memonly_cfl || outputFile.extension() == ".mem") {
+		    load_mem_cfl(outputFile.c_str(), header.size(), header.data()); 
+	       }
+	       else {
+		    header = read_BART_hdr<long>(generated_files_folder / outputFile);
+	       }
+	       
+	       std::ostringstream cmd4;
+	       cmd4 << "bart reshape 1023 " << header[0] << " " << header[1] << " " << header[2] << " " << header[3] << " " << header[9] * header[4] <<
+		    " " << header[5] << " " << header[6] << " " << header[7] << " " << header[8] << " 1 " << outputFile.c_str() << " " << outputFileReshape.c_str();
 
-		auto ims = std::make_unique<GadgetContainerMessage<IsmrmrdImageArray>>();
-		IsmrmrdImageArray & imarray = *ims->getObjectPtr();
+	       if (!call_BART(cmd4.str()))
+	       {
+		    return GADGET_FAIL;
+	       }
+	  
+	       /**** READ FROM BART FILES ***/
+	       std::vector<long> DIMS_OUT(16);
+	       auto data = reinterpret_cast<std::complex<float>*>(load_mem_cfl(outputFileReshape.c_str(), DIMS_OUT.size(), DIMS_OUT.data()));
+	       
+	       if (data == 0 || data == nullptr) {
+		    GERROR("Failed to retrieve data from in-memory CFL file!");
+		    return GADGET_FAIL;
+	       }
 
-		// Grab data from BART files
-		std::vector<size_t> BART_DATA_dims(1);
-		BART_DATA_dims[0] = std::accumulate(BART_DATA.first.begin(), BART_DATA.first.end(), 1, std::multiplies<size_t>());
-		hoNDArray<std::complex<float>> DATA = hoNDArray<std::complex<float>>(BART_DATA_dims, &BART_DATA.second[0]);
 
-		// The image array data will be [E0,E1,E2,1,N,S,LOC]
-		std::vector<size_t> data_dims(7);
-		data_dims[0] = BART_DATA.first[0];
-		data_dims[1] = BART_DATA.first[1];
-		data_dims[2] = BART_DATA.first[2];
-		data_dims[3] = BART_DATA.first[3];
-		data_dims[4] = BART_DATA.first[4];
-		data_dims[5] = BART_DATA.first[5];
-		data_dims[6] = BART_DATA.first[6];
+	       if (isBartFileBeingStored.value()) {
+		    cleanup_guard.dismiss();
+	       }
 
-		DATA.reshape(data_dims);
+	       IsmrmrdImageArray imarray;
 
-		// Extract the first image from each time frame (depending on the number of maps generated by the user)
-		std::vector<size_t> data_dims_Final(7);
-		data_dims_Final[0] = BART_DATA.first[0];
-		data_dims_Final[1] = BART_DATA.first[1];
-		data_dims_Final[2] = BART_DATA.first[2];
-		data_dims_Final[3] = BART_DATA.first[3];
-		assert(header[4] > 0);
-		data_dims_Final[4] = BART_DATA.first[4] / header[4];
-		data_dims_Final[5] = BART_DATA.first[5];
-		data_dims_Final[6] = BART_DATA.first[6];
-		imarray.data_.create(&data_dims_Final);
+	       // Grab data from BART files
+	       std::vector<size_t> BART_DATA_dims{
+		    static_cast<size_t>(std::accumulate(DIMS_OUT.begin(), DIMS_OUT.end(), 1, std::multiplies<size_t>()))};
+	       hoNDArray<std::complex<float>> DATA(BART_DATA_dims, data);
 
-		std::vector<std::complex<float> > DATA_Final;
-		DATA_Final.reserve(std::accumulate(data_dims_Final.begin(), data_dims_Final.end(), 1, std::multiplies<size_t>()));
+	       // The image array data will be [E0,E1,E2,1,N,S,LOC]
+	       std::vector<size_t> data_dims(DIMS_OUT.begin(), DIMS_OUT.begin()+7);
+	       DATA.reshape(data_dims);
 
-		for (uint16_t loc = 0; loc < data_dims[6]; ++loc) {
-			for (uint16_t s = 0; s < data_dims[5]; ++s) {
-				for (uint16_t n = 0; n < data_dims[4]; n += header[4]) {
+	       // Extract the first image from each time frame (depending on the number of maps generated by the user)
+	       std::vector<size_t> data_dims_Final{static_cast<size_t>(DIMS_OUT[0]),
+						   static_cast<size_t>(DIMS_OUT[1]),
+						   static_cast<size_t>(DIMS_OUT[2]),
+						   static_cast<size_t>(DIMS_OUT[3]),
+						   static_cast<size_t>(DIMS_OUT[4] / header[4]),
+						   static_cast<size_t>(DIMS_OUT[5]),
+						   static_cast<size_t>(DIMS_OUT[6])};
+	       assert(header[4] > 0);
+	       imarray.data_.create(data_dims_Final);
 
-					//Grab a wrapper around the relevant chunk of data [E0,E1,E2,CHA] for this loc, n, and s
-					//Each chunk will be [E0,E1,E2,CHA] big
-					std::vector<size_t> chunk_dims(4), Temp_one_1d(1);
-					chunk_dims[0] = data_dims_Final[0];
-					chunk_dims[1] = data_dims_Final[1];
-					chunk_dims[2] = data_dims_Final[2];
-					chunk_dims[3] = data_dims_Final[3];
-					hoNDArray<std::complex<float> > chunk = hoNDArray<std::complex<float> >(chunk_dims, &DATA(0, 0, 0, 0, n, s, loc));
+	       std::vector<std::complex<float> > DATA_Final;
+	       DATA_Final.reserve(std::accumulate(data_dims_Final.begin(), data_dims_Final.end(), 1, std::multiplies<size_t>()));
 
-					Temp_one_1d[0] = chunk_dims[0] * chunk_dims[1] * chunk_dims[2] * chunk_dims[3];
-					chunk.reshape(Temp_one_1d);
-					DATA_Final.insert(DATA_Final.end(), chunk.begin(), chunk.end());
-				}
-			}
-		}
+	       //Each chunk will be [E0,E1,E2,CHA] big
+	       std::vector<size_t> chunk_dims{data_dims_Final[0], data_dims_Final[1], data_dims_Final[2], data_dims_Final[3]};
+	       const std::vector<size_t> Temp_one_1d(1, chunk_dims[0] * chunk_dims[1] * chunk_dims[2] * chunk_dims[3]);
+	  
+	       for (uint16_t loc = 0; loc < data_dims[6]; ++loc) {
+		    for (uint16_t s = 0; s < data_dims[5]; ++s) {
+			 for (uint16_t n = 0; n < data_dims[4]; n += header[4]) {
+			      //Grab a wrapper around the relevant chunk of data [E0,E1,E2,CHA] for this loc, n, and s
+			      auto chunk = hoNDArray<std::complex<float> >(chunk_dims, &DATA(0, 0, 0, 0, n, s, loc));
+			      chunk.reshape(Temp_one_1d);
+			      DATA_Final.insert(DATA_Final.end(), chunk.begin(), chunk.end());
+			 }
+		    }
+	       }
 
-		std::copy(DATA_Final.begin(), DATA_Final.end(), imarray.data_.begin());
+	       std::copy(DATA_Final.begin(), DATA_Final.end(), imarray.data_.begin());
 
-		// Fill image header 
-		for (size_t it = 0, rbit_size = m1->getObjectPtr()->rbit_.size(); it != rbit_size; ++it)
-		{
-			compute_image_header(m1->getObjectPtr()->rbit_[it], imarray, it);
-			send_out_image_array(m1->getObjectPtr()->rbit_[it], imarray, it, image_series.value() + (static_cast<int>(it) + 1), GADGETRON_IMAGE_REGULAR);
-		}
+	       compute_image_header(recon_bit, imarray, it);
+	       send_out_image_array(recon_bit, imarray, it, image_series.value() + (static_cast<int>(it) + 1), GADGETRON_IMAGE_REGULAR);
+	       ++it;
+	  }
 
-		m1->release();
-		return GADGET_OK;
-	}
+	  m1->release();
+	  return GADGET_OK;
+     }
 
-	GADGET_FACTORY_DECLARE(BartGadget)
+     bool call_BART(std::string cmdline)
+     {
+	  GINFO_STREAM("Executing BART command: " << cmdline);
+	  enum { MAX_ARGS = 256 };
+
+	  int argc(0);
+	  char* argv[MAX_ARGS];
+
+	  auto cmdline_s = std::make_unique<char[]>(cmdline.size()+1);
+	  strcpy(cmdline_s.get(), cmdline.c_str());
+
+	  char *p2 = strtok(cmdline_s.get(), " ");
+	  while (p2 && argc < MAX_ARGS-1)
+	  {
+	       argv[argc++] = p2;
+	       p2 = strtok(0, " ");
+	  }
+	  argv[argc] = nullptr;
+	  
+	  // boost::char_separator<char> sep(" ");
+	  // boost::tokenizer<boost::char_separator<char>> tokens(cmdline.begin(),
+	  // 						       cmdline.end(),
+	  // 						       sep);
+	  // std::vector<std::unique_ptr<char[]>> tmp;
+	  // auto k(0UL);
+	  // for (auto tok: tokens) {
+	  //      tmp.push_back(std::make_unique<char[]>(tok.size()+1));
+	  //      strcpy(tmp.back().get(), tok.c_str());
+	  //      argv[k++] = tmp.back().get();
+	  // }
+	  // argc = tmp.size();
+
+	  char out_str[512] = {'\0'};
+	  auto ret(bart_command(512, out_str, argc, argv));
+	  if (ret == 0) {
+	       if (strlen(out_str) > 0) {
+		    GINFO(out_str);
+	       }
+	       return true;
+	  }
+	  else {
+	       GERROR_STREAM("BART command failed with return code: " << ret);
+	       return false;
+	  }
+     }
+
+     GADGET_FACTORY_DECLARE(BartGadget)
 }

--- a/gadgets/bart/bartgadget.h
+++ b/gadgets/bart/bartgadget.h
@@ -42,7 +42,7 @@
 
 namespace Gadgetron {
      namespace fs = boost::filesystem;
-	
+
      // The user is free to add more parameters as the need arises.
      struct Default_parameters 
      {
@@ -99,7 +99,6 @@ namespace Gadgetron {
 #endif /* MEMONLY_CFL */
 	       ;
 	
-
 	  Default_parameters dp;
 	  bart_memory_behaviour memory_behaviour_;
 	  fs::path command_script_;

--- a/gadgets/bart/bartgadget.h
+++ b/gadgets/bart/bartgadget.h
@@ -56,6 +56,9 @@ namespace Gadgetron {
 	  uint16_t acc_factor_PE2;
 	  uint16_t reference_lines_PE1;
 	  uint16_t reference_lines_PE2;
+	  std::string reference_data;
+	  std::string input_data;
+	  std::string traj_data;		
      };
 
      class EXPORTGADGETS_bartgadget BartGadget final : public GenericReconGadget
@@ -87,10 +90,20 @@ namespace Gadgetron {
 	  int process(GadgetContainerMessage<IsmrmrdReconData>* m1);		
 
      private:
+
+	  static constexpr auto memonly_cfl = 
+#ifdef MEMONLY_CFL
+	       true
+#else
+	       false
+#endif /* MEMONLY_CFL */
+	       ;
+	
+
 	  Default_parameters dp;
 	  bart_memory_behaviour memory_behaviour_;
 	  fs::path command_script_;
-		
+
 	  void replace_default_parameters(std::string &str);
 	  
      };

--- a/gadgets/bart/bartgadget.h
+++ b/gadgets/bart/bartgadget.h
@@ -1,11 +1,16 @@
-/****************************************************************************************************************************
-* Description: Gadget using the Berkeley Advanced Reconstruction Toolbox (BART)
-* Author: Mahamadou Diakite, PhD.
-* Institution: National Institutes of Health (NIH)
-* Lang: C++
-* Date: 10/15/2017
-* Version: 1.0.0
-****************************************************************************************************************************/
+/******************************************************************************
+ * Description: Gadget using the Berkeley Advanced Reconstruction Toolbox (BART)
+ * Authors: 
+ *   Mahamadou Diakite, PhD. [1]
+ *   Nguyen Damien, PhD. [2]
+ *   Francesco Santini, PhD. [2]
+ * Institutions: 
+ *   [1] National Institutes of Health (NIH)
+ *   [2] University of Basel, Switzerland
+ * Lang: C++
+ * Date: 08/10/2018
+ * Version: 1.5.0
+ ******************************************************************************/
 
 #ifndef BART_GADGET_H
 #define BART_GADGET_H
@@ -13,14 +18,16 @@
 #include "GenericReconGadget.h"
 #include "gadgetron_mricore_export.h"
 #include "mri_core_data.h"
-#include <boost/filesystem.hpp>
+#include "gadgetron_home.h"
+
 #include <vector>
 #include <cassert>
 #include <fstream>
 #include <algorithm>
 #include <iterator>
 #include <string>
-#include "gadgetron_home.h"
+
+#include <boost/filesystem.hpp>
 
 #if defined (WIN32)
 #ifdef __BUILD_GADGETRON_bartgadget__
@@ -34,95 +41,165 @@
 
 
 namespace Gadgetron {
+     namespace fs = boost::filesystem;
 	
-	// The user is free to add more parameters as the need arises.
-	struct Default_parameters 
-	{
-		uint16_t recon_matrix_x;
-		uint16_t recon_matrix_y;
-		uint16_t recon_matrix_z;
-		uint16_t FOV_x;
-		uint16_t FOV_y;
-		uint16_t FOV_z;
-		uint16_t acc_factor_PE1;
-		uint16_t acc_factor_PE2;
-		uint16_t reference_lines_PE1;
-		uint16_t reference_lines_PE2;
-	};
+     // The user is free to add more parameters as the need arises.
+     struct Default_parameters 
+     {
+	  uint16_t recon_matrix_x;
+	  uint16_t recon_matrix_y;
+	  uint16_t recon_matrix_z;
+	  uint16_t FOV_x;
+	  uint16_t FOV_y;
+	  uint16_t FOV_z;
+	  uint16_t acc_factor_PE1;
+	  uint16_t acc_factor_PE2;
+	  uint16_t reference_lines_PE1;
+	  uint16_t reference_lines_PE2;
+     };
 
-	class EXPORTGADGETS_bartgadget BartGadget final : public GenericReconGadget
-	{
-
-	public:
-		GADGET_DECLARE(BartGadget)
+     class EXPORTGADGETS_bartgadget BartGadget final : public GenericReconGadget
+     {
+     public:
+	  enum bart_memory_behaviour {BART_ALL_IN_MEM, BART_ALL_ON_DISK, BART_MIX_DISK_MEM};
+	  
+	  GADGET_DECLARE(BartGadget);
 		
-		using BaseClass = GenericReconGadget;
+	  using BaseClass = GenericReconGadget;
 
-		BartGadget();
-		~BartGadget() = default;
+	  BartGadget();
+	  ~BartGadget() = default;
 
-	protected:
-		GADGET_PROPERTY(isVerboseON, bool, "Display some information about the incoming data", false);
-        GADGET_PROPERTY(BartWorkingDirectory_path, std::string, "Absolute path to temporary file location", "/tmp/gadgetron/");
-		GADGET_PROPERTY(AbsoluteBartCommandScript_path, std::string, "Absolute path to bart script(s)", get_gadgetron_home().string() + "/share/gadgetron/bart");
-		GADGET_PROPERTY(BartCommandScript_name, std::string, "Script file containing bart command(s) to be loaded", "");
-		GADGET_PROPERTY(isBartFileBeingStored, bool, "Store Bart file", false);
+     protected:
+	  GADGET_PROPERTY(isVerboseON, bool, "Display some information about the incoming data", false);
+	  // This property has no effect if BartGadget is compiled with -DMEMONLY_CFL or if the memory behaviour is either BART_ALL_IN_MEM or BART_ALL_ON_DISK
+	  GADGET_PROPERTY(BartStoreGadgetronInputInMemory, bool, "Whether BartGadget should always store incoming data in-memory (might append *.mem extension)", true);
+	  // The property controls how BART stores CFL files. Possible values are: BART_ALL_IN_MEM, BART_MIX_MEM_DISK, BART_ALL_ON_DISK
+	  GADGET_PROPERTY(BartFileBehaviour, std::string, "Controls how BART stores files: either all in memory, or mixed disk/memory behaviour", "BART_MIX_DISK_MEM");
+	  GADGET_PROPERTY(BartWorkingDirectory_path, std::string, "Absolute path to a temporary file location for generated BART files", "/tmp/gadgetron/");
+	  GADGET_PROPERTY(AbsoluteBartCommandScript_path, std::string, "Absolute path to BART script(s)", get_gadgetron_home().string() + "/share/gadgetron/bart");
+	  GADGET_PROPERTY(BartCommandScript_name, std::string, "Script file containing BART command(s) to be loaded", "");
+	  GADGET_PROPERTY(isBartFileBeingStored, bool, "Keep generated BART files on the disk after the processing ends (has no effect if BART_ALL_IN_MEM is specified as behaviour)", false);
+	  GADGET_PROPERTY(image_series, int, "Set image series", 0);
+	  GADGET_PROPERTY(BartPrintfDebugLevel, std::string, "Debug level for BART outputs (DP_ERROR, DP_WARN, DP_INFO, DP_DEBUG1,etc.)", "DP_INFO");
 
-		GADGET_PROPERTY(image_series, int, "Set image series", 0);
+	  int process_config(ACE_Message_Block* mb);
+	  int process(GadgetContainerMessage<IsmrmrdReconData>* m1);		
 
-		/*Caution: this option must be enable only if the user has root privilege and able to allocation virtual memory*/
-		GADGET_PROPERTY(isBartFolderBeingCachedToVM, bool, "Mount bart directory to the virtual memory for better performance", false);
-		GADGET_PROPERTY(AllocateMemorySizeInMegabytes, int, "Allocate memory to bart directory", 50);
-
-		int process_config(ACE_Message_Block* mb);
-		int process(GadgetContainerMessage<IsmrmrdReconData>* m1);		
-
-
-	private:
-		Default_parameters dp;
+     private:
+	  Default_parameters dp;
+	  bart_memory_behaviour memory_behaviour_;
+	  fs::path command_script_;
 		
-		// Write BART files
-		template<typename T>
-		void write_BART_hdr(const std::string& filename, std::vector<T> &DIMS);
-		template<typename T, typename U>
-		void write_BART_Files(const std::string& filename, std::vector<T> &DIMS, std::vector<U> &DATA);
+	  void replace_default_parameters(std::string &str);
+	  
+     };
 
-		// Read BART files
-		std::vector<size_t> read_BART_hdr(const std::string& filename);
-		std::pair< std::vector<size_t>, std::vector<std::complex<float> > > read_BART_files(const std::string& filename);
+     bool call_BART(std::string cmdline);
 
-		// Utility functions
-		std::string &getOutputFilename(const std::string &bartCommandLine);
-		void cleanup(std::string &createdFiles);
-		void ltrim(std::string &str);
-		void rtrim(std::string &str);
-		void trim(std::string &str);
-		void replace_default_parameters(std::string &str);
-	};
+     // Read BART files     
+     template <typename int_t>
+     std::vector<int_t> read_BART_hdr(fs::path filename)
+     {
+	  std::vector<int_t> DIMS;
+	  
+	  std::ifstream infile((filename += ".hdr").c_str());
+	  if (infile)
+	  {
+	       std::vector<std::string> tokens;
+	       std::string line;
 
+	       while (std::getline(infile, line, '\n'))
+	       {
+		    tokens.push_back(line);
+	       }
 
-	template<typename T>
-	void BartGadget::write_BART_hdr(const std::string& filename, std::vector<T> &DIMS)
-	{
-		constexpr size_t MAX_DIMS = 16;
-		std::vector<size_t> v(MAX_DIMS, 1);
-		assert(DIMS.size() < MAX_DIMS);
-		std::copy(DIMS.cbegin(), DIMS.cend(), v.begin());
-		std::ofstream pFile(filename + ".hdr");
-		if (!pFile.is_open())
-			GERROR("Failed to write into HDR file: %s\n", filename);
-		pFile << "# Dimensions\n";
-		std::copy(v.cbegin(), v.cend(), std::ostream_iterator<size_t>(pFile, " "));
-	}
+	       // Parse the dimensions
+	       std::stringstream ss(tokens[1]);
+	       std::string items;
+	       while (getline(ss, items, ' ')) {
+		    DIMS.push_back(std::stoi(items));
+	       }
+	  }
+	  else
+	  {
+	       GERROR("Failed to open file: %s\n", filename.c_str());
+	  }
 
-	template<typename T, typename U>
-	void BartGadget::write_BART_Files(const std::string& filename, std::vector<T> &DIMS, std::vector<U> &DATA)
-	{
-		write_BART_hdr(filename, DIMS);
-		std::ofstream pFile(filename + ".cfl", std::ofstream::binary);
-		if (!pFile.is_open())
-			GERROR("Failed to write into CFL file: %s\n", filename);
-		pFile.write(reinterpret_cast<const char*>(&DATA[0]), DATA.size() * sizeof(U));
-	}
+	  return DIMS;
+     }
+
+     template <typename int_t>
+     std::pair<std::vector<int_t>, std::vector<std::complex<float>>>
+     read_BART_files(fs::path filename)
+     {
+	  // Load the header file
+	  auto DIMS = read_BART_hdr<int_t>(filename);
+
+	  // Load the cfl file
+	  std::ifstream infile((filename += ".cfl").c_str(), std::ifstream::binary);
+	  if (!infile)
+	  {
+	       GERROR("Failed to open file: %s\n", filename.c_str());
+	       return std::make_pair(DIMS, std::vector<std::complex<float>>());
+	  }
+	  else
+	  {
+	       // First determine data size
+	       infile.seekg(0, infile.end);
+	       size_t size(infile.tellg());
+
+	       // Now read data from file
+	       infile.seekg(0);
+	       std::vector<std::complex<float>> Data(size/sizeof(float)/2.);
+	       infile.read(reinterpret_cast<char*>(Data.data()), size);
+
+	       return std::make_pair(DIMS, Data);
+	  }
+     }
+     
+     // For convenience
+     std::vector<size_t> read_BART_hdr(fs::path filename);
+     std::pair< std::vector<size_t>, std::vector<std::complex<float> > > read_BART_files(fs::path filename);
+
+     // ------------------------------------------------------------------------
+     // Write BART files
+     template<typename int_t>
+     void write_BART_hdr(fs::path filename, const std::vector<int_t>& DIMS)
+     {
+	  constexpr size_t MAX_DIMS = 16;
+	  std::vector<size_t> v(MAX_DIMS, 1);
+	  assert(DIMS.size() < MAX_DIMS);
+	  std::copy(DIMS.cbegin(), DIMS.cend(), v.begin());
+	  std::ofstream pFile((filename += ".hdr").c_str());
+	  if (!pFile)
+	       GERROR("Failed to write into file: %s\n", filename);
+	  pFile << "# Dimensions\n";
+	  std::copy(v.cbegin(), v.cend(), std::ostream_iterator<size_t>(pFile, " "));
+     }
+
+     template<typename int_t>
+     void write_BART_Files(fs::path filename, const std::vector<int_t>& DIMS, const std::vector<std::complex<float>>& DATA)
+     {
+	  GDEBUG("Writing CFL file to %s\n", filename.c_str());
+	  write_BART_hdr(filename, DIMS);
+	  std::ofstream pFile((filename += ".cfl").c_str(),
+			      std::ofstream::out | std::ofstream::binary);
+	  if (!pFile)
+	       GERROR("Failed to write into file: %s\n", filename);
+	  pFile.write(reinterpret_cast<const char*>(&DATA[0]), DATA.size() * sizeof(std::complex<float>));
+     }
+     
+     template<typename int_t>
+     void write_BART_Files(fs::path filename, const std::vector<int_t>&DIMS, const hoNDArray<std::complex<float>>& DATA)
+     {
+	  GDEBUG("Writing CFL file to %s\n", filename.c_str());
+	  write_BART_hdr(filename, DIMS);
+	  std::ofstream pFile((filename += ".cfl").c_str(),
+			      std::ofstream::out | std::ofstream::binary);
+	  if (!pFile)
+	       GERROR("Failed to write into file: %s\n", filename);
+	  pFile.write(reinterpret_cast<const char*>(&DATA[0]), DATA.get_number_of_bytes());
+     }
 } // namespace Gadgetron
 #endif //BART_GADGET_H

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -14,10 +14,14 @@ foreach(test ${TEST_CASE})
     file(APPEND ./test_cases.txt "${test}\n")
 endforeach()
 
-find_program(BARTCMD bart)
-if (BARTCMD)
-  set(TEST_CASE_BART ${TEST_CASE_BART})
-  foreach(test ${TEST_CASE_BART})
-    file(APPEND ./test_cases.txt "${test}\n")
-  endforeach()
+# The USE_BART option is defined in gadgets/CMakeLists.txt
+if(USE_BART) 
+  # If we need to include BART tests, BART_SOURCE_DIR should be defined by now...
+  if(EXISTS ${BART_SOURCE_DIR}/CMakeLists.txt)
+    set(TEST_CASE_BART ${TEST_CASE_BART})
+    foreach(test ${TEST_CASE_BART})
+      file(APPEND ./test_cases.txt "${test}\n")
+    endforeach()
+  endif()
 endif()
+


### PR DESCRIPTION
# Purpose #

Due to recents update to BART, it is now possible to embed BART more easily into other projects. This PR is to better integrate BART within Gadgetron.

----

# New implementation #

## Breaking changes for users ##

Due to the way the new implementation is done, there are a few breaking changes for users of `BartGagdet`. These are all due to the removal of a couple of properties of `BartGadget` which do not make sense anymore:
- `isBartFolderBeingCachedToVM`
- `AllocateMemorySizeInMegabytes`

One possible workaround would be to have the config parser ignore them with an appropriate warning message, but I don't know if that at all possible with Gadgetron as of now and did not look into it.

## Introducing BART as a submodule ##

One big changes due to the embedding of BART into Gagdetron is that now the BART sources need to be compiled at the same time as Gadgetron. [1]

For people with recent CMake installation (>= 3.11), the configuration step of CMake can automatically take care of checking out a copy of the BART sources in the appropriate directory using the `FetchContent` module. For those using Git, I've added a submodule that tracks BART's master branch. This can be initialized during cloning by using `git clone --recursive https://github.com/gadgetron/gadgetron` or by issuing `git submodule update --init` from within the Git repository. Otherwise, users can simply unpack the BART source code in the `gadgets/bart/bart_source' directory.


_[1] Actually this is not entirely true: it would be possible to compile the `libbartmain.a` static library and simply link it to the `BartGadget` library but then one would need to properly add all the library dependencies which could be more error prone._

----

## Implementation details ##

Most of the implementation consist in modernizing the code to use C++11 standard whenever possible, as well as prefer using Boost or standard libraries. The code should therefore be easier to read, understand and maintain.

Also, now BART outputs can be passed through Gadgetron's log interface, which makes error messages easier to find and understand when executing BART scripts.

#### Hacking into BART ####

There is, however, one caveat to the new implementation: getting files to be written to a particular directory is more complicated. The solution I have gone with in this case is to hack into BART and intercept calls to the `create_cfl` and `load_cfl` functions and properly set the working directory that way. In practice, this is done by forcefully renaming those functions in `bart_source/src/misc/mmio.c` and providing replacements in `barthack.cpp`.

Currently, the build process takes care of that, but one solution could be to have a fork of BART that is kept up to date with those two modifications in place and have Gadgetron track that instead of the original repository. I could set up a fork with an automatic update script to keep it up to date with the upstream BART repository.

## Integration tests ##

The integration test for BART currently fail, but that is due to some changes in BART that probably altered the results somewhat as executing the test without this PR with the most recent version of BART fails with an identical message.

```
Running Gadgetron test with: 
  -- ISMRMRD_HOME  : /usr/local
  -- GADGETRON_HOME  : /usr/local/gadgetron
  -- PATH            : [...]
  -- LD_LIBRARY_PATH : [...]
  -- TEST CASE       : bart_cases/bart.cfg
Running test case: bart_cases/bart.cfg
Converting Siemens .dat file to ISMRMRD for the first dependency measurement.
Running Gadgetron recon on the first dependency measurement
Converting Siemens .dat file to ISMRMRD for data measurement.
Running Gadgetron recon on data measurement
Elapsed time: 53.841870069503784
Comparing results
 Shape 1: (48, 1, 1, 120, 160)  numpy: [48, 120, 160]
 Shape 2: (48, 1, 1, 120, 160)  numpy: [48, 120, 160]
 Compare dimensions: True
   --Comparing dimensions: True
   --Comparing values, norm diff : 0.06218795 (threshold: 0.001)
   --Comparing image scales, ratio : 1.0043382613379186 (0.004338261337918592) (threshold: 0.001)
TEST: bart_cases/bart.cfg FAILED
```


