### PR TITLE
Calling format over using f-strings to support older Python.

### DIFF
--- a/test/integration/get_data.py
+++ b/test/integration/get_data.py
@@ -26,10 +26,10 @@ class Progress:
             self.end = time.time()
             duration = self.end - self.start
             print(' ' * 96, end='\r')
-            print(f"Downloaded {total_size:n} bytes at {int(total_size / duration):n} bytes per second.")
+            print("Downloaded {:n} bytes at {:n} bytes per second.".format(current_size, int(total_size / duration)))
         else:
             print(' ' * 96, end='\r')
-            print(f"\t{current_size:n} of {total_size:n} bytes [{current_size/total_size:.2%}]", end='\r')
+            print("\t{:n} of {:n} bytes [{:.2%}]".format(current_size, total_size, current_size / total_size), end='\r')
 
 
 def is_valid(file, digest):
@@ -67,20 +67,20 @@ def main():
 
     for entry in entries:
 
-        url = f"{args.host}{entry['file']}"
+        url = "{}{}".format(args.host, entry['file'])
         destination = os.path.join(args.destination, entry['file'])
 
         if is_valid(destination, entry['md5']):
-            print(f"Verified: {destination}")
+            print("Verified: {}".format(destination))
             continue
 
-        print(f"Downloading file: {destination}")
+        print("Downloading file: {}".format(destination))
 
         os.makedirs(os.path.dirname(destination), exist_ok=True)
         urllib.request.urlretrieve(url, destination, reporthook=Progress().notify)
 
         if not is_valid(destination, entry['md5']):
-            print(f"Downloaded file {destination} failed validation.")
+            print("Downloaded file {} failed validation.".format(destination))
             sys.exit(1)
 
     sys.exit(0)

--- a/test/integration/run_tests.py
+++ b/test/integration/run_tests.py
@@ -12,7 +12,7 @@ import subprocess
 
 
 def output_csv(stats, filename):
-    print(f"Writing stats to: {filename}")
+    print("Writing stats to: {}".format(filename))
 
     with open(filename, 'w') as f:
         writer = csv.DictWriter(f, ['test', 'processing_time'])
@@ -60,10 +60,10 @@ def main():
     skipped = []
     handlers = {0: pass_handler, 1: fail_handler, 2: skip_handler}
 
-    tests = set(itertools.chain(*[glob.glob(pattern) for pattern in args.tests]))
+    tests = sorted(set(itertools.chain(*[glob.glob(pattern) for pattern in args.tests])))
 
     for i, test in enumerate(tests, start=1):
-        print(f"\nTest {i} of {len(tests)}: {test}\n")
+        print("\nTest {} of {}: {}\n".format(i, len(tests), test))
         proc = subprocess.run(['python3', 'run_gadgetron_test.py',
                                '-G', args.gadgetron_home,
                                '-I', args.ismrmrd_home,
@@ -75,8 +75,8 @@ def main():
     if args.stats:
         output_csv(stats, args.stats)
 
-    print(f"\n{len(passed)} tests passed. {len(skipped)} tests skipped.")
-    print(f"Total processing time: {sum(stat['processing_time'] for stat in stats):.2f} seconds")
+    print("\n{} tests passed. {} tests skipped.".format(len(passed), len(skipped)))
+    print("Total processing time: {:.2f} seconds.".format(sum(stat['processing_time'] for stat in stats)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ubuntu 16.04 ships with Python 3.5 by default, not supporting [f-strings](https://docs.python.org/3/reference/lexical_analysis.html#f-strings). 
