### PR TITLE
Ubuntu packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ install(TARGETS FFTW EXPORT gadgetron-export)
 
 set(GADGETRON_BUILD_RPATH "")
 
-option(USE_MKL OFF)
+option(USE_MKL Off)
 if (USE_MKL)
     find_package(MKL REQUIRED)
     add_library(BLAS INTERFACE)
@@ -289,15 +289,22 @@ if (USE_MKL)
     add_definitions(-DUSE_MKL)
     set(GADGETRON_BUILD_RPATH "${MKL_LIB_DIR};${MKL_COMPILER_LIB_DIR}")
 else ()
-
     find_package(CBLAS REQUIRED)
     find_package(LAPACK REQUIRED)
     find_package(LAPACKE REQUIRED)
+
     add_library(BLAS INTERFACE)
     set_property(TARGET BLAS PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CBLAS_INCLUDE_DIR} ${LAPACK_INCLUDE_DIR} ${LAPACKE_INCLUDE_DIR})
     set_property(TARGET BLAS PROPERTY INTERFACE_LINK_LIBRARIES ${CBLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${LAPACKE_LIBRARIES})
+
     find_package(PkgConfig)
     pkg_check_modules(PC_lapacke lapacke)
+
+    string(COMPARE EQUAL ${BLA_VENDOR} "OpenBLAS" USING_OPENBLAS)
+    if (USING_OPENBLAS)
+        message("OpenBLAS detected; setting max number of OpenBLAS pthreads to one.")
+        add_definitions(-DFORCE_LIMIT_OPENBLAS_NUM_THREADS)
+    endif()
 endif ()
 
 install(TARGETS BLAS EXPORT gadgetron-export)

--- a/apps/gadgetron/CMakeLists.txt
+++ b/apps/gadgetron/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(gadgetron
         Connection.h
         paths.cpp
         paths.h
+        initialization.cpp
+        initialization.h
         system_info.cpp
         connection/Config.cpp
         connection/Config.h
@@ -67,7 +69,7 @@ target_link_libraries(gadgetron
         gadgetron_core
         gadgetron_toolbox_log
         boost
-        )
+        BLAS)
 
 target_include_directories(gadgetron
         PRIVATE

--- a/apps/gadgetron/connection/stream/Stream.cpp
+++ b/apps/gadgetron/connection/stream/Stream.cpp
@@ -49,7 +49,7 @@ namespace {
     };
 
     std::shared_ptr<Processable> load_node(const Config::Gadget &conf, const StreamContext &context, Loader &loader) {
-        GDEBUG("Loading Gadget %s of class %s from \n",conf.name.c_str(),conf.classname.c_str(),conf.dll.c_str());
+        GDEBUG("Loading Gadget %s of class %s from %s\n", conf.name.c_str(), conf.classname.c_str(), conf.dll.c_str());
         auto factory = loader.load_factory<Loader::generic_factory<Node>>("gadget_factory_export_", conf.classname,
                                                                           conf.dll);
         return std::make_shared<NodeProcessable>(factory(context, conf.properties), Config::name(conf));

--- a/apps/gadgetron/initialization.cpp
+++ b/apps/gadgetron/initialization.cpp
@@ -1,9 +1,8 @@
 
 #include "initialization.h"
 
-
 #ifdef FORCE_LIMIT_OPENBLAS_NUM_THREADS
-#include <openblas/cblas.h>
+#include <cblas.h>
 #endif
 
 namespace Gadgetron::Server {

--- a/apps/gadgetron/initialization.cpp
+++ b/apps/gadgetron/initialization.cpp
@@ -1,0 +1,23 @@
+
+#include "initialization.h"
+
+
+#ifdef FORCE_LIMIT_OPENBLAS_NUM_THREADS
+#include <openblas/cblas.h>
+#endif
+
+namespace Gadgetron::Server {
+
+    void configure_blas_libraries() {
+
+#ifdef FORCE_LIMIT_OPENBLAS_NUM_THREADS
+        /*
+         * Certain distributions (Ubuntu) doesn't ship OpenMP OpenBLAS, so we have to make do with
+         * a version compiled for pthreads. It'll work - maybe even without degrading performance
+         * a lot, but only if we limit the number of threads to one.
+         */
+        openblas_set_num_threads(1);
+#endif
+
+    }
+}

--- a/apps/gadgetron/initialization.h
+++ b/apps/gadgetron/initialization.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace Gadgetron::Server {
+    void configure_blas_libraries();
+}

--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -6,6 +6,7 @@
 
 #include "log.h"
 #include "paths.h"
+#include "initialization.h"
 
 #include "system_info.h"
 #include "gadgetron_config.h"
@@ -50,6 +51,8 @@ int main(int argc, char *argv[]) {
     GINFO("Running on port %d\n", args["port"].as<unsigned short>());
 
     try {
+        configure_blas_libraries();
+
         // Ensure working directory exists.
         create_directories(args["dir"].as<path>());
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,6 +14,9 @@ add_library(gadgetron_core SHARED
         Message.cpp
         Response.cpp
         io/from_string.cpp)
+set_target_properties(gadgetron_core PROPERTIES
+        VERSION ${GADGETRON_VERSION_STRING}
+        SOVERSION ${GADGETRON_SOVERSION})
 
 target_link_libraries(gadgetron_core
         ISMRMRD::ISMRMRD


### PR DESCRIPTION
Made a few changes, most related to getting Gadgetron to package for Debian/Ubuntu. 

Most notably, I'm detecting the use of OpenBLAS, and forcing the number of pthreads available to OpenBLAS internally to one. This has no effect when OpenBLAS is compiled for OpenMP, and it prevents several threading issues when OpenBLAS is compiled for pthreads (as on Ubuntu). 

I saw no degradation of performance when running the test suite. 
