### PR TITLE
Added Gadget to compute coilmaps from image data

### DIFF
--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -26,7 +26,7 @@ set(gadgetron_mricore_header_files GadgetMRIHeaders.h
         RemoveROOversamplingGadget.h
         CoilReductionGadget.h
         ScaleGadget.h
-       FlowPhaseSubtractionGadget.h
+        FlowPhaseSubtractionGadget.h
         readers/GadgetIsmrmrdReader.h
         PhysioInterpolationGadget.h
         IsmrmrdDumpGadget.h
@@ -68,7 +68,8 @@ set(gadgetron_mricore_header_files GadgetMRIHeaders.h
         ImageAccumulatorGadget.h
         writers/GadgetIsmrmrdWriter.h
         ImageResizingGadget.h
-        DenoiseGadget.h)
+        DenoiseGadget.h
+        CoilComputationGadget.h)
 
 set(gadgetron_mricore_src_files
         AcquisitionPassthroughGadget.cpp
@@ -130,7 +131,8 @@ set(gadgetron_mricore_src_files
         writers/GadgetIsmrmrdWriter.cpp
         ImageResizingGadget.cpp
         AutoScaleGadget.cpp
-        DenoiseGadget.cpp)
+        DenoiseGadget.cpp
+        CoilComputationGadget.cpp)
 
 set(gadgetron_mricore_config_files
         config/default.xml

--- a/gadgets/mri_core/CoilComputationGadget.cpp
+++ b/gadgets/mri_core/CoilComputationGadget.cpp
@@ -1,0 +1,55 @@
+#include "CoilComputationGadget.h"
+#include "gadgetron/hoNDArray_elemwise.h"
+#include "gadgetron/hoNDImage_util.h"
+
+#include "gadgetron/mri_core_coil_map_estimation.h"
+/*
+*       CoilComputationGadget.cpp
+*       Author: Johannes Mayer
+*/
+
+
+
+namespace Gadgetron
+{
+    CoilComputationGadget::CoilComputationGadget()
+    {
+    }
+
+    CoilComputationGadget::~CoilComputationGadget()
+    {
+    }
+
+
+    int CoilComputationGadget::process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1, GadgetContainerMessage<ArrayType>* m2)
+    {
+        ArrayType* input_array = m2->getObjectPtr();
+
+        std::vector<size_t> dims;
+        input_array->get_dimensions(dims);
+
+        if (input_array->get_number_of_dimensions() == 4)
+        {
+            ArrayType csm;
+
+//            coil_map_Inati<ValueType>(*input_array, csm, ks_.value(), kz_.value(), power_.value());
+            coil_map_Inati<ValueType>(*input_array, csm);
+            *m2->getObjectPtr() = csm;
+        }
+        else
+        {
+            GERROR_STREAM("CoilComputationGadget, no 4D data was passed ... ");
+            return GADGET_FAIL;
+        }
+
+        if (this->next()->putq(m1) < 0)
+        {
+            GERROR_STREAM("CoilComputationGadget, failed to pass images to next gadget ... ");
+            return GADGET_FAIL;
+        }
+
+        return GADGET_OK;
+    }
+
+    GADGET_FACTORY_DECLARE(CoilComputationGadget)
+}

--- a/gadgets/mri_core/CoilComputationGadget.cpp
+++ b/gadgets/mri_core/CoilComputationGadget.cpp
@@ -1,8 +1,6 @@
 #include "CoilComputationGadget.h"
-#include "gadgetron/hoNDArray_elemwise.h"
-#include "gadgetron/hoNDImage_util.h"
-
 #include "gadgetron/mri_core_coil_map_estimation.h"
