### PR TITLE
send out gmap first if required in generic chain

### DIFF
--- a/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
+++ b/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
@@ -205,20 +205,6 @@ namespace Gadgetron {
                 recon_obj_[e].recon_res_.acq_headers_ = recon_bit_->rbit_[e].data_.headers_;
 
                 // ---------------------------------------------------------------
-
-                if (!debug_folder_full_path_.empty()) {
-                    this->gt_exporter_.export_array_complex(recon_obj_[e].recon_res_.data_,
-                                                            debug_folder_full_path_ + "recon_res" + os.str());
-                }
-
-                if (perform_timing.value()) {
-                    gt_timer_.start("GenericReconCartesianGrappaGadget::send_out_image_array");
-                }
-                this->send_out_image_array(recon_obj_[e].recon_res_, e,
-                                           image_series.value() + ((int) e + 1), GADGETRON_IMAGE_REGULAR);
-                if (perform_timing.value()) { gt_timer_.stop(); }
-
-                // ---------------------------------------------------------------
                 if (send_out_gfactor.value() && recon_obj_[e].gfactor_.get_number_of_elements() > 0 &&
                     (acceFactorE1_[e] * acceFactorE2_[e] > 1)) {
                     IsmrmrdImageArray res;
@@ -268,6 +254,20 @@ namespace Gadgetron {
                         if (perform_timing.value()) { gt_timer_.stop(); }
                     }
                 }
+
+                // ---------------------------------------------------------------
+
+                if (!debug_folder_full_path_.empty()) {
+                    this->gt_exporter_.export_array_complex(recon_obj_[e].recon_res_.data_,
+                        debug_folder_full_path_ + "recon_res" + os.str());
+                }
+
+                if (perform_timing.value()) {
+                    gt_timer_.start("GenericReconCartesianGrappaGadget::send_out_image_array");
+                }
+                this->send_out_image_array(recon_obj_[e].recon_res_, e,
+                    image_series.value() + ((int)e + 1), GADGETRON_IMAGE_REGULAR);
+                if (perform_timing.value()) { gt_timer_.stop(); }
             }
 
             recon_obj_[e].recon_res_.data_.clear();


### PR DESCRIPTION
let gmap be sent first if required, since some downstream application may expect gmap to be used with images