### PR TITLE
add missing include in setup-gadget-header

### DIFF
--- a/test/gadgets/setup_gadget.h
+++ b/test/gadgets/setup_gadget.h
@@ -3,10 +3,10 @@
 //
 #pragma once
 
-#include <Channel.h>
-#include <Context.h>
-#include <Node.h>
-#include <PropertyMixin.h>
+#include "Channel.h"
+#include "Context.h"
+#include "Node.h"
+#include "PropertyMixin.h"
 #include <array>
 #include <ismrmrd/ismrmrd.h>
 #include <ismrmrd/xml.h>

--- a/test/gadgets/setup_gadget.h
+++ b/test/gadgets/setup_gadget.h
@@ -5,6 +5,7 @@
 
 #include <Channel.h>
 #include <Context.h>
+#include <Node.h>
 #include <PropertyMixin.h>
 #include <array>
 #include <ismrmrd/ismrmrd.h>


### PR DESCRIPTION
This missing include does not cause compilation error because this header
is only included test/gadgets/AcquisitionAccumulateTrigget_test.cpp which
includes AcquisitionAccumulateTriggerGadget.h which includes Node.h.