### PR TITLE
Fix boost python3 char convert

### DIFF
--- a/gadgets/python/GadgetInstrumentationStreamController.h
+++ b/gadgets/python/GadgetInstrumentationStreamController.h
@@ -10,6 +10,46 @@
 
 namespace Gadgetron {
 
+#if PY_VERSION_HEX > 0x3000000
+
+    template<> struct python_converter<char>
+    {
+        static void* convert_to_cstring(PyObject* obj)
+        {
+            return PyBytes_Check(obj) ? PyBytes_AsString(obj) : 0;
+        }
+
+        static void create()
+        {
+            bp::type_info info = bp::type_id<char>();
+            const bp::converter::registration* reg = bp::converter::registry::query(info);
+
+            bp::converter::convertible_function func_py_to_c= &convert_to_cstring;
+
+            // only register if not already registered!
+            bool has_register=false;
+            if (nullptr != reg)
+            {
+                bp::converter::lvalue_from_python_chain* lvalue_chain=reg->lvalue_chain;
+                while(nullptr != lvalue_chain)
+                {
+                    if (lvalue_chain->convert == func_py_to_c)
+                    {
+                        has_register=true;
+                        break;
+                    }
+                    lvalue_chain=lvalue_chain->next;
+                }
+            }
+
+            if(!has_register){
+                bp::converter::registry::insert(func_py_to_c, bp::type_id<char>(),&bp::converter::wrap_pytype<&PyBytes_Type>::get_pytype);
+            }
+        }
+    };
+
+#endif
+
     class GadgetInstrumentationStreamController
         : public GadgetStreamInterface
     {
@@ -72,6 +112,12 @@ namespace Gadgetron {
 
             register_converter<IsmrmrdReconData>();
             register_converter<IsmrmrdImageArray>();
+
+#if PY_VERSION_HEX > 0x3000000
+
+            register_converter<char>();
+
+#endif
 
             cntrl_ = new GadgetInstrumentationStreamController;
         }


### PR DESCRIPTION
minor fix for python3 compatibility

ref:
1. tango-controls/pytango#226
2. tango-controls/pytango#216
3. https://www.boost.org/doc/libs/1_69_0/libs/python/doc/internals.html