### PR TITLE
Fix gadgetron_ismrmrd_client when the loopback device is the only network device with an address

### DIFF
--- a/apps/clients/gadgetron_ismrmrd_client/gadgetron_ismrmrd_client.cpp
+++ b/apps/clients/gadgetron_ismrmrd_client/gadgetron_ismrmrd_client.cpp
@@ -1151,7 +1151,10 @@ public:
     void connect(std::string hostname, std::string port)
     {
         tcp::resolver resolver(io_service);
-        tcp::resolver::query query(tcp::v4(), hostname.c_str(), port.c_str());
+        // numeric_service flag is required to send data if the Linux machine has no internet connection (in this case the loopback device is the only network device with an address).
+        // https://stackoverflow.com/questions/5971242/how-does-boost-asios-hostname-resolution-work-on-linux-is-it-possible-to-use-n
+        // https://www.boost.org/doc/libs/1_65_0/doc/html/boost_asio/reference/ip__basic_resolver_query.html
+        tcp::resolver::query query(tcp::v4(), hostname.c_str(), port.c_str(), boost::asio::ip::resolver_query_base::numeric_service);
         tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
         tcp::resolver::iterator end;
 


### PR DESCRIPTION
**Steps to reproduce**
- Use a Linux machine
- Disconnect your machine from internet
- Ensure the loopback device is the only network device with an address:
  - open a terminal
  - launch ifconfig
  - check lo (loopback device) is the only network device which has an inet address (127.0.0.1)
- Follow the hellow world gadgetron tutorial: https://github.com/gadgetron/gadgetron/wiki/Gadgetron-Hello-World

**Result**
Nothing is received by gadgetron and gadgetron_ismrmrd_client caught this error:
"Error caught: resolve: Host not found (authoritative)"

**Expected Result**
Gadgetron Hello World works as described in the tutorial

**Reason**
tcp::resolver::query constructor uses boost::asio::ip::resolver_query_base::address_configured
as default value for the last parameter "resolve_flags".
In our case this flag does not return IPV4 address as described in boost
documentation: https://www.boost.org/doc/libs/1_65_0/doc/html/boost_asio/reference/ip__basic_resolver_query.html

**Solution**
Use boost::asio::ip::resolver_query_base::numeric_service which is the suitable
flag.