### PR TITLE
Conditional include of node_discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,9 +205,18 @@ endif()
 
 # We actually only use system and thread explicitly, but they require linking in date_time and chrono
 if (WIN32)
-  find_package(Boost 1.64.0 COMPONENTS system thread date_time chrono program_options filesystem timer REQUIRED)
+  find_package(Boost COMPONENTS system thread date_time chrono program_options filesystem timer REQUIRED)
 else()
-  find_package(Boost 1.64.0 COMPONENTS system thread program_options filesystem timer REQUIRED)
+  find_package(Boost COMPONENTS system thread program_options filesystem timer REQUIRED)
+endif()
+
+if (Boost_VERSION GREATER 106400)
+  option(USE_NODE_DISCOVERY "Build node_discovery" ON)
+  MESSAGE("Enabling node_discovery library")
+  add_definitions(-DUSE_NODE_DISCOVERY)
+else()
+  option(USE_NODE_DISCOVERY "Build node_discovery" OFF)
+  MESSAGE("OLD Boost version < 1.64.0, disabling node_discovery")
 endif()
 
 find_package(ACE REQUIRED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,12 +81,15 @@ set(test_src_files tests.cpp
       image_morphology_test.cpp 
       pattern_recognition_test.cpp 
       cmr_mapping_test.cpp
-      node_discovery_test.cpp
       )
 
 if (PYTHONLIBS_FOUND)
     set(test_src_files ${test_src_files} python_converter_test.cpp )
 endif ()
+
+if ( USE_NODE_DISCOVERY )
+    set(test_src_files ${test_src_files} node_discovery_test.cpp)
+endif()
 
 if ( CUDA_FOUND )
 

--- a/toolboxes/CMakeLists.txt
+++ b/toolboxes/CMakeLists.txt
@@ -9,7 +9,10 @@ if (MKL_FOUND)
 endif ()
 
 add_subdirectory(log)
-add_subdirectory(node_discovery)
+
+if (USE_NODE_DISCOVERY)
+  add_subdirectory(node_discovery)
+endif()
 
 add_subdirectory(operators)
 add_subdirectory(solvers)

--- a/toolboxes/cloudbus/CloudBus.cpp
+++ b/toolboxes/cloudbus/CloudBus.cpp
@@ -1,5 +1,9 @@
 #include "CloudBus.h"
-#include "node_discovery.h"
+
+#ifdef USE_NODE_DISCOVERY
+    #include "node_discovery.h"
+#endif
+
 #include "log.h"
 
 namespace Gadgetron
@@ -265,6 +269,7 @@ namespace Gadgetron
         n.last_recon = 0;
         nodes.clear();
         nodes.push_back(n);
+#ifdef USE_NODE_DISCOVERY
     } else if (IsNodeDiscoveryConfigured()) {
         std::vector<NodeDiscoveryEntry> node_entries;
 
@@ -285,7 +290,7 @@ namespace Gadgetron
 	  GERROR("Failed to run NodeDiscovery\n");
 	  return;
 	}
-
+#endif //USE_NODE_DISCOVERY
     } else {
         update_node_info();
 	{


### PR DESCRIPTION
`node_discovery` is only included and used when Boost_VERSION >= 1.64.