### PR TITLE
fix compilation for win 10 and vs2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,21 +184,27 @@ set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 # necessary for Windows and RHEL <=6 systems
-set(Boost_NO_BOOST_CMAKE ON)
+# set(Boost_NO_BOOST_CMAKE ON)
 
 if(WIN32)
-add_definitions( -DHAVE_SNPRINTF) #Python decides to overwrite snprintf if this is not defined, because ofcourse it does.
+  add_definitions( -DBOOST_ALL_NO_LIB )
+  add_definitions( -DBOOST_ALL_DYN_LINK )
+  #add_definitions( -DBOOST_NO_EXCEPTIONS )
 endif()
+
 # We actually only use system and thread explicitly, but they require linking in date_time and chrono
 if (WIN32)
-find_package(Boost 1.65.0 COMPONENTS system date_time chrono program_options filesystem timer exception REQUIRED )
+  set(BOOST_LIB_LIST system thread date_time chrono program_options filesystem timer iostreams)
 else()
-find_package(Boost 1.65.0 COMPONENTS system program_options filesystem timer REQUIRED )
+  set(BOOST_LIB_LIST system thread program_options filesystem timer iostreams)
 endif()
+
+find_package(Boost COMPONENTS ${BOOST_LIB_LIST} REQUIRED)
+
 add_library(boost INTERFACE)
 set_target_properties(boost PROPERTIES
 INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIR})
-#set_property(TARGET boost PROPERTY INTERFACE_LINK_LIBRARIES ${Boost_LIBRARIES})
+message(${Boost_LIBRARIES})
 target_link_libraries(boost INTERFACE ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 
 if (NOT DEFINED Boost_VERSION_STRING)

--- a/apps/gadgetron/CMakeLists.txt
+++ b/apps/gadgetron/CMakeLists.txt
@@ -1,5 +1,6 @@
 configure_file(gadgetron_config.in gadgetron_config.h)
 
+include_directories(${PUGIXML_INCLUDE_DIRS})
 
 add_executable(gadgetron
         main.cpp
@@ -69,7 +70,8 @@ target_link_libraries(gadgetron
         gadgetron_core
         gadgetron_toolbox_log
         boost
-        BLAS)
+        BLAS 
+        ${PUGIXML_LIBRARIES} )
 
 target_include_directories(gadgetron
         PRIVATE

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(gadgetron_core SHARED
         Message.cpp
         Response.cpp
         io/from_string.cpp)
+
 set_target_properties(gadgetron_core PROPERTIES
         VERSION ${GADGETRON_VERSION_STRING}
         SOVERSION ${GADGETRON_SOVERSION})
@@ -21,7 +22,7 @@ set_target_properties(gadgetron_core PROPERTIES
 target_link_libraries(gadgetron_core
         ISMRMRD::ISMRMRD
         gadgetron_toolbox_cpucore
-        boost)
+        )
 
 target_include_directories(gadgetron_core PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -37,7 +38,7 @@ install(TARGETS gadgetron_core
         )
 
 
-install(FILES
+install(FILES 
         Channel.h
         Channel.hpp
         ChannelIterator.h

--- a/core/MessageID.h
+++ b/core/MessageID.h
@@ -2,6 +2,10 @@
 
 #include <cstdint>
 
+#ifdef ERROR
+    #undef ERROR
+#endif // ERROR
+
 namespace Gadgetron::Core {
     enum MessageID : uint16_t {
         FILENAME                                           = 1,

--- a/gadgets/dicom/CMakeLists.txt
+++ b/gadgets/dicom/CMakeLists.txt
@@ -83,6 +83,10 @@ target_link_libraries(gadgetron_dicom
     ISMRMRD::ISMRMRD
     ${GT_DICOM_LIBRARIES} )
 
+if (WIN32)
+    target_link_libraries(gadgetron_dicom netapi32.lib wsock32.lib WS2_32.Lib)
+endif(WIN32)
+
 if(ARMADILLO_FOUND)
     target_link_libraries(gadgetron_dicom gadgetron_toolbox_cpucore_math )
 endif()

--- a/gadgets/dicom/DicomImageWriter.cpp
+++ b/gadgets/dicom/DicomImageWriter.cpp
@@ -18,6 +18,8 @@
 #include "dcmtk/dcmdata/dcostrmb.h"
 #include "dcmtk/dcmdata/dctk.h"
 
+#include "MessageID.h"
+
 namespace Gadgetron {
 
     void DicomImageWriter::serialize(std::ostream& stream, const DcmFileFormat& dcmInput,
@@ -50,7 +52,7 @@ namespace Gadgetron {
         dcmFile.transferEnd();
 
 
-        Core::IO::write(stream, GADGET_MESSAGE_DICOM_WITHNAME);
+        Core::IO::write(stream, Core::GADGET_MESSAGE_DICOM_WITHNAME);
 
         uint32_t nbytes = (uint32_t)serialized_length;
         Core::IO::write(stream, nbytes);

--- a/gadgets/dicom/DicomImageWriter.h
+++ b/gadgets/dicom/DicomImageWriter.h
@@ -3,7 +3,7 @@
 
 #include <dcmtk/dcmdata/dctk.h>
 #include "gadgetron_dicom_export.h"
-#include "GadgetMRIHeaders.h"
+// #include "GadgetMRIHeaders.h"
 #include "ismrmrd/ismrmrd.h"
 #include "Writer.h"
 

--- a/toolboxes/image_io/CMakeLists.txt
+++ b/toolboxes/image_io/CMakeLists.txt
@@ -15,7 +15,7 @@ set(image_io_src_files
 
 add_library(gadgetron_toolbox_image_analyze_io SHARED ${image_io_header_files} ${image_io_src_files})
 set_target_properties(gadgetron_toolbox_image_analyze_io PROPERTIES VERSION ${GADGETRON_VERSION_STRING} SOVERSION ${GADGETRON_SOVERSION})
-target_link_libraries(gadgetron_toolbox_image_analyze_io gadgetron_toolbox_log gadgetron_toolbox_cpucore boost)
+target_link_libraries(gadgetron_toolbox_image_analyze_io gadgetron_toolbox_log gadgetron_toolbox_cpucore)
 target_include_directories(gadgetron_toolbox_image_analyze_io
         PUBLIC
         $<INSTALL_INTERFACE:include/gadgetron>


### PR DESCRIPTION
fix compilation for win 10

1) adjust boost cmake
2) remove set(Boost_NO_BOOST_CMAKE ON)
3) for windows, remove add_definitions( -DBOOST_NO_EXCEPTIONS )
4) a few adjust for win linkage