### PR TITLE
Move gadgetron/ismrmrd-specific python

### DIFF
--- a/docker/build_gadgetron_dependencies.sh
+++ b/docker/build_gadgetron_dependencies.sh
@@ -28,6 +28,11 @@ while [ "$1" != "" ]; do
     shift
 done
 
+# Should these go here?
+pip3 install git+https://github.com/ismrmrd/ismrmrd-python.git
+pip3 install git+https://github.com/gadgetron/gadgetron-python.git
+
+
 mkdir -p ${WORKDIR}
 
 #ISMRMRD

--- a/docker/install_ubuntu_dependencies.sh
+++ b/docker/install_ubuntu_dependencies.sh
@@ -106,8 +106,6 @@ pip3 install \
     scipy \
     sympy \
     tk-tools
-pip3 install git+https://github.com/ismrmrd/ismrmrd-python.git
-pip3 install git+https://github.com/gadgetron/gadgetron-python.git
 
 # If this is an image with CUDA...
 if [ -f /usr/local/cuda/bin/nvcc ]; then


### PR DESCRIPTION
Hi David, 

Would you object to moving these lines?
Logic would be to keep non - gadgetron/ismrmrd items out of the ubuntu dependencies script (and keep them together in the gadgetron dependencies script).

It would help me in patching in a block of variables to specify particular commits of these items against which to build.

Oliver