### PR TITLE
Codespaces devcontainer

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,1 @@
+devcontainer.json

--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,1 @@
+devcontainer-strip.json

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+FROM gadgetron/ubuntu_2004_base_basic
+
+#Set more environment variables in preparation for Gadgetron installation
+ENV GADGETRON_HOME=/usr/local \
+    ISMRMRD_HOME=/usr/local
+
+ENV PATH=$PATH:$GADGETRON_HOME/bin:$ISMRMRD_HOME/bin \
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ISMRMRD_HOME/lib:$GADGETRON_HOME/lib
+
+#ISMRMRD
+RUN cd /opt/code && \
+    git clone https://github.com/ismrmrd/ismrmrd.git && \
+    cd ismrmrd && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    make -j $(nproc) && \
+    make install
+
+# Install Python interface.
+RUN pip3 install gadgetron
+
+#SIEMENS_TO_ISMRMRD
+RUN cd /opt/code && \
+    git clone https://github.com/ismrmrd/siemens_to_ismrmrd.git && \
+    cd siemens_to_ismrmrd && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    make -j $(nproc) && \
+    make install
+
+#PHILIPS_TO_ISMRMRD
+RUN cd /opt/code && \
+    git clone https://github.com/ismrmrd/philips_to_ismrmrd.git && \
+    cd philips_to_ismrmrd && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    make -j $(nproc) && \
+    make install

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -102,3 +102,7 @@ RUN cd /opt/code && \
     cmake ../ && \
     make -j $(nproc) && \
     make install
+
+# Copy the contents of the .devcontainer folder into image to bake the file versions into image digest
+# devcontainer.json file is excluded by .dockerignore file
+COPY . /.devcontainer

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,73 @@
-FROM gadgetron/ubuntu_2004_base_basic
+FROM ubuntu:20.04
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+ARG HELM_VERSION="v3.1.2"
+ARG KUBE_VERSION="v1.18.1"
+ARG AZURE_CLI_VERSION="2.5.1-1~buster"
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client less iproute2 procps apt-transport-https gnupg2 curl lsb-release \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Install Docker
+    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
+    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce docker-ce-cli containerd.io \
+    #
+    # Install kubectl
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    #
+    # Install Helm
+    && curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- -v $HELM_VERSION \
+    #
+    # Install the Azure CLI
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+    && apt-get update \
+    && apt-get install -y azure-cli=${AZURE_CLI_VERSION} \
+    #
+    # Install the Azure Container Registry's Docker Credential Helper
+    && curl -L https://aka.ms/acr/installaad/bash | /bin/bash \
+    #
+    # Install jq
+    && apt-get install -y jq \
+    #
+    # Install some gadgetron dependencies
+    && apt install -yes wget build-essential cython3 \
+        libcrypto++-dev  python3-dev python3-pip libhdf5-serial-dev \
+        cmake git-core libboost-all-dev libfftw3-dev h5utils jq hdf5-tools \
+        liblapack-dev libatlas-base-dev libxml2-dev libfreetype6-dev \
+        pkg-config libxslt-dev libarmadillo-dev libace-dev libgtest-dev \
+        liblapacke-dev libplplot-dev gcc-multilib supervisor net-tools \
+        cpio libpugixml-dev jove libopenblas-base libopenblas-dev \
+
+RUN apt-get install -y locales && \
+    locale-gen
 
 #Set more environment variables in preparation for Gadgetron installation
 ENV GADGETRON_HOME=/usr/local \
@@ -39,6 +108,3 @@ RUN cd /opt/code && \
     cmake ../ && \
     make -j $(nproc) && \
     make install
-
-RUN apt-get install -y locales && \
-    locale-gen

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM gadgetron/ubuntu_2004_base_basic
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
@@ -14,7 +14,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Configure apt and install packages
 ARG HELM_VERSION="v3.1.2"
 ARG KUBE_VERSION="v1.18.1"
-ARG AZURE_CLI_VERSION="2.5.1-1~buster"
 
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
@@ -49,22 +48,13 @@ RUN apt-get update \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
     && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
     && apt-get update \
-    && apt-get install -y azure-cli=${AZURE_CLI_VERSION} \
+    && apt-get install -y azure-cli \
     #
     # Install the Azure Container Registry's Docker Credential Helper
     && curl -L https://aka.ms/acr/installaad/bash | /bin/bash \
     #
     # Install jq
-    && apt-get install -y jq \
-    #
-    # Install some gadgetron dependencies
-    && apt install -yes wget build-essential cython3 \
-        libcrypto++-dev  python3-dev python3-pip libhdf5-serial-dev \
-        cmake git-core libboost-all-dev libfftw3-dev h5utils jq hdf5-tools \
-        liblapack-dev libatlas-base-dev libxml2-dev libfreetype6-dev \
-        pkg-config libxslt-dev libarmadillo-dev libace-dev libgtest-dev \
-        liblapacke-dev libplplot-dev gcc-multilib supervisor net-tools \
-        cpio libpugixml-dev jove libopenblas-base libopenblas-dev \
+    && apt-get install -y jq 
 
 RUN apt-get install -y locales && \
     locale-gen

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     #
     # Let the non-root user use DOcker without sudo
     && groupadd -g 800 docker \