+
 /*
 *       CoilComputationGadget.cpp
 *       Author: Johannes Mayer

--- a/gadgets/mri_core/CoilComputationGadget.cpp
+++ b/gadgets/mri_core/CoilComputationGadget.cpp
@@ -1,5 +1,5 @@
 #include "CoilComputationGadget.h"
-#include "gadgetron/mri_core_coil_map_estimation.h"
+#include "mri_core_coil_map_estimation.h"
 
 /*
 *       CoilComputationGadget.cpp

--- a/gadgets/mri_core/CoilComputationGadget.cpp
+++ b/gadgets/mri_core/CoilComputationGadget.cpp
@@ -30,8 +30,7 @@ namespace Gadgetron
         {
             ArrayType csm;
 
-//            coil_map_Inati<ValueType>(*input_array, csm, ks_.value(), kz_.value(), power_.value());
-            coil_map_Inati<ValueType>(*input_array, csm);
+            coil_map_Inati<ValueType>(*input_array, csm, ks_.value(), kz_.value(), power_.value());
             *m2->getObjectPtr() = csm;
         }
         else

--- a/gadgets/mri_core/CoilComputationGadget.h
+++ b/gadgets/mri_core/CoilComputationGadget.h
@@ -1,0 +1,40 @@
+/** \file   CoilComputationGadget.h
+    \brief  This Gadget computes coil senstivities based on image data.
+    \author Johannes Mayer
+*/
+
+#pragma once
+
+#include "gadgetron/Gadget.h"
+#include "gadgetron/hoNDArray.h"
+
+#include "ismrmrd/meta.h"
+#include <ismrmrd/ismrmrd.h>
+
+#include "gadgetron_mricore_export.h"
+
+
+
+namespace Gadgetron
+{
+    class EXPORTGADGETSMRICORE CoilComputationGadget :public Gadget2<ISMRMRD::ImageHeader, hoNDArray< std::complex<float> > >
+    {
+    public:
+
+        GADGET_DECLARE(CoilComputationGadget);
+
+//        GADGET_PROPERTY(ks_, size_t, "Correlation matrix size in plane.", 7);
+//        GADGET_PROPERTY(kz_, size_t, "Correlation matrix size in slice direction.", 5);
+//        GADGET_PROPERTY(power_, size_t, "Number of iterations to apply power method", 3);
+
+        typedef std::complex<float> ValueType;
+        typedef hoNDArray< ValueType > ArrayType;
+
+        CoilComputationGadget();
+        virtual ~CoilComputationGadget();
+
+
+    protected:
+        virtual int process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1, GadgetContainerMessage<ArrayType>* m2);
+    };
+}

--- a/gadgets/mri_core/CoilComputationGadget.h
+++ b/gadgets/mri_core/CoilComputationGadget.h
@@ -20,12 +20,11 @@ namespace Gadgetron
     class EXPORTGADGETSMRICORE CoilComputationGadget :public Gadget2<ISMRMRD::ImageHeader, hoNDArray< std::complex<float> > >
     {
     public:
-
         GADGET_DECLARE(CoilComputationGadget);
 
-//        GADGET_PROPERTY(ks_, size_t, "Correlation matrix size in plane.", 7);
-//        GADGET_PROPERTY(kz_, size_t, "Correlation matrix size in slice direction.", 5);
-//        GADGET_PROPERTY(power_, size_t, "Number of iterations to apply power method", 3);
+        GADGET_PROPERTY(ks_, size_t, "Correlation matrix size in plane.", 7);
+        GADGET_PROPERTY(kz_, size_t, "Correlation matrix size in slice direction.", 5);
+        GADGET_PROPERTY(power_, size_t, "Number of iterations to apply power method", 3);
 
         typedef std::complex<float> ValueType;
         typedef hoNDArray< ValueType > ArrayType;

--- a/gadgets/mri_core/CoilComputationGadget.h
+++ b/gadgets/mri_core/CoilComputationGadget.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "gadgetron/Gadget.h"
-#include "gadgetron/hoNDArray.h"
+#include "Gadget.h"
+#include "hoNDArray.h"
 
 #include "ismrmrd/meta.h"
 #include <ismrmrd/ismrmrd.h>


### PR DESCRIPTION
This is meant to be used as an interface to Gadgetron to access its coil computation capabilities.

It simply applies the  `coil_map_Inati` method to a set of image data that are provided in the form of uncombined reconstructions.

This allows to define the inverse Fourier transform outside of Gadgetron itself but still couple to it and extract the coilmap features.

