### PR TITLE
Fixed issue where test script would never skip tests due to insufficient system memory.

### DIFF
--- a/test/integration/run_gadgetron_test.py
+++ b/test/integration/run_gadgetron_test.py
@@ -142,7 +142,7 @@ def prepare_rules(args, requirements):
 
     rules = {
         'system_memory': lambda req: Rule('gadgetron::info::memory', "Insufficient system memory.",
-                                          lambda val: float(req) <= float(val)),
+                                          lambda val: float(req) * 1024 * 1024 <= float(val)),
         'python_support': lambda req: Rule('gadgetron::info::python', "Python support required.", is_enabled),
         'matlab_support': lambda req: Rule('gadgetron::info::matlab', "MATLAB support required.", is_enabled),
         'gpu_support': lambda req: Rule('gadgetron::info::cuda', "CUDA support required.", is_enabled),


### PR DESCRIPTION
Test script compared megabytes (as specified in the test config) to number of bytes available on system. Obviously, this caused the skipping based on memory to frequently fail. 