### PR TITLE
Allow user style-sheet to be specified for integration test cases

### DIFF
--- a/test/integration/run_gadgetron_test.py
+++ b/test/integration/run_gadgetron_test.py
@@ -43,12 +43,15 @@ Skipped = "Skipped", 2
 
 def siemens_to_ismrmrd(echo_handler, *, input, output, parameters, schema, measurement, flag=None):
 
-    command = ["siemens_to_ismrmrd", "-X",
-               "-f", input,
-               "-m", parameters,
-               "-x", schema,
-               "-o", output,
-               "-z", measurement] + ([flag] if flag else [])
+    command = (
+                ["siemens_to_ismrmrd", "-X",
+                 "-f", input,
+                 "-m", parameters ] +
+               (["-x", schema,] if not (flag and flag[:18] == '--user-stylesheet=') else []) +
+                ["-o", output,
+                 "-z", measurement] +
+                ([flag] if flag else [])
+              )
 
     echo_handler(command)
     subprocess.run(command,


### PR DESCRIPTION
Just submitting this draft for comments.

siemens_to_ismrmrd accepts only one of the -x or --user-stylesheet options so the logic here is:

"Remove the -x option and its argument, and add in the --user-stylesheet option and its argument, if specified."

To minimise the number Python lines my (Python novice) fingers might damage I have (ab)used the data_conversion_flag test parameter to pass in the --user-stylesheet option and argument. Note the line to be added in the .cfg file has to use a second "=" as a separator and not [space] to be passed unmolested by Python to siemens_to_ismrmrd.

`data_conversion_flag=--user-stylesheet=filename.xsl`

The alternative, more elegant but involving somewhat more coding, would seem be adding a new parameter:

`user_parameter_xsl=filename.xsl`