### PR TITLE
Updated SDC to enable atomic mode for DCF

### DIFF
--- a/toolboxes/mri/sdc/SDC.h
+++ b/toolboxes/mri/sdc/SDC.h
@@ -6,7 +6,7 @@
 
 #include "mri_sdc_export.h"
 
-#include "gadgetron/cuGriddingConvolution.h"
+//#include "gadgetron/cuGriddingConvolution.h"
 namespace Gadgetron
 {
     /**
@@ -28,26 +28,26 @@ namespace Gadgetron
         REAL os_factor = 2.1,
         unsigned int num_iterations = 10);
 
-        /**
-     * \brief Estimate density compensation weights for an arbitrary trajectory.
-     * 
-     * \tparam ARRAY Array type.
-     * \tparam REAL Floating-point type.
-     * \tparam D Number of dimensions.
-     * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
-     * \param matrix_size Size of reconstructed image.
-     * \param os_factor Oversampling factor
-     * \param num_iterations Number of iterations.
-     * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
-     * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
-     */
-    template<class REAL, unsigned int D>
-    EXPORTSDC std::shared_ptr<cuNDArray<REAL>> estimate_dcw(
-        const cuNDArray<vector_td<REAL, D>>& traj,
-        const vector_td<size_t, D>& matrix_size,
-        REAL os_factor = 2.1,
-        unsigned int num_iterations = 10,
-        ConvolutionType convtype = ConvolutionType::STANDARD);
+    //     /**
+    //  * \brief Estimate density compensation weights for an arbitrary trajectory.
+    //  * 
+    //  * \tparam ARRAY Array type.
+    //  * \tparam REAL Floating-point type.
+    //  * \tparam D Number of dimensions.
+    //  * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
+    //  * \param matrix_size Size of reconstructed image.
+    //  * \param os_factor Oversampling factor
+    //  * \param num_iterations Number of iterations.
+    //  * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
+    //  * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
+    //  */
+    // template<class REAL, unsigned int D>
+    // EXPORTSDC std::shared_ptr<cuNDArray<REAL>> estimate_dcw(
+    //     const cuNDArray<vector_td<REAL, D>>& traj,
+    //     const vector_td<size_t, D>& matrix_size,
+    //     REAL os_factor = 2.1,
+    //     unsigned int num_iterations = 10,
+    //     ConvolutionType convtype = ConvolutionType::STANDARD);
 
 
 
@@ -72,27 +72,27 @@ namespace Gadgetron
         REAL os_factor = 2.1,
         unsigned int num_iterations = 10);
 
-/**
-     * \brief Estimate density compensation weights for an arbitrary trajectory.
-     * 
-     * \tparam ARRAY Array type.
-     * \tparam REAL Floating-point type.
-     * \tparam D Number of dimensions.
-     * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
-     * \param initial_dcw Initial estimate for density compensation weights.
-     * \param matrix_size Size of reconstructed image.
-     * \param os_factor Oversampling factor
-     * \param num_iterations Number of iterations.
-     * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
-     * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
-     */
-    template < class REAL, unsigned int D>
-    EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<REAL>> estimate_dcw(
-        const Gadgetron::cuNDArray<vector_td<REAL, D>>& traj,
-        const Gadgetron::cuNDArray<REAL>& initial_dcw,
-        const vector_td<size_t, D>& matrix_size,
-        REAL os_factor = 2.1,
-        unsigned int num_iterations = 10,
-        ConvolutionType convtype = ConvolutionType::STANDARD);
+// /**
+//      * \brief Estimate density compensation weights for an arbitrary trajectory.
+//      * 
+//      * \tparam ARRAY Array type.
+//      * \tparam REAL Floating-point type.
+//      * \tparam D Number of dimensions.
+//      * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
+//      * \param initial_dcw Initial estimate for density compensation weights.
+//      * \param matrix_size Size of reconstructed image.
+//      * \param os_factor Oversampling factor
+//      * \param num_iterations Number of iterations.
+//      * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
+//      * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
+//      */
+//     template < class REAL, unsigned int D>
+//     EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<REAL>> estimate_dcw(
+//         const Gadgetron::cuNDArray<vector_td<REAL, D>>& traj,
+//         const Gadgetron::cuNDArray<REAL>& initial_dcw,
+//         const vector_td<size_t, D>& matrix_size,
+//         REAL os_factor = 2.1,
+//         unsigned int num_iterations = 10,
+//         ConvolutionType convtype = ConvolutionType::STANDARD);
 
 } // namespace Gadgetron

