### PR TITLE
Fixed a few issues causing PureDistributed to hang on Fedora 33.

### DIFF
--- a/apps/gadgetron/connection/stream/PureDistributed.h
+++ b/apps/gadgetron/connection/stream/PureDistributed.h
@@ -40,8 +40,8 @@ namespace Gadgetron::Server::Connection::Stream {
         using Job = std::future<Core::Message>;
         using Queue = Core::MPMCChannel<Job>;
 
-        void process_outbound(Core::GenericInputChannel, Queue &);
-        void process_inbound(Core::OutputChannel, Queue &);
+        void process_outbound(Core::GenericInputChannel, std::shared_ptr<Queue>);
+        void process_inbound(Core::OutputChannel, std::shared_ptr<Queue>);
 
         std::shared_ptr<Serialization> serialization;
         std::shared_ptr<Configuration> configuration;

--- a/apps/gadgetron/connection/stream/common/Discovery.cpp
+++ b/apps/gadgetron/connection/stream/common/Discovery.cpp
@@ -70,13 +70,22 @@ namespace Gadgetron::Server::Connection::Stream {
         auto worker_discovery_command = std::getenv("GADGETRON_REMOTE_WORKER_COMMAND");
         if (!worker_discovery_command) return std::vector<Address>{};
 
+        GDEBUG_STREAM("Worker discovery command: " << worker_discovery_command);
+
+        std::error_code error_code;
         std::future<std::string> output;
         boost::process::system(
                 worker_discovery_command,
                 boost::process::std_out > output,
                 boost::process::std_err > boost::process::null,
-                boost::asio::io_service{}
+                boost::asio::io_service{},
+                error_code
         );
+
+        if (error_code) {
+            GWARN_STREAM("Failed executing remote worker command: " << error_code.message());
+            return std::vector<Address>();
+        }
 
         return parse_remote_workers(output.get());
     }

--- a/apps/gadgetron/connection/stream/common/External.cpp
+++ b/apps/gadgetron/connection/stream/common/External.cpp
@@ -4,6 +4,8 @@
 
 #include <boost/asio.hpp>
 
+#include "system_info.h"
+
 #include "connection/SocketStreamBuf.h"
 #include "log.h"
 
@@ -53,7 +55,7 @@ namespace Gadgetron::Server::Connection::Stream {
 
         boost::asio::io_service service;
         boost::asio::ip::tcp::endpoint peer;
-        boost::asio::ip::tcp::endpoint local(boost::asio::ip::tcp::v6(), port);
+        boost::asio::ip::tcp::endpoint local(Gadgetron::Server::Info::tcp_protocol(), port);
         boost::asio::ip::tcp::acceptor acceptor(service, local);
 
         auto socket = std::make_unique<boost::asio::ip::tcp::socket>(service);


### PR DESCRIPTION

 * Fixed an issue where gadgetron would fail to detect IPv6 on newer platforms, leading to connection issues for workers.
 * Fixed issue where PureDistributed would hang if no workers could be reached. 
 * Improved error/warning output a little. 
