### PR TITLE
Fix sphinx documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,3 +79,5 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+master_doc = 'index'


### PR DESCRIPTION
Steps to reproduce:
Open a terminal
Go into gadgetron build directory
Launch the following commands:
cmake -DBUILD_DOCUMENTATION=On ..
make

Result:
The documentation build does not succeed because of this error:

Sphinx error:
master file /home/aymeric/Workspace/gadgetron-github/doc/source/contents.rst not found
doc/CMakeFiles/Sphinx.dir/build.make:57: recipe for target 'doc/CMakeFiles/Sphinx' failed

Expected result:
Documentation is built without any error.

Reason & Solution:
https://stackoverflow.com/questions/56336234/build-fail-sphinx-error-contents-rst-not-found