### PR TITLE
Fix fill_dicom_image_from_ismrmrd_header when utf-8 encoding is used.

### DIFF
--- a/gadgets/dicom/dicom_ismrmrd_utility.cpp
+++ b/gadgets/dicom/dicom_ismrmrd_utility.cpp
@@ -147,7 +147,7 @@ namespace Gadgetron
 
             // Specific Character Set
             key.set(0x0008, 0x0005);
-            write_dcm_string(dataset, key, "ISO_IR 100");
+            write_dcm_string(dataset, key, "ISO_IR 192");
 
             // Image Type
             // ORIGINAL or DERIVED describes origin of pixel data


### PR DESCRIPTION
This function sets the encoding to Latin1 (ISO_IR 100) but utf-8 allows
to manage much more characters.
This function is used only in DicomFinishGadget which does not require
Latin1 encoding.