--- a/toolboxes/mri/sdc/SDC.h
+++ b/toolboxes/mri/sdc/SDC.h
@@ -6,6 +6,7 @@
 
 #include "mri_sdc_export.h"
 
+#include "gadgetron/cuGriddingConvolution.h"
 namespace Gadgetron
 {
     /**
@@ -27,6 +28,29 @@ namespace Gadgetron
         REAL os_factor = 2.1,
         unsigned int num_iterations = 10);
 
+        /**
+     * \brief Estimate density compensation weights for an arbitrary trajectory.
+     * 
+     * \tparam ARRAY Array type.
+     * \tparam REAL Floating-point type.
+     * \tparam D Number of dimensions.
+     * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
+     * \param matrix_size Size of reconstructed image.
+     * \param os_factor Oversampling factor
+     * \param num_iterations Number of iterations.
+     * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
+     * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
+     */
+    template<class REAL, unsigned int D>
+    EXPORTSDC std::shared_ptr<cuNDArray<REAL>> estimate_dcw(
+        const cuNDArray<vector_td<REAL, D>>& traj,
+        const vector_td<size_t, D>& matrix_size,
+        REAL os_factor = 2.1,
+        unsigned int num_iterations = 10,
+        ConvolutionType convtype = ConvolutionType::STANDARD);
+
+
+
     /**
      * \brief Estimate density compensation weights for an arbitrary trajectory.
      * 
@@ -47,5 +71,28 @@ namespace Gadgetron
         const vector_td<size_t, D>& matrix_size,
         REAL os_factor = 2.1,
         unsigned int num_iterations = 10);
+
+/**
+     * \brief Estimate density compensation weights for an arbitrary trajectory.
+     * 
+     * \tparam ARRAY Array type.
+     * \tparam REAL Floating-point type.
+     * \tparam D Number of dimensions.
+     * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
+     * \param initial_dcw Initial estimate for density compensation weights.
+     * \param matrix_size Size of reconstructed image.
+     * \param os_factor Oversampling factor
+     * \param num_iterations Number of iterations.
+     * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
+     * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
+     */
+    template < class REAL, unsigned int D>
+    EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<REAL>> estimate_dcw(
+        const Gadgetron::cuNDArray<vector_td<REAL, D>>& traj,
+        const Gadgetron::cuNDArray<REAL>& initial_dcw,
+        const vector_td<size_t, D>& matrix_size,
+        REAL os_factor = 2.1,
+        unsigned int num_iterations = 10,
+        ConvolutionType convtype = ConvolutionType::STANDARD);
 
 } // namespace Gadgetron

--- a/toolboxes/mri/sdc/SDC.hpp
+++ b/toolboxes/mri/sdc/SDC.hpp
@@ -4,97 +4,142 @@
 #include "ConvolutionKernel.h"
 #include "GriddingConvolution.h"
 
