### PR TITLE
Fix ongoing acquisitions trigger (+ typo)

### DIFF
--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.cpp
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.cpp
@@ -99,7 +99,10 @@ namespace Gadgetron {
                 size_t current_target_acquisitions = first ? target_acquisitions_first : target_acquisitions;
                 bool result = ++num_acquisitions >= current_target_acquisitions;
                 if (result)
+                {
+                    first = false;
                     num_acquisitions = 0;
+                }
                 return result;
             }
         };

--- a/gadgets/mri_core/RateLimitGadget.h
+++ b/gadgets/mri_core/RateLimitGadget.h
@@ -1,5 +1,5 @@
-#ifndef ACCUMULATORGADGET_H
-#define ACCUMULATORGADGET_H
+#ifndef RATELIMITGADGET_H
+#define RATELIMITGADGET_H
 
 #include "Gadget.h"
 #include "hoNDArray.h"


### PR DESCRIPTION
For n_acquisitions trigger, target was "stuck" on initial value.
Copy / paste error in RateLimitGadget.