### PR TITLE
fix GadgetronTimer include in mri_core_coil_map_estimation

### DIFF
--- a/toolboxes/mri_core/mri_core_coil_map_estimation.cpp
+++ b/toolboxes/mri_core/mri_core_coil_map_estimation.cpp
@@ -10,11 +10,9 @@
 #include "hoNDArray_elemwise.h"
 #include "hoNDArray_reductions.h"
 #include "complext.h"
-
+#include "GadgetronTimer.h"
 #ifdef USE_OMP
     #include <omp.h>
-#include <GadgetronTimer.h>
-
 #endif // USE_OMP
 
 namespace Gadgetron


### PR DESCRIPTION
bug occurred only if OPENMP is off