-namespace Gadgetron
-{
-    template<class T>
-    struct safe_divides
-    {
-        __host__ __device__
-        T operator()(const T& x, const T& y) const
-        {
-            return y == T(0) ? T(0) : x / y;
-        }
-    };
+namespace Gadgetron {
+template <class T> struct safe_divides {
+    __host__ __device__ T operator()(const T& x, const T& y) const { return y == T(0) ? T(0) : x / y; }
+};
 
+template <template <class> class ARRAY, class REAL> struct updates {
+    void operator()(const ARRAY<REAL>& src, ARRAY<REAL>& dst);
+};
 
-    template<template<class> class ARRAY, class REAL>
-    struct updates
-    {
-        void operator()(const ARRAY<REAL>& src, ARRAY<REAL>& dst);
-    };
+template <template <class> class ARRAY, class REAL, unsigned int D> struct validates {
+    vector_td<size_t, D> operator()(const vector_td<size_t, D>& size);
+};
 
+template <template <class> class ARRAY, class REAL, unsigned int D>
+std::shared_ptr<ARRAY<REAL>> estimate_dcw(const ARRAY<vector_td<REAL, D>>& traj,
+                                          const vector_td<size_t, D>& matrix_size, REAL os_factor,
+                                          unsigned int num_iterations) {
+    // Initialize weights to 1.
+    ARRAY<REAL> dcw(*traj.get_dimensions());
+    fill(&dcw, (REAL)1);
 
-    template<template<class> class ARRAY, class REAL, unsigned int D>
-    struct validates
-    {
-        vector_td<size_t, D> operator()(const vector_td<size_t, D>& size);
-    };
-
-
-    template<template<class> class ARRAY, class REAL, unsigned int D>
-    std::shared_ptr<ARRAY<REAL>> estimate_dcw(
-        const ARRAY<vector_td<REAL, D>>& traj,
-        const vector_td<size_t, D>& matrix_size,
-        REAL os_factor,
-        unsigned int num_iterations)
-    {
-        // Initialize weights to 1.
-        ARRAY<REAL> dcw(*traj.get_dimensions());
-        fill(&dcw, (REAL)1);
-
-        // Compute density compensation weights.
-        return estimate_dcw(traj, dcw, matrix_size, os_factor, num_iterations);
-    }
-
-
-    template<template<class> class ARRAY, class REAL, unsigned int D>
-    std::shared_ptr<ARRAY<REAL>> estimate_dcw(
-        const ARRAY<vector_td<REAL, D>>& traj,
-        const ARRAY<REAL>& initial_dcw,
-        const vector_td<size_t, D>& matrix_size,
-        REAL os_factor,
-        unsigned int num_iterations)
-    {
-        // Specialized functors.
-        auto update_weights = updates<ARRAY, REAL>();
-        auto validate_size = validates<ARRAY, REAL, D>();
-
-        // Matrix size with oversampling.
-        auto matrix_size_os = vector_td<size_t, D>(
-            vector_td<REAL, D>(matrix_size) * os_factor);
-
-        // Validate matrix size.
-        auto valid_matrix_size = validate_size(matrix_size);
-        auto valid_matrix_size_os = validate_size(matrix_size_os);
-
-        // Convolution kernel.
-        auto kernel = JincKernel<REAL, D>(
-            vector_td<unsigned int, D>(valid_matrix_size),
-            vector_td<unsigned int, D>(valid_matrix_size_os));
-
-        // Prepare gridding convolution.
-        auto conv = GriddingConvolution<ARRAY, REAL, D, JincKernel>::make(
-            valid_matrix_size, valid_matrix_size_os, kernel);
-        conv->preprocess(traj);
-
-        // Working arrays.
-        ARRAY<REAL> dcw(initial_dcw);
-        ARRAY<REAL> grid(to_std_vector(conv->get_matrix_size_os()));
-        ARRAY<REAL> tmp(*dcw.get_dimensions());
-
-        // Iteration loop.
-        for (size_t i = 0; i < num_iterations; i++)
-        {
-            // To intermediate grid.
-            conv->compute(dcw, grid, GriddingConvolutionMode::NC2C);
-
-            // To original trajectory.
-            conv->compute(grid, tmp, GriddingConvolutionMode::C2NC);
-
-            // Update weights.
-            update_weights(tmp, dcw);
-        }
-
-        return std::make_shared<ARRAY<REAL>>(dcw);
-    }
+    // Compute density compensation weights.
+    return estimate_dcw(traj, dcw, matrix_size, os_factor, num_iterations);
 }
+
+template <template <class> class ARRAY, class REAL, unsigned int D>
+std::shared_ptr<ARRAY<REAL>> estimate_dcw(const ARRAY<vector_td<REAL, D>>& traj, const ARRAY<REAL>& initial_dcw,
+                                          const vector_td<size_t, D>& matrix_size, REAL os_factor,
+                                          unsigned int num_iterations) {
+    // Specialized functors.
+    auto update_weights = updates<ARRAY, REAL>();
+    auto validate_size = validates<ARRAY, REAL, D>();
+
+    // Matrix size with oversampling.
+    auto matrix_size_os = vector_td<size_t, D>(vector_td<REAL, D>(matrix_size) * os_factor);
+
+    // Validate matrix size.
+    auto valid_matrix_size = validate_size(matrix_size);
+    auto valid_matrix_size_os = validate_size(matrix_size_os);
+
+    // Convolution kernel.
+    auto kernel = JincKernel<REAL, D>(vector_td<unsigned int, D>(valid_matrix_size),
+                                      vector_td<unsigned int, D>(valid_matrix_size_os));
+
+    // Prepare gridding convolution.
+    auto conv = GriddingConvolution<ARRAY, REAL, D, JincKernel>::make(valid_matrix_size, valid_matrix_size_os, kernel);
+
+    // cudaPointerAttributes attributes;
+    // cudaPointerGetAttributes(&attributes,traj.get_data_ptr());
+
+    // if(attributes.devicePointer != NULL)
+    //     //conv->initialize(ConvolutionType::ATOMIC);
+
+    conv->preprocess(traj);
+
+    // Working arrays.
+    ARRAY<REAL> dcw(initial_dcw);
+    ARRAY<REAL> grid(to_std_vector(conv->get_matrix_size_os()));
+    ARRAY<REAL> tmp(*dcw.get_dimensions());
+
+    // Iteration loop.
+    for (size_t i = 0; i < num_iterations; i++) {
+        // To intermediate grid.
+        conv->compute(dcw, grid, GriddingConvolutionMode::NC2C);
+
+        // To original trajectory.
+        conv->compute(grid, tmp, GriddingConvolutionMode::C2NC);
+
+        // Update weights.
+        update_weights(tmp, dcw);
+    }
+
+    return std::make_shared<ARRAY<REAL>>(dcw);
+}
+
+template <class REAL, unsigned int D>
+std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj,
+                                              const vector_td<size_t, D>& matrix_size, REAL os_factor,
+                                              unsigned int num_iterations, ConvolutionType convtype) {
+    // Initialize weights to 1.
+    cuNDArray<REAL> dcw(*traj.get_dimensions());
+    fill(&dcw, (REAL)1);
+
+    // Compute density compensation weights.
+    return estimate_dcw(traj, dcw, matrix_size, os_factor, num_iterations, convtype);
+}
+
+template <class REAL, unsigned int D>
+std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj,
+                                              const cuNDArray<REAL>& initial_dcw,
+                                              const vector_td<size_t, D>& matrix_size, REAL os_factor,
+                                              unsigned int num_iterations, ConvolutionType convtype) {
+    // Specialized functors.
+    auto update_weights = updates<cuNDArray, REAL>();
+    auto validate_size = validates<cuNDArray, REAL, D>();
+
+    // Matrix size with oversampling.
+    auto matrix_size_os = vector_td<size_t, D>(vector_td<REAL, D>(matrix_size) * os_factor);
+
+    // Validate matrix size.
+    auto valid_matrix_size = validate_size(matrix_size);
+    auto valid_matrix_size_os = validate_size(matrix_size_os);
+
+    // Convolution kernel.
+    auto kernel = JincKernel<REAL, D>(vector_td<unsigned int, D>(valid_matrix_size),
+                                      vector_td<unsigned int, D>(valid_matrix_size_os));
+
+    // Prepare gridding convolution.
+    auto conv = GriddingConvolution<cuNDArray, REAL, D, JincKernel>::make(valid_matrix_size, valid_matrix_size_os, kernel,convtype);
+
+    // cudaPointerAttributes attributes;
+    // cudaPointerGetAttributes(&attributes,traj.get_data_ptr());
+
+    // if(attributes.devicePointer != NULL)
+    //     //conv->initialize(ConvolutionType::ATOMIC);
+
+    conv->preprocess(traj);
+
+    // Working arrays.
+    cuNDArray<REAL> dcw(initial_dcw);
+    cuNDArray<REAL> grid(to_std_vector(conv->get_matrix_size_os()));
+    cuNDArray<REAL> tmp(*dcw.get_dimensions());
+
+    // Iteration loop.
+    for (size_t i = 0; i < num_iterations; i++) {
+        // To intermediate grid.
+        conv->compute(dcw, grid, GriddingConvolutionMode::NC2C);
+
+        // To original trajectory.
+        conv->compute(grid, tmp, GriddingConvolutionMode::C2NC);
+
+        // Update weights.
+        update_weights(tmp, dcw);
+    }
+
+    return std::make_shared<cuNDArray<REAL>>(dcw);
+}
+
+} // namespace Gadgetron

