### PR TITLE
minor fix for ubuntu 18.04

### DIFF
--- a/gadgets/python/gadgets/image_viewer.py
+++ b/gadgets/python/gadgets/image_viewer.py
@@ -37,7 +37,7 @@ class ImageViewWindow:
         self.window.show_all()
 
     def delete_event(self, widget, event, data=None):
-        gtk.main_quit()
+        Gtk.main_quit()
         return False
    
     def on_key_press_event(self, widget, event, data=None):
@@ -48,7 +48,7 @@ class ImageViewWindow:
             return False
 
     def main(self):
-        gtk.main()
+        Gtk.main()
 
 
 class ImageViewer(Gadget):

--- a/gadgets/python/gadgets/image_viewer.py
+++ b/gadgets/python/gadgets/image_viewer.py
@@ -3,29 +3,24 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure   
 
-#from matplotlib.axes import Subplot   
-# uncomment to select /GTK/GTKAgg/GTKCairo
-from matplotlib.backends.backend_gtk import FigureCanvasGTK as FigureCanvas
-#from matplotlib.backends.backend_gtkagg import FigureCanvasGTKAgg as FigureCanvas
-#from matplotlib.backends.backend_gtkcairo import FigureCanvasGTKCairo as FigureCanvas
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk
 
-# or NavigationToolbar for classic
-#from matplotlib.backends.backend_gtk import NavigationToolbar2GTK as NavigationToolbar
-from matplotlib.backends.backend_gtkagg import NavigationToolbar2GTKAgg as NavigationToolbar
-
-import pygtk
-pygtk.require('2.0')
-import gtk
+from matplotlib.backends.backend_gtk3 import (
+    NavigationToolbar2GTK3 as NavigationToolbar)
+from matplotlib.backends.backend_gtk3agg import (
+    FigureCanvasGTK3Agg as FigureCanvas)
 
 class ImageViewWindow:
     def __init__(self, img_data):
-        self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         self.window.connect("delete_event", self.delete_event)
         self.window.connect('key_press_event', self.on_key_press_event)
         self.window.set_default_size(400,300)
         self.window.set_title("Gadgetron Image Viewer")
 
-        self.vbox = gtk.VBox()
+        self.vbox = Gtk.VBox()
         self.window.add(self.vbox)
 
         self.fig = Figure(figsize=(5,4), dpi=100)
@@ -36,9 +31,9 @@ class ImageViewWindow:
         self.img_ax = self.ax.imshow(np.squeeze(np.abs(img_data)))
 
         self.canvas = FigureCanvas(self.fig)  # a gtk.DrawingArea
-        self.vbox.pack_start(self.canvas)
+        self.vbox.pack_start(self.canvas, True, True, 0)
         self.toolbar = NavigationToolbar(self.canvas, self.window)
-        self.vbox.pack_start(self.toolbar, False, False)
+        self.vbox.pack_start(self.toolbar, False, False, 0)
         self.window.show_all()
 
     def delete_event(self, widget, event, data=None):
@@ -46,10 +41,10 @@ class ImageViewWindow:
         return False
    
     def on_key_press_event(self, widget, event, data=None):
-        keyname = gtk.gdk.keyval_name(event.keyval)
+        keyname = Gdk.keyval_name(event.keyval)
         if (keyname == "Escape"):
             self.window.destroy()
-            gtk.main_quit()
+            Gtk.main_quit()
             return False
 
     def main(self):


### PR DESCRIPTION
fixed to work but only test on Ubuntu 18.04 with BUILD_WITH_PYTHON3=ON 


As Gtk+matplotlib has too much choice variant,  it's not easy to choose the right combination, not only this,  python2/python3,  PyGTK/PyGObject, GTK with/without Cairo all has its own history and compatible problem, a clearly workable one may be better for user

ref:
https://matplotlib.org/faq/usage_faq.html?highlight=backend
https://matplotlib.org/gallery/user_interfaces/embedding_in_gtk3_panzoom_sgskip.html
https://matplotlib.org/users/navigation_toolbar.html