### PR TITLE
Fix Unable to open Recon script error

### DIFF
--- a/gadgets/bart/bart_logger.cpp
+++ b/gadgets/bart/bart_logger.cpp
@@ -6,7 +6,7 @@ enum debug_levels { DP_ERROR, DP_WARN, DP_INFO, DP_DEBUG1, DP_DEBUG2, DP_DEBUG3,
 
 extern "C"
 void vendor_log(int level,
-		const char* func_name,
+        const char* /*func_name*/,
 		const char* file,
 		unsigned int line,
 		const char* message)

--- a/gadgets/bart/bartgadget.h
+++ b/gadgets/bart/bartgadget.h
@@ -107,11 +107,11 @@ namespace Gadgetron {
 	  
      };
 
-     bool call_BART(std::string cmdline);
+     bool call_BART(const std::string &cmdline);
 
      // Read BART files     
      template <typename int_t>
-     std::vector<int_t> read_BART_hdr(fs::path filename)
+     std::vector<int_t> read_BART_hdr(fs::path &filename)
      {
 	  std::vector<int_t> DIMS;
 	  
@@ -143,7 +143,7 @@ namespace Gadgetron {
 
      template <typename int_t>
      std::pair<std::vector<int_t>, std::vector<std::complex<float>>>
-     read_BART_files(fs::path filename)
+     read_BART_files(fs::path &filename)
      {
 	  // Load the header file
 	  auto DIMS = read_BART_hdr<int_t>(filename);
@@ -171,8 +171,8 @@ namespace Gadgetron {
      }
      
      // For convenience
-     std::vector<size_t> read_BART_hdr(fs::path filename);
-     std::pair< std::vector<size_t>, std::vector<std::complex<float> > > read_BART_files(fs::path filename);
+     std::vector<size_t> read_BART_hdr(boost::filesystem::path &filename);
+     std::pair< std::vector<size_t>, std::vector<std::complex<float> > > read_BART_files(fs::path &filename);
 
      // ------------------------------------------------------------------------
      // Write BART files


### PR DESCRIPTION
Fix "Unable to open recon script error"
Remove unused parameter
Replace deprecated C++ header
Remove unnecessary copied parameters
Remove redundant class member initialization
Remove "compare" to test equality of strings
Use more effective overload function 