--- a/toolboxes/mri/sdc/SDC.hpp
+++ b/toolboxes/mri/sdc/SDC.hpp
@@ -54,6 +54,7 @@ std::shared_ptr<ARRAY<REAL>> estimate_dcw(const ARRAY<vector_td<REAL, D>>& traj,
     // cudaPointerAttributes attributes;
     // cudaPointerGetAttributes(&attributes,traj.get_data_ptr());
 
+
     // if(attributes.devicePointer != NULL)
     //     //conv->initialize(ConvolutionType::ATOMIC);
 
@@ -113,14 +114,13 @@ std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>
 
     // Prepare gridding convolution.
     auto conv = GriddingConvolution<cuNDArray, REAL, D, JincKernel>::make(valid_matrix_size, valid_matrix_size_os, kernel,convtype);
-
     // cudaPointerAttributes attributes;
     // cudaPointerGetAttributes(&attributes,traj.get_data_ptr());
 
     // if(attributes.devicePointer != NULL)
     //     //conv->initialize(ConvolutionType::ATOMIC);
 
-    conv->preprocess(traj);
+    conv->preprocess(traj,GriddingConvolutionPrepMode::ALL);
 
     // Working arrays.
     cuNDArray<REAL> dcw(initial_dcw);
@@ -129,11 +129,14 @@ std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>
 
     // Iteration loop.
     for (size_t i = 0; i < num_iterations; i++) {
+               
         // To intermediate grid.
         conv->compute(dcw, grid, GriddingConvolutionMode::NC2C);
-
-        // To original trajectory.
+        
+         // To original trajectory.
         conv->compute(grid, tmp, GriddingConvolutionMode::C2NC);
+
+
 
         // Update weights.
         update_weights(tmp, dcw);

--- a/toolboxes/mri/sdc/SDC.hpp
+++ b/toolboxes/mri/sdc/SDC.hpp
@@ -80,69 +80,6 @@ std::shared_ptr<ARRAY<REAL>> estimate_dcw(const ARRAY<vector_td<REAL, D>>& traj,
     return std::make_shared<ARRAY<REAL>>(dcw);
 }
 
-template <class REAL, unsigned int D>
-std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj,
-                                              const vector_td<size_t, D>& matrix_size, REAL os_factor,
-                                              unsigned int num_iterations, ConvolutionType convtype) {
-    // Initialize weights to 1.
-    cuNDArray<REAL> dcw(*traj.get_dimensions());
-    fill(&dcw, (REAL)1);
 
-    // Compute density compensation weights.
-    return estimate_dcw(traj, dcw, matrix_size, os_factor, num_iterations, convtype);
-}
-
-template <class REAL, unsigned int D>
-std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj,
-                                              const cuNDArray<REAL>& initial_dcw,
-                                              const vector_td<size_t, D>& matrix_size, REAL os_factor,
-                                              unsigned int num_iterations, ConvolutionType convtype) {
-    // Specialized functors.
-    auto update_weights = updates<cuNDArray, REAL>();
-    auto validate_size = validates<cuNDArray, REAL, D>();
-
-    // Matrix size with oversampling.
-    auto matrix_size_os = vector_td<size_t, D>(vector_td<REAL, D>(matrix_size) * os_factor);
-
-    // Validate matrix size.
-    auto valid_matrix_size = validate_size(matrix_size);
-    auto valid_matrix_size_os = validate_size(matrix_size_os);
-
-    // Convolution kernel.
-    auto kernel = JincKernel<REAL, D>(vector_td<unsigned int, D>(valid_matrix_size),
-                                      vector_td<unsigned int, D>(valid_matrix_size_os));
-
-    // Prepare gridding convolution.
-    auto conv = GriddingConvolution<cuNDArray, REAL, D, JincKernel>::make(valid_matrix_size, valid_matrix_size_os, kernel,convtype);
-    // cudaPointerAttributes attributes;
-    // cudaPointerGetAttributes(&attributes,traj.get_data_ptr());
-
-    // if(attributes.devicePointer != NULL)
-    //     //conv->initialize(ConvolutionType::ATOMIC);
-
-    conv->preprocess(traj,GriddingConvolutionPrepMode::ALL);
-
-    // Working arrays.
-    cuNDArray<REAL> dcw(initial_dcw);
-    cuNDArray<REAL> grid(to_std_vector(conv->get_matrix_size_os()));
-    cuNDArray<REAL> tmp(*dcw.get_dimensions());
-
-    // Iteration loop.
-    for (size_t i = 0; i < num_iterations; i++) {
-               
-        // To intermediate grid.
-        conv->compute(dcw, grid, GriddingConvolutionMode::NC2C);
-        
-         // To original trajectory.
-        conv->compute(grid, tmp, GriddingConvolutionMode::C2NC);
-
-
-
-        // Update weights.
-        update_weights(tmp, dcw);
-    }
-
-    return std::make_shared<cuNDArray<REAL>>(dcw);
-}
 
 } // namespace Gadgetron

