### PR TITLE
Implement an Python real time image viewer

### DIFF
--- a/gadgets/python/CMakeLists.txt
+++ b/gadgets/python/CMakeLists.txt
@@ -34,6 +34,7 @@ set(gadgetron_python_src_files GadgetronPythonMRI.cpp
 set(gadgetron_python_config_files 
                             config/pseudoreplica.xml
                             config/python.xml
+                            config/python_realtime.xml
                             config/python_buckets.xml
                             config/python_ideal_cg.xml
                             config/python_short.xml
@@ -56,6 +57,7 @@ set(gadgetron_python_gadgets_files
                             gadgets/gadgetron.py
                             gadgets/IDEAL.py
                             gadgets/image_viewer.py
+                            gadgets/real_time_image_viewer.py
                             gadgets/passthrough.py
                             gadgets/pseudoreplicagather.py
                             gadgets/remove_2x_oversampling.py

--- a/gadgets/python/GadgetInstrumentationStreamController.h
+++ b/gadgets/python/GadgetInstrumentationStreamController.h
@@ -10,46 +10,6 @@
 
 namespace Gadgetron {
 
-#if PY_VERSION_HEX > 0x3000000
-
-    template<> struct python_converter<char>
-    {
-        static void* convert_to_cstring(PyObject* obj)
-        {
-            return PyBytes_Check(obj) ? PyBytes_AsString(obj) : 0;
-        }
-
-        static void create()
-        {
-            bp::type_info info = bp::type_id<char>();
-            const bp::converter::registration* reg = bp::converter::registry::query(info);
-
-            bp::converter::convertible_function func_py_to_c= &convert_to_cstring;
-
-            // only register if not already registered!
-            bool has_register=false;
-            if (nullptr != reg)
-            {
-                bp::converter::lvalue_from_python_chain* lvalue_chain=reg->lvalue_chain;
-                while(nullptr != lvalue_chain)
-                {
-                    if (lvalue_chain->convert == func_py_to_c)
-                    {
-                        has_register=true;
-                        break;
-                    }
-                    lvalue_chain=lvalue_chain->next;
-                }
-            }
-
-            if(!has_register){
-                bp::converter::registry::insert(func_py_to_c, bp::type_id<char>(),&bp::converter::wrap_pytype<&PyBytes_Type>::get_pytype);
-            }
-        }
-    };
-
-#endif
-
     class GadgetInstrumentationStreamController
         : public GadgetStreamInterface
     {
@@ -112,12 +72,6 @@ namespace Gadgetron {
 
             register_converter<IsmrmrdReconData>();
             register_converter<IsmrmrdImageArray>();
-
-#if PY_VERSION_HEX > 0x3000000
-
-            register_converter<char>();
-
-#endif
 
             cntrl_ = new GadgetInstrumentationStreamController;
         }

--- a/gadgets/python/GadgetInstrumentationStreamController.h
+++ b/gadgets/python/GadgetInstrumentationStreamController.h
@@ -10,6 +10,46 @@
 
 namespace Gadgetron {
 
+#if PY_VERSION_HEX > 0x3000000
+
+    template<> struct python_converter<char>
+    {
+        static void* convert_to_cstring(PyObject* obj)
+        {
+            return PyBytes_Check(obj) ? PyBytes_AsString(obj) : 0;
+        }
+
+        static void create()
+        {
+            bp::type_info info = bp::type_id<char>();
+            const bp::converter::registration* reg = bp::converter::registry::query(info);
+
+            bp::converter::convertible_function func_py_to_c= &convert_to_cstring;
+
+            // only register if not already registered!
+            bool has_register=false;
+            if (nullptr != reg)
+            {
+                bp::converter::lvalue_from_python_chain* lvalue_chain=reg->lvalue_chain;
+                while(nullptr != lvalue_chain)
+                {
+                    if (lvalue_chain->convert == func_py_to_c)
+                    {
+                        has_register=true;
+                        break;
+                    }
+                    lvalue_chain=lvalue_chain->next;
+                }
+            }
+
+            if(!has_register){
+                bp::converter::registry::insert(func_py_to_c, bp::type_id<char>(),&bp::converter::wrap_pytype<&PyBytes_Type>::get_pytype);
+            }
+        }
+    };
+
+#endif
+
     class GadgetInstrumentationStreamController
         : public GadgetStreamInterface
     {
@@ -72,6 +112,12 @@ namespace Gadgetron {
 
             register_converter<IsmrmrdReconData>();
             register_converter<IsmrmrdImageArray>();
+
+#if PY_VERSION_HEX > 0x3000000
+
+            register_converter<char>();
+
+#endif
 
             cntrl_ = new GadgetInstrumentationStreamController;
         }

--- a/gadgets/python/config/python_realtime.xml
+++ b/gadgets/python/config/python_realtime.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gadgetronStreamConfiguration xsi:schemaLocation="http://gadgetron.sf.net/gadgetron gadgetron.xsd"
+        xmlns="http://gadgetron.sf.net/gadgetron"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <reader>
+        <slot>1008</slot>
+        <dll>gadgetron_mricore</dll>
+        <classname>GadgetIsmrmrdAcquisitionMessageReader</classname>
+    </reader>
+    <reader>
+        <slot>1026</slot>
+        <dll>gadgetron_mricore</dll>
+        <classname>GadgetIsmrmrdWaveformMessageReader</classname>
+    </reader>
+
+    <writer>
+      <slot>1022</slot>
+      <dll>gadgetron_mricore</dll>
+      <classname>MRIImageWriter</classname>
+    </writer>
+
+    <gadget>
+      <name>RemoveOversamplingPython</name>
+      <dll>gadgetron_python</dll>
+      <classname>PythonGadget</classname>
+      <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
+      <property><name>python_module</name>                <value>remove_2x_oversampling</value></property>
+      <property><name>python_class</name>                <value>Remove2xOversampling</value></property>
+    </gadget>
+
+    <gadget>
+      <name>AccReconPython</name>
+      <dll>gadgetron_python</dll>
+      <classname>PythonGadget</classname>
+      <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
+      <property><name>python_module</name>                <value>accumulate_and_recon</value></property>
+      <property><name>python_class</name>                <value>AccumulateAndRecon</value></property>
+    </gadget>
+
+    <gadget>
+      <name>CoilCombinePython</name>
+      <dll>gadgetron_python</dll>
+      <classname>PythonGadget</classname>
+      <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
+      <property><name>python_module</name>                <value>rms_coil_combine</value></property>
+      <property><name>python_class</name>                <value>RMSCoilCombine</value></property>
+    </gadget>
+
+    <gadget>
+      <name>ImageViewPython</name>
+      <dll>gadgetron_python</dll>
+      <classname>PythonGadget</classname>
+      <property><name>python_path</name>                  <value>/home/myuser/scripts/python</value></property>
+      <property><name>python_module</name>                <value>real_time_image_viewer</value></property>
+      <property><name>python_class</name>                <value>RealTimeImageViewerGadget</value></property>
+    </gadget>
+
+     <gadget>
+      <name>Extract</name>
+      <dll>gadgetron_mricore</dll>
+      <classname>ExtractGadget</classname>
+     </gadget>
+
+    <gadget>
+      <name>ImageFinish</name>
+      <dll>gadgetron_mricore</dll>
+      <classname>ImageFinishGadget</classname>
+    </gadget>
+
+</gadgetronStreamConfiguration>

--- a/gadgets/python/gadgets/gadgetron.py
+++ b/gadgets/python/gadgets/gadgetron.py
@@ -36,7 +36,11 @@ class Gadget(object):
 
     def wait(self):
         pass
-    
+
+    def end(self):
+        return 0
+        pass
+
     def put_next(self, *args):
         if self.next_gadget is not None:
             if isinstance(self.next_gadget, Gadget):

--- a/gadgets/python/gadgets/real_time_image_viewer.py
+++ b/gadgets/python/gadgets/real_time_image_viewer.py
@@ -1,0 +1,226 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Usage:
+
+    Run as standalone python app
+
+    Run as a gadget:
+        1. ismrmrd_generate_cartesian_shepp_logan -r 24
+        2. gadgetron_ismrmrd_client -f testdata.h5 -c python_realtime.xml -o out.h5
+
+"""
+
+import sys
+
+# When load in gadget, there is no argv attr which will cause "from gi.repository import something" failed
+if not hasattr(sys, 'argv'):
+    sys.argv  = ['']
+
+import time
+from threading import Thread, Event
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
+from gi.repository import GLib, Gdk, Gtk
+
+import matplotlib
+matplotlib.use('GTK3Agg')
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_gtk3 import NavigationToolbar2GTK3 as NavigationToolbar
+from matplotlib.backends.backend_gtk3agg import FigureCanvasGTK3Agg as FigureCanvas
+
+import numpy as np
+from gadgetron import Gadget
+
+class ImageViewWindow:
+
+    @staticmethod
+    def get_instance():
+        """
+
+        :return:
+        :rtype ImageViewWindow
+        """
+        return ImageViewWindow._instance # type: ImageViewWindow
+
+    def __init__(self, wait_time_before_exit=0):# event: Event):
+
+        print('Image View Init, wait before exit is %s'%wait_time_before_exit)
+
+        self.wait_time_before_exit=wait_time_before_exit
+
+        self.img_index=0
+
+        self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        self.window.connect("delete_event", self.delete_event)
+        self.window.connect('key_press_event', self.on_key_press_event)
+        self.window.set_default_size(800,600)
+        self.window.set_title("Gadgetron Real Time Image Viewer")
+
+        self.vbox = Gtk.VBox()
+        self.window.add(self.vbox)
+
+        self.fig = Figure(figsize=(5,4), dpi=100)
+
+        #plt.gray()
+
+        self.ax = self.fig.add_subplot(111)
+
+        #self.img_ax = self.ax.imshow(np.squeeze(np.abs(img_data)))
+
+        self.progress=Gtk.ProgressBar(show_text=True)
+        self.vbox.pack_start(self.progress, False, False, 0)
+
+        self.canvas = FigureCanvas(self.fig)  # a gtk.DrawingArea
+        self.vbox.pack_start(self.canvas, True, True, 0)
+
+        self.toolbar = NavigationToolbar(self.canvas, self.window)
+        self.vbox.pack_start(self.toolbar, False, False, 0)
+        self.window.show_all()
+
+        ImageViewWindow._instance=self
+
+        self.has_closed=False
+
+        self.ui_quit_event=None # type: Event
+
+    def wait_to_exit(self, ui_quit_event: Event):
+        if not self.has_closed:
+            GLib.idle_add(self.wait_to_exit_impl, ui_quit_event)
+        else:
+            ui_quit_event.set()
+        pass
+
+    def wait_to_exit_impl(self, ui_quit_event):
+        self.ui_quit_event=ui_quit_event # mark and wait delete event callback to quit and set!
+        self.window.close()
+        pass
+
+    def update_data_async(self, img_data):
+        if not self.has_closed:
+            GLib.idle_add(self.update_data_impl, img_data)
+        else:
+            print('ui has closed!')
+
+    def update_data_impl(self, img_data):
+        #print('image_data_impl %s\n'%self.img_index)
+        self.img_index+=1
+
+        self.progress.set_text(str(self.img_index))
+        progress_new_value=self.progress.get_fraction()+1/61 # TODO 1/61 for what?
+        self.progress.set_fraction(progress_new_value)
+
+        self.ax.clear()
+        self.img_ax = self.ax.imshow(np.squeeze(np.abs(img_data)),cmap='gray')
+
+        # if use draw_idle the system may try to draw after window closed or when closing which will throw exception
+        self.canvas.draw() # self.canvas.draw_idle()
+        # prefer_width=self.window.get_preferred_width()
+        pass
+
+    def real_exit_impl(self):
+        #TODO self.canvas.destroy() needed?
+        Gtk.main_quit()
+        pass
+
+    def delete_event(self, widget, event, data=None):
+        """
+            tips: even close window by api will trigger delete_event
+
+        :param widget:
+        :param event:
+        :param data:
+        :return:
+        """
+        self.has_closed=True
+        if self.ui_quit_event is not None:
+            self.ui_quit_event.set()
+
+        print('wait for %s second before exit'%self.wait_time_before_exit)
+        GLib.timeout_add(int(self.wait_time_before_exit), self.real_exit_impl)
+
+        return False # zero means succ?
+
+    def on_key_press_event(self, widget, event, data=None):
+        keyname = Gdk.keyval_name(event.keyval)
+        if (keyname == "Escape"): # TODO how to deal with data arrive lately one we close main window
+            self.window.close()
+            return False
+
+    @staticmethod
+    def StartImpl(wait_time_before_exit, event):
+        iv=ImageViewWindow(wait_time_before_exit)
+        event.set()
+        Gtk.main()
+        pass
+
+
+    @staticmethod
+    def wait_to_start(wait_time_before_exit):
+        ui_start_finish_event=Event()
+
+        t=Thread(
+            target=lambda: ImageViewWindow.StartImpl(wait_time_before_exit, ui_start_finish_event),
+            daemon=True
+        )
+        t.start()
+
+        ui_start_finish_event.wait()
+
+
+    @staticmethod
+    def wait_to_finish():
+        print('--begin-- Wait ImageView to close and exit ui thread!')
+        ui_quit_event=Event()
+        ImageViewWindow.get_instance().wait_to_exit(ui_quit_event)
+        ui_quit_event.wait()
+        print('--end-- Wait ImageView to close and exit ui thread!')
+        pass
+
+class RealTimeImageViewerGadget(Gadget):
+    ParaNameWaitBeforeExit='wait_before_exit'
+    DefaultValueforWaitBeforeExit=2 # seconds
+    def process_config(self, cfg):
+        print("--begin-- Attempting to open window")
+        ImageViewWindow.wait_to_start(
+            self.params[RealTimeImageViewerGadget.ParaNameWaitBeforeExit] if RealTimeImageViewerGadget.ParaNameWaitBeforeExit in self.params else RealTimeImageViewerGadget.DefaultValueforWaitBeforeExit)
+        print("--end-- Attempting to open window")
+
+
+    def process(self, h,im):
+        #time.sleep(0.2) # TODO
+        ImageViewWindow.get_instance().update_data_async(im)
+        self.put_next(h,im)
+        return 0
+
+    def end(self):
+        print('--begin-- Python Gaddget end process in svc Thread!')
+        ImageViewWindow.get_instance().wait_to_finish()
+        print('--end-- Python Gaddget end process in svc Thread!')
+        return 0
+        pass
+
+
+if __name__ == '__main__':
+    # test by dummy data
+    print('enter main thread!')
+
+    ImageViewWindow.wait_to_start(RealTimeImageViewerGadget.DefaultValueforWaitBeforeExit+5)
+
+    N=10
+    current=0
+    while current<N:
+        im = np.random.random((256, 256))
+        ImageViewWindow.get_instance().update_data_async(im)
+        time.sleep(0.2)
+        current+=1
+        pass
+
+    ImageViewWindow.wait_to_finish()
+
+    print('exit from main thread!')
+
+    pass


### PR DESCRIPTION
1. Add an explicit overrideable end lifecycle for Python Gadget to support multiple threads like application, like UI application or Gadget self-control services.

2. Implement a python base real-time image viewer application to show why the end lifecycle is useful and must need.
 
try fix https://github.com/gadgetron/gadgetron/issues/750 