-    && sermod -a -G docker $USER_UID \
+    && usermod -a -G docker $USER_UID \
     #
     # Install Docker
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ FROM gadgetron/ubuntu_2004_base_basic
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
 # will be updated to match your local UID/GID (when using the dockerFile property).
 # See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=vscode
+ARG USERNAME=gadgetron
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
@@ -29,6 +29,10 @@ RUN apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
     && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Let the non-root user use DOcker without sudo
+    && groupadd -g 800 docker \
+    && sermod -a -G docker $USER_UID \
     #
     # Install Docker
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,3 +39,6 @@ RUN cd /opt/code && \
     cmake ../ && \
     make -j $(nproc) && \
     make install
+
+RUN apt-get install -y locales && \
+    locale-gen

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     #
     # Let the non-root user use DOcker without sudo
     && groupadd -g 800 docker \
-    && usermod -a -G docker $USER_UID \
+    && usermod -a -G docker $USERNAME \
     #
     # Install Docker
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/.devcontainer/build-and-push-codespace-image.sh
+++ b/.devcontainer/build-and-push-codespace-image.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+thisDir=$(dirname $0)
+IMAGE_NAME="gadgetron/codespaces-ubuntu2004"
+
+if [ ! -f ~/.docker/config.json ]; then
+    echo "Please login to docker hub with 'docker login'"
+    exit 1
+fi
+
+dockerCreds=$(cat ~/.docker/config.json | jq -r '.auths."https://index.docker.io/v1/".auth')
+if [ "null" == "$dockerCreds" ]; then
+    echo "No credentials stored for docker hub. Please sign in with 'docker login'"
+    exit 1
+fi
+
+# Make a devcontainer.json file without the image digest
+cat $thisDir/devcontainer.json | jq -r ".image=\"$IMAGE_NAME\"" > $thisDir/devcontainer-strip.json
+
+USERNAME=$(cat $thisDir/devcontainer.json | jq -r ".remoteUser")
+IMAGE_ID=$(docker build --build-arg USERNAME=$USERNAME -q -t $IMAGE_NAME $thisDir)
+
+if [ -z "$IMAGE_ID" ]; then
+    echo "Image build failed"
+    exit 1
+fi
+
+docker push $IMAGE_NAME
+DIGEST=$(docker inspect $IMAGE_ID | jq -r .[0].RepoDigests[0])
+devcontainerJson=$(cat $thisDir/devcontainer.json | jq ".image=\"${DIGEST}\"")
+echo $devcontainerJson | jq . > $thisDir/devcontainer.json
+
+# Remove temporary file
+rm $thisDir/devcontainer-strip.json

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,12 @@
     "dockerFile": "Dockerfile",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"
-	}
+	},
+	"extensions": [
+		"ms-vscode.cpptools",
+		"ms-azuretools.vscode-docker",
+		"ms-python.python",
+		"eamodio.gitlens",
+		"visualstudioexptteam.vscodeintellicode"
+	]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
-    "dockerFile": "Dockerfile",
+	"dockerFile": "Dockerfile",
+	"runArgs": [
+		"-v", "/var/run/docker.sock:/var/run/docker.sock"
+	],
+	"remoteUser": "gadgetron",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "image": "gadgetron/ubuntu_2004_base_basic:latest"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,6 @@
 {
-    "image": "gadgetron/ubuntu_2004_base_basic:latest"
+    "dockerFile": "Dockerfile",
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,18 @@
 {
-	"dockerFile": "Dockerfile",
-	"runArgs": [
-		"-v", "/var/run/docker.sock:/var/run/docker.sock"
-	],
-	"remoteUser": "gadgetron",
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
-	"extensions": [
-		"ms-vscode.cpptools",
-		"ms-azuretools.vscode-docker",
-		"ms-python.python",
-		"eamodio.gitlens",
-		"visualstudioexptteam.vscodeintellicode"
-	]
+  "image": "gadgetron/codespaces-ubuntu2004@sha256:ce6c0202deb2a155cb76f795eaa60fe0c426442b2bbcc0813ede879aaadf6aa2",
+  "runArgs": [
+    "-v",
+    "/var/run/docker.sock:/var/run/docker.sock"
+  ],
+  "remoteUser": "gadgetron",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": [
+    "ms-vscode.cpptools",
+    "ms-azuretools.vscode-docker",
+    "ms-python.python",
+    "eamodio.gitlens",
+    "visualstudioexptteam.vscodeintellicode"
+  ]
 }

--- a/.devcontainer/get-current-image-digest.sh
+++ b/.devcontainer/get-current-image-digest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker inspect $(docker images -q cloudenvimage:latest) | jq -r .[0].RepoDigests[0]


### PR DESCRIPTION
This PR adds a [VS codespaces](https://visualstudio.microsoft.com/services/visual-studio-codespaces/) `.devcontainer` configuration to the code base. With this addition, it is possible to create a pre-configured codespace with all the tools setup and do Gadgetron development in either the browser or in VS code with full syntax highlighting, intellisense, etc.

Example of full IDE experience in the browser:

![image](https://user-images.githubusercontent.com/1149740/88350502-2c024480-cd08-11ea-8d4f-89e74467563d.png)
 