--- a/toolboxes/mri/sdc/gpu/CMakeLists.txt
+++ b/toolboxes/mri/sdc/gpu/CMakeLists.txt
@@ -31,6 +31,7 @@ install(TARGETS gadgetron_toolbox_gpusdc
 	COMPONENT main
 )
 
-install(FILES 
+install(FILES
+  cuSDC.h
   DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH}
   COMPONENT main)

--- a/toolboxes/mri/sdc/gpu/cuSDC.cu
+++ b/toolboxes/mri/sdc/gpu/cuSDC.cu
@@ -56,6 +56,7 @@ Gadgetron::estimate_dcw<Gadgetron::cuNDArray, float, 3>(
     float os_factor,
     unsigned int num_iterations);
 
+
 template EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<float>>
 Gadgetron::estimate_dcw<Gadgetron::cuNDArray, float, 2>(
     const Gadgetron::cuNDArray<Gadgetron::vector_td<float, 2>>& traj,
@@ -71,4 +72,38 @@ Gadgetron::estimate_dcw<Gadgetron::cuNDArray, float, 3>(
     const Gadgetron::vector_td<size_t, 3>& matrix_size,
     float os_factor,
     unsigned int num_iterations);
+
+template EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<float>>
+Gadgetron::estimate_dcw<float, 3>(
+    const Gadgetron::cuNDArray<Gadgetron::vector_td<float, 3>>& traj,
+    const Gadgetron::vector_td<size_t, 3>& matrix_size,
+    float os_factor,
+    unsigned int num_iterations, 
+    ConvolutionType convtype);
+
+template EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<float>>
+Gadgetron::estimate_dcw<float, 2>(
+    const Gadgetron::cuNDArray<Gadgetron::vector_td<float, 2>>& traj,
+    const Gadgetron::vector_td<size_t, 2>& matrix_size,
+    float os_factor,
+    unsigned int num_iterations, 
+    ConvolutionType convtype);
+
+template EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<float>>
+Gadgetron::estimate_dcw<float, 3>(
+    const Gadgetron::cuNDArray<Gadgetron::vector_td<float, 3>>& traj,
+    const Gadgetron::cuNDArray<float>& initial_dcw,
+    const Gadgetron::vector_td<size_t, 3>& matrix_size,
+    float os_factor,
+    unsigned int num_iterations, 
+    ConvolutionType convtype);
+
+template EXPORTSDC std::shared_ptr<Gadgetron::cuNDArray<float>>
+Gadgetron::estimate_dcw<float, 2>(
+    const Gadgetron::cuNDArray<Gadgetron::vector_td<float, 2>>& traj,
+    const Gadgetron::cuNDArray<float>& initial_dcw,
+    const Gadgetron::vector_td<size_t, 2>& matrix_size,
+    float os_factor,
+    unsigned int num_iterations, 
+    ConvolutionType convtype);
     

--- a/toolboxes/mri/sdc/gpu/cuSDC.cu
+++ b/toolboxes/mri/sdc/gpu/cuSDC.cu
@@ -39,6 +39,70 @@ namespace Gadgetron
             return ((size + warp_size - size_t(1)) / warp_size) * warp_size;
         }
     };
+    template <class REAL, unsigned int D>
+std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj,
+                                              const vector_td<size_t, D>& matrix_size, REAL os_factor,
+                                              unsigned int num_iterations, ConvolutionType convtype) {
+    // Initialize weights to 1.
+    cuNDArray<REAL> dcw(*traj.get_dimensions());
+    fill(&dcw, (REAL)1);
+
+    // Compute density compensation weights.
+    return estimate_dcw(traj, dcw, matrix_size, os_factor, num_iterations, convtype);
+}
+
+template <class REAL, unsigned int D>
+std::shared_ptr<cuNDArray<REAL>> estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj,
+                                              const cuNDArray<REAL>& initial_dcw,
+                                              const vector_td<size_t, D>& matrix_size, REAL os_factor,
+                                              unsigned int num_iterations, ConvolutionType convtype) {
+    // Specialized functors.
+    auto update_weights = updates<cuNDArray, REAL>();
+    auto validate_size = validates<cuNDArray, REAL, D>();
+
+    // Matrix size with oversampling.
+    auto matrix_size_os = vector_td<size_t, D>(vector_td<REAL, D>(matrix_size) * os_factor);
+
+    // Validate matrix size.
+    auto valid_matrix_size = validate_size(matrix_size);
+    auto valid_matrix_size_os = validate_size(matrix_size_os);
+
+    // Convolution kernel.
+    auto kernel = JincKernel<REAL, D>(vector_td<unsigned int, D>(valid_matrix_size),
+                                      vector_td<unsigned int, D>(valid_matrix_size_os));
+
+    // Prepare gridding convolution.
+    auto conv = GriddingConvolution<cuNDArray, REAL, D, JincKernel>::make(valid_matrix_size, valid_matrix_size_os, kernel,convtype);
+    // cudaPointerAttributes attributes;
+    // cudaPointerGetAttributes(&attributes,traj.get_data_ptr());
+
+    // if(attributes.devicePointer != NULL)
+    //     //conv->initialize(ConvolutionType::ATOMIC);
+
+    conv->preprocess(traj,GriddingConvolutionPrepMode::ALL);
+
+    // Working arrays.
+    cuNDArray<REAL> dcw(initial_dcw);
+    cuNDArray<REAL> grid(to_std_vector(conv->get_matrix_size_os()));
+    cuNDArray<REAL> tmp(*dcw.get_dimensions());
+
+    // Iteration loop.
+    for (size_t i = 0; i < num_iterations; i++) {
+               
+        // To intermediate grid.
+        conv->compute(dcw, grid, GriddingConvolutionMode::NC2C);
+        
+         // To original trajectory.
+        conv->compute(grid, tmp, GriddingConvolutionMode::C2NC);
+
+
+
+        // Update weights.
+        update_weights(tmp, dcw);
+    }
+
+    return std::make_shared<cuNDArray<REAL>>(dcw);
+}
 }
 
 

--- a/toolboxes/mri/sdc/gpu/cuSDC.h
+++ b/toolboxes/mri/sdc/gpu/cuSDC.h
@@ -1,3 +1,44 @@
 #pragma once
 
 #include "SDC.h"
+#include "cuGriddingConvolution.h"
+namespace Gadgetron {
+
+/**
+ * \brief Estimate density compensation weights for an arbitrary trajectory.
+ *
+ * \tparam ARRAY Array type.
+ * \tparam REAL Floating-point type.
+ * \tparam D Number of dimensions.
+ * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
+ * \param matrix_size Size of reconstructed image.
+ * \param os_factor Oversampling factor
+ * \param num_iterations Number of iterations.
+ * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
+ * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
+ */
+template <class REAL, unsigned int D>
+EXPORTSDC std::shared_ptr<cuNDArray<REAL>>
+estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj, const vector_td<size_t, D>& matrix_size, REAL os_factor = 2.1,
+             unsigned int num_iterations = 10, ConvolutionType convtype = ConvolutionType::STANDARD);
+
+/**
+ * \brief Estimate density compensation weights for an arbitrary trajectory.
+ *
+ * \tparam ARRAY Array type.
+ * \tparam REAL Floating-point type.
+ * \tparam D Number of dimensions.
+ * \param traj Flattened trajectory array of size [Ns, ...], where Ns is the number of samples in a single frame.
+ * \param initial_dcw Initial estimate for density compensation weights.
+ * \param matrix_size Size of reconstructed image.
+ * \param os_factor Oversampling factor
+ * \param num_iterations Number of iterations.
+ * \param convtype is ConvolutionType::STANDARD ConvolutionType::ATOMIC
+ * \return std::shared_ptr<ARRAY<REAL>> Density compensation weights, same size as trajectory.
+ */
+template <class REAL, unsigned int D>
+EXPORTSDC std::shared_ptr<cuNDArray<REAL>>
+estimate_dcw(const cuNDArray<vector_td<REAL, D>>& traj, const cuNDArray<REAL>& initial_dcw,
+             const vector_td<size_t, D>& matrix_size, REAL os_factor = 2.1, unsigned int num_iterations = 10,
+             ConvolutionType convtype = ConvolutionType::STANDARD);
+} // namespace Gadgetron


### PR DESCRIPTION
Added the function template to estimate DCF with convolution types for cuNDArrays. 

Please note there are memory access errors with Atomic Mode that I was testing to be able to do DCF estimation for large data sets. 