### PR TITLE
Integration Test Tags

### DIFF
--- a/apps/gadgetron/system_info.cpp
+++ b/apps/gadgetron/system_info.cpp
@@ -144,7 +144,8 @@ namespace Gadgetron::Server::Info {
         void print_cuda_information(std::ostream &os) {
             int device_count = CUDA::cuda_device_count();
 
-            os << "  -- CUDA Support       : YES (" << GADGETRON_CUDA_NVCC_FLAGS << ")" << std::endl;
+            os << "  -- CUDA Support       : YES" << std::endl;
+            os << "  -- NVCC Flags         : " << GADGETRON_CUDA_NVCC_FLAGS << std::endl;
             os << "    * Number of CUDA capable devices: " << device_count << std::endl;
 
             for (int dev = 0; dev < device_count; dev++) {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,12 +84,16 @@ jobs:
     matrix:
       ubuntu2004:
         imageName: gadgetron_ubuntu_2004
+        requirements: python
       ubuntu2004CUDA:
         imageName: gadgetron_ubuntu_2004_cuda11_cudnn8
+        requirements: python,cuda
       ubuntu1804:
         imageName: gadgetron_ubuntu_1804
+        requirements: python
       ubuntu1804CUDA:
         imageName: gadgetron_ubuntu_1804_cuda11_cudnn8
+        requirements: python,cuda
   steps:
   - task: Docker@2
     displayName: Login to ACR
@@ -110,7 +114,7 @@ jobs:
   - script: |
         set -e
         fullImageName="$(AcrRegistryAddress)/$(AcrRegistryName)/$(imageName):$(build.BuildNumber)"
-        docker run --gpus all -v $(pwd)/testdata:/opt/code/gadgetron/test/integration/data --rm $fullImageName /bin/bash -c "cd /opt/code/gadgetron/test/integration/ && ./run_tests.py --echo-log-on-failure --timeout=600 --ignore-requirements=cuda,python cases/*"
+        docker run --gpus all -v $(pwd)/testdata:/opt/code/gadgetron/test/integration/data --rm $fullImageName /bin/bash -c "cd /opt/code/gadgetron/test/integration/ && ./run_tests.py --echo-log-on-failure --timeout=600 --ignore-requirements=$requirements cases/*"
     displayName: "Run integration tests"
 
 - job:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ jobs:
   - script: |
         set -e
         fullImageName="$(AcrRegistryAddress)/$(AcrRegistryName)/$(imageName):$(build.BuildNumber)"
-        docker run --gpus all -v $(pwd)/testdata:/opt/code/gadgetron/test/integration/data --rm $fullImageName /bin/bash -c "cd /opt/code/gadgetron/test/integration/ && ./run_tests.py --echo-log-on-failure --timeout=600 cases/*"
+        docker run --gpus all -v $(pwd)/testdata:/opt/code/gadgetron/test/integration/data --rm $fullImageName /bin/bash -c "cd /opt/code/gadgetron/test/integration/ && ./run_tests.py --echo-log-on-failure --timeout=600 --ignore-requirements=cuda,python cases/*"
     displayName: "Run integration tests"
 
 - job:

--- a/test/integration/cases/cmr_cine_binning.cfg
+++ b/test/integration/cases/cmr_cine_binning.cfg
@@ -13,3 +13,6 @@ output_dataset=CMR_2DT_RTCine_KspaceBinning.xml/image_2/data
 
 [REQUIREMENTS]
 system_memory=16384
+
+[TAGS]
+tags=slow

--- a/test/integration/cases/cmr_cine_binning_2slices.cfg
+++ b/test/integration/cases/cmr_cine_binning_2slices.cfg
@@ -12,3 +12,6 @@ output_dataset=CMR_2DT_RTCine_KspaceBinning.xml/image_2/data
 
 [REQUIREMENTS]
 system_memory=8192
+
+[TAGS]
+tags=slow

--- a/test/integration/cases/cmr_cine_binning_2slices_distributed.cfg
+++ b/test/integration/cases/cmr_cine_binning_2slices_distributed.cfg
@@ -12,5 +12,9 @@ output_dataset=CMR_2DT_RTCine_KspaceBinning_Cloud.xml/image_2/data
 
 [REQUIREMENTS]
 system_memory=8192
+
+[TAGS]
+tags=slow,distributed
+
 [DISTRIBUTED]
 nodes=2

--- a/test/integration/cases/cmr_mapping_t1_sr.cfg
+++ b/test/integration/cases/cmr_mapping_t1_sr.cfg
@@ -16,3 +16,6 @@ output_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_11/data
 
 [REQUIREMENTS]
 system_memory=16384
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/cpu_grappa_simple.cfg
+++ b/test/integration/cases/cpu_grappa_simple.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-2
 
 [REQUIREMENTS]
 system_memory=2048
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/distributed_buffer_simple_gre.cfg
+++ b/test/integration/cases/distributed_buffer_simple_gre.cfg
@@ -15,6 +15,9 @@ scale_comparison_threshold=1e-5
 [REQUIREMENTS]
 system_memory=1024
 
+[TAGS]
+tags=fast,distributed
+
 [DISTRIBUTED]
 nodes=1
 

--- a/test/integration/cases/distributed_image_simple_gre.cfg
+++ b/test/integration/cases/distributed_image_simple_gre.cfg
@@ -15,5 +15,8 @@ scale_comparison_threshold=1e-5
 [REQUIREMENTS]
 system_memory=1024
 
+[TAGS]
+tags=fast,distributed
+
 [DISTRIBUTED]
 nodes=2

--- a/test/integration/cases/distributed_simple_gre.cfg
+++ b/test/integration/cases/distributed_simple_gre.cfg
@@ -15,10 +15,9 @@ scale_comparison_threshold=1e-5
 [REQUIREMENTS]
 system_memory=1024
 
+[TAGS]
+tags=fast,distributed
+
 [DISTRIBUTED]
 nodes=2
-
-# Defaults:
-relay_port=8004
-
 

--- a/test/integration/cases/epi_2d.cfg
+++ b/test/integration/cases/epi_2d.cfg
@@ -16,3 +16,6 @@ scale_comparison_threshold=1e-3
 
 [REQUIREMENTS]
 system_memory=1024
+
+[TAGS]
+tags=

--- a/test/integration/cases/external_equivalent_example.cfg
+++ b/test/integration/cases/external_equivalent_example.cfg
@@ -13,3 +13,6 @@ value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
+
+[TAGS]
+tags=fast,external

--- a/test/integration/cases/external_matlab_acquisition_example.cfg
+++ b/test/integration/cases/external_matlab_acquisition_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
 matlab_support=1
+
+[TAGS]
+tags=external

--- a/test/integration/cases/external_matlab_bucket_example.cfg
+++ b/test/integration/cases/external_matlab_bucket_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
 matlab_support=1
+
+[TAGS]
+tags=external

--- a/test/integration/cases/external_matlab_buffer_example.cfg
+++ b/test/integration/cases/external_matlab_buffer_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
 matlab_support=1
+
+[TAGS]
+tags=external

--- a/test/integration/cases/external_matlab_tiny_example.cfg
+++ b/test/integration/cases/external_matlab_tiny_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
 matlab_support=1
+
+[TAGS]
+tags=external

--- a/test/integration/cases/external_python_acquisition_example.cfg
+++ b/test/integration/cases/external_python_acquisition_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
 python_support=1
+
+[TAGS]
+tags=fast,external

--- a/test/integration/cases/external_python_bucket_example.cfg
+++ b/test/integration/cases/external_python_bucket_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
 python_support=1
+
+[TAGS]
+tags=fast,external

--- a/test/integration/cases/external_python_buffer_example.cfg
+++ b/test/integration/cases/external_python_buffer_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-4
 
 [REQUIREMENTS]
 python_support=1
+
+[TAGS]
+tags=fast,external

--- a/test/integration/cases/fs_csi.cfg
+++ b/test/integration/cases/fs_csi.cfg
@@ -13,3 +13,6 @@ output_dataset=FS-CSI.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=

--- a/test/integration/cases/generic_cartesian_cine_denoise.cfg
+++ b/test/integration/cases/generic_cartesian_cine_denoise.cfg
@@ -16,3 +16,6 @@ scale_comparison_threshold=0.001
 [REQUIREMENTS]
 system_memory=6000
 
+[TAGS]
+tags=generic
+

--- a/test/integration/cases/generic_cartesian_cine_python.cfg
+++ b/test/integration/cases/generic_cartesian_cine_python.cfg
@@ -17,3 +17,5 @@ scale_comparison_threshold=0.001
 system_memory=6384
 python_support=1
 
+[TAGS]
+tags=generic

--- a/test/integration/cases/generic_grappa2x1_3d.cfg
+++ b/test/integration/cases/generic_grappa2x1_3d.cfg
@@ -11,3 +11,6 @@ output_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=slow,generic

--- a/test/integration/cases/generic_grappa2x2_3d.cfg
+++ b/test/integration/cases/generic_grappa2x2_3d.cfg
@@ -11,3 +11,6 @@ output_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=slow,generic

--- a/test/integration/cases/generic_grappa_T2W.cfg
+++ b/test/integration/cases/generic_grappa_T2W.cfg
@@ -16,3 +16,5 @@ scale_comparison_threshold=0.075
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_epi_ave.cfg
+++ b/test/integration/cases/generic_grappa_epi_ave.cfg
@@ -15,3 +15,5 @@ output_dataset=Generic_Cartesian_Grappa_EPI_AVE.xml/image_1/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes120.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.cfg
@@ -13,3 +13,6 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -13,3 +13,6 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
@@ -13,3 +13,6 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.cfg
@@ -13,3 +13,6 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.cfg
@@ -13,3 +13,6 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat__PEFOV100_PERes120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat__PEFOV100_PERes120.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -13,3 +13,6 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R3_tpat__PEFOV100_PERes120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R3_tpat__PEFOV100_PERes120.cfg
@@ -16,3 +16,5 @@ scale_comparison_threshold=0.02
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_grappa_tse.cfg
+++ b/test/integration/cases/generic_grappa_tse.cfg
@@ -14,3 +14,5 @@ output_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 [REQUIREMENTS]
 system_memory=4096
 
+[TAGS]
+tags=fast,generic

--- a/test/integration/cases/generic_nl_spirit_cartesian_sampling_cine.cfg
+++ b/test/integration/cases/generic_nl_spirit_cartesian_sampling_cine.cfg
@@ -15,3 +15,6 @@ scale_comparison_threshold=0.001
 
 [REQUIREMENTS]
 system_memory=16384
+
+[TAGS]
+tags=slow

--- a/test/integration/cases/generic_nl_spirit_random_sampling_cine.cfg
+++ b/test/integration/cases/generic_nl_spirit_random_sampling_cine.cfg
@@ -13,3 +13,6 @@ scale_comparison_threshold=0.001
 
 [REQUIREMENTS]
 system_memory=16384
+
+[TAGS]
+tags=slow

--- a/test/integration/cases/generic_spirit_cartesian_sampling_spat2.cfg
+++ b/test/integration/cases/generic_spirit_cartesian_sampling_spat2.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=0.001
 
 [REQUIREMENTS]
 system_memory=4096
+
+[TAGS]
+tags=slow

--- a/test/integration/cases/gpu_fixed_radial_mode1_cg.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_cg.cfg
@@ -14,3 +14,6 @@ output_dataset=fixed_radial_mode1_gpusense_cg.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_fixed_radial_mode1_ktsense.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_ktsense.cfg
@@ -14,3 +14,6 @@ output_dataset=fixed_radial_mode1_gpu_ktsense.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_fixed_radial_mode1_realtime.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_realtime.cfg
@@ -14,3 +14,6 @@ output_dataset=fixed_radial_mode1_realtime.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_cg.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_cg.cfg
@@ -15,3 +15,6 @@ scale_comparison_threashold=0.012
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_ktsense.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_ktsense.cfg
@@ -14,3 +14,6 @@ output_dataset=golden_radial_mode2_gpu_ktsense.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_realtime.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_realtime.cfg
@@ -14,3 +14,6 @@ output_dataset=golden_radial_mode2_realtime.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_sb.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_sb.cfg
@@ -14,3 +14,6 @@ output_dataset=golden_radial_mode2_gpusense_sb.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=2048
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_grappa_simple.cfg
+++ b/test/integration/cases/gpu_grappa_simple.cfg
@@ -16,3 +16,6 @@ scale_comparison_threshold=1e-2
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast,realtime

--- a/test/integration/cases/gpu_spiral.cfg
+++ b/test/integration/cases/gpu_spiral.cfg
@@ -14,3 +14,6 @@ output_dataset=spiral_flow_gpusense_cg.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_spiral_realtime_deblurring.cfg
+++ b/test/integration/cases/gpu_spiral_realtime_deblurring.cfg
@@ -12,8 +12,10 @@ reference_file=spiral/spiral_rt_deblurring_out.h5
 reference_dataset=deblurring_recon_acctrig.xml/image_1/data
 output_dataset=deblurring_recon_acctrig.xml/image_1/data
 
-
 [REQUIREMENTS]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/gpu_spiral_sb.cfg
+++ b/test/integration/cases/gpu_spiral_sb.cfg
@@ -14,3 +14,6 @@ output_dataset=spiral_flow_gpusense_sb.xml/image_0/data
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/grappa_T2W_python_passthrough.cfg
+++ b/test/integration/cases/grappa_T2W_python_passthrough.cfg
@@ -16,3 +16,6 @@ scale_comparison_threshold=0.075
 [REQUIREMENTS]
 system_memory=4096
 python_support=1
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/parallel_bypass_example.cfg
+++ b/test/integration/cases/parallel_bypass_example.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-5
 
 [REQUIREMENTS]
 system_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/simple_gre.cfg
+++ b/test/integration/cases/simple_gre.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-5
 
 [REQUIREMENTS]
 system_memory=1024
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/simple_gre_3d.cfg
+++ b/test/integration/cases/simple_gre_3d.cfg
@@ -14,3 +14,6 @@ scale_comparison_threshold=1e-5
 
 [REQUIREMENTS]
 system_memory=2048
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/simple_gre_python.cfg
+++ b/test/integration/cases/simple_gre_python.cfg
@@ -15,3 +15,6 @@ scale_comparison_threshold=0.001
 [REQUIREMENTS]
 system_memory=2048
 python_support=1
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/simple_gre_python_buckets.cfg
+++ b/test/integration/cases/simple_gre_python_buckets.cfg
@@ -15,3 +15,6 @@ scale_comparison_threshold=0.001
 [REQUIREMENTS]
 system_memory=2048
 python_support=1
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/simple_gre_python_image_array.cfg
+++ b/test/integration/cases/simple_gre_python_image_array.cfg
@@ -15,3 +15,6 @@ scale_comparison_threshold=1e-5
 [REQUIREMENTS]
 system_memory=1024
 python_support=1
+
+[TAGS]
+tags=fast

--- a/test/integration/cases/simple_gre_python_image_array_recon.cfg
+++ b/test/integration/cases/simple_gre_python_image_array_recon.cfg
@@ -15,3 +15,6 @@ scale_comparison_threshold=1e-5
 [REQUIREMENTS]
 system_memory=1024
 python_support=1
+
+[TAGS]
+tags=fast

--- a/test/integration/run_gadgetron_test.py
+++ b/test/integration/run_gadgetron_test.py
@@ -38,7 +38,6 @@ default_config_values = {
 
 Passed = "Passed", 0
 Failure = "Failure", 1
-Skipped = "Skipped", 2
 
 
 def siemens_to_ismrmrd(echo_handler, *, input, output, parameters, schema, measurement, flag=None):
@@ -93,19 +92,6 @@ def send_data_to_gadgetron(echo_handler, gadgetron, *, input, output, configurat
                    check=True)
 
 
-def query_gadgetron_instance(echo_handler, gadgetron, query):
-
-    command = ["gadgetron_ismrmrd_client",
-               "-a", gadgetron.host,
-               "-p", gadgetron.port,
-               "-q", "-Q", query]
-
-    echo_handler(command)
-    return subprocess.check_output(command,
-                                   env=environment,
-                                   universal_newlines=True)
-
-
 def start_gadgetron_instance(*, log, port, env=environment):
     print("Starting Gadgetron instance on port", port)
     proc = subprocess.Popen(["gadgetron",
@@ -115,39 +101,6 @@ def start_gadgetron_instance(*, log, port, env=environment):
                             env=env)
     time.sleep(2)
     return proc
-
-
-def prepare_rules(args, requirements):
-
-    class Rule:
-        def __init__(self, query, reason, validate):
-            self.query = query
-            self.reason = reason
-            self.validate = validate
-
-        def accepts(self, gadgetron):
-            try:
-                return self.validate(query_gadgetron_instance(args.echo_handler, gadgetron, self.query).strip())
-            except:
-                return False
-
-    def is_enabled(value):
-        return value in ['YES', 'yes', 'True', 'true', '1']
-
-    def as_list(value, func=float):
-        return [func(val) for val in value.split(';')]
-
-    rules = {
-        'system_memory': lambda req: Rule('gadgetron::info::memory', "Insufficient system memory.",
-                                          lambda val: float(req) * 1024 * 1024 <= float(val)),
-        'python_support': lambda req: Rule('gadgetron::info::python', "Python support required.", is_enabled),
-        'matlab_support': lambda req: Rule('gadgetron::info::matlab', "MATLAB support required.", is_enabled),
-        'gpu_support': lambda req: Rule('gadgetron::info::cuda', "CUDA support required.", is_enabled),
-        'gpu_memory': lambda req: Rule('gadgetron::cuda::memory', "Insufficient GPU memory.",
-                                       lambda val: float(req) <= min(as_list(val)))
-    }
-
-    return [rules.get(rule)(requirement) for rule, requirement in requirements if rule in rules]
 
 
 def validate_output(*, output_file, reference_file, output_dataset, reference_dataset,
@@ -230,25 +183,6 @@ def ensure_gadgetron_instance(args, config):
         yield use_external_gadgetron_action
     else:
         yield start_gadgetron_action
-
-
-def ensure_instance_satisfies_requirements(args, config):
-    if args.force:
-        return
-
-    def action(cont, *, gadgetron, **state):
-
-        failed_rules = [rule for rule in prepare_rules(args, config.items('REQUIREMENTS'))
-                        if not rule.accepts(gadgetron)]
-
-        if failed_rules:
-            for rule in failed_rules:
-                print("Skipping test case: {}".format(rule.reason))
-            return Skipped
-
-        return cont(gadgetron=gadgetron, **state)
-
-    yield action
 
 
 def prepare_copy_input_data(args, config):
@@ -435,7 +369,6 @@ def build_actions(args, config):
     yield from clear_test_folder(args, config)
     yield from start_additional_nodes(args, config)
     yield from ensure_gadgetron_instance(args, config)
-    yield from ensure_instance_satisfies_requirements(args, config)
     yield from prepare_copy_input_data(args, config)
     yield from prepare_siemens_input_data(args, config)
     yield from run_gadgetron_client(args, config)

--- a/test/integration/run_tests.py
+++ b/test/integration/run_tests.py
@@ -4,12 +4,29 @@ import os
 import sys
 import glob
 
+import re
 import csv
 import json
-import argparse
 import itertools
 import subprocess
+
+import argparse
+import configparser
+
 from pathlib import Path
+
+
+reqs = {
+    'python_support': 'python',
+    'matlab_support': 'matlab',
+    'system_memory': 'memory',
+    'gpu_support': 'cuda',
+    'gpu_memory': 'cuda'
+}
+
+
+def split_tag_list(arg):
+    return re.split(r"[,;]", arg) if arg else []
 
 
 def output_csv(stats, filename):
@@ -28,6 +45,137 @@ def output_log_file(filename):
         print(f.read())
 
 
+def query_capabilities_from_executable():
+
+    command = ["gadgetron", "--info"]
+
+    return subprocess.check_output(command, universal_newlines=True)
+
+
+def query_capabilities_from_instance(host, port):
+
+    command = ["gadgetron_ismrmrd_client",
+               "-a", host,
+               "-p", str(port),
+               "-q", "-Q", "gadgetron::info"]
+
+    return subprocess.check_output(command, universal_newlines=True)
+
+
+def query_gadgetron_capabilities(args):
+    info_string = query_capabilities_from_instance(args.host, args.port) if args.external else \
+                  query_capabilities_from_executable()
+
+    value_pattern = r"(?:\s*):(?:\s+)(?P<value>.*)?"
+
+    capability_markers = {
+        'version': "Version",
+        'build': "Git SHA1",
+        'memory': "System Memory size",
+        'python': "Python Support",
+        'matlab': "Matlab Support",
+        'cuda': "CUDA Support",
+    }
+
+    plural_capability_markers = {
+        'cuda_memory': "Total amount of global GPU memory"
+    }
+
+    def find_value(marker):
+        pattern = re.compile(marker + value_pattern, re.IGNORECASE)
+        match = pattern.search(info_string)
+
+        if not match:
+            raise RuntimeError("Failed to parse Gadgetron info string; Gadgetron capabilities could not be determined.")
+
+        return match['value']
+
+    def find_plural_values(marker):
+        pattern = re.compile(marker + value_pattern, re.IGNORECASE)
+        return [match['value'] for match in pattern.finditer(info_string)]
+
+    capabilities = {key: find_value(marker) for key, marker in capability_markers.items()}
+    capabilities.update({key: find_plural_values(marker) for key, marker in plural_capability_markers.items()})
+
+    return capabilities
+
+
+def read_test_details(filename):
+    config = configparser.ConfigParser()
+    config.read(filename)
+
+    def tags_from_tags(section):
+        return split_tag_list(section['tags'])
+
+    def tags_from_reqs(section):
+        return [tag for key, tag in reqs.items() if key in section]
+
+    class Rule:
+        def __init__(self, capability, validator, message):
+            self.capability = capability
+            self.validator = validator
+            self.message = message
+
+        def is_satisfied(self, capabilities):
+            value = capabilities.get(self.capability)
+            return self.validator(value)
+
+    def rules_from_reqs(section):
+
+        def parse_memory(string):
+            pattern = re.compile(r"(?P<value>\d+)(?: MB)?")
+            match = pattern.search(string)
+            return float(match['value'])
+
+        def is_enabled(value):
+            return value in ['YES', 'yes', 'True', 'true', '1']
+
+        def has_more_than(target):
+            return lambda value: parse_memory(target) <= parse_memory(value)
+
+        def each(validator):
+            return lambda values: all([validator(value) for value in values])
+
+        rules = [
+            ('matlab_support', lambda req: Rule('matlab', is_enabled, "MATLAB support required.")),
+            ('python_support', lambda req: Rule('python', is_enabled, "Python support required.")),
+            ('system_memory', lambda req: Rule('memory', has_more_than(req), "Not enough system memory.")),
+            ('gpu_support', lambda req: Rule('cuda', is_enabled, "CUDA support required.")),
+            ('gpu_memory', lambda req: Rule('cuda_memory', each(has_more_than(req)), "Not enough graphics memory."))
+        ]
+
+        return [(key, rule(section[key])) for key, rule in rules if key in section]
+
+    return {
+        'file': filename,
+        'tags': set(tags_from_tags(config['TAGS']) +
+                    tags_from_reqs(config['REQUIREMENTS']) +
+                    ['all']),
+        'reqs': rules_from_reqs(config['REQUIREMENTS'])
+    }
+
+
+def should_skip_test(test, capabilities, args, skip_handler):
+
+    def key_is_ignored(key):
+        return reqs.get(key, None) in args.ignore_requirements
+
+    for rule in [rule for key, rule in test.get('reqs') if not key_is_ignored(key)]:
+        if not rule.is_satisfied(capabilities):
+            skip_handler(test, rule.message)
+            return True
+
+    if not any([tag in test.get('tags') for tag in args.only]):
+        skip_handler(test, "Test missing required tag.")
+        return True
+
+    if any([tag in test.get('tags') for tag in args.exclude]):
+        skip_handler(test, "Test matched excluded tag.")
+        return True
+
+    return False
+
+
 def main():
 
     script_dir = Path(sys.argv[0]).parent
@@ -38,13 +186,13 @@ def main():
     failed = []
     skipped = []
 
+    def skip_handler(test, message):
+        skipped.append((test, message))
+
     def pass_handler(test):
         passed.append(test)
         with open('test/stats.json') as f:
             stats.append(json.loads(f.read()))
-
-    def skip_handler(test):
-        skipped.append(test)
 
     def ignore_failure(test):
         args.echo_log()
@@ -83,9 +231,6 @@ def main():
     parser.add_argument('-s', '--stats', type=str, default=None,
                         help="Output individual test stats to CSV file.")
 
-    parser.add_argument('--force', action='store_const', const=['--force'],
-                        default=[], help='Force Gadgetron to run all tests, without querying for memory/GPU/etc')
-
     parser.add_argument('--timeout', type=int, default=None,
                         help="Fail test if it's been running for more than timeout seconds.")
 
@@ -93,31 +238,49 @@ def main():
                         action='store_const', const=echo_log, default=do_not_echo_log,
                         help="Send test logs to stdout on a failed test.")
 
+    parser.add_argument('--ignore-requirements', type=split_tag_list, default='none', metavar='tags',
+                        help="Run tests with the specified tags regardless of Gadgetron capabilities.")
+
+    parser.add_argument('--only', type=split_tag_list, default='all', metavar='tags',
+                        help="Only run tests with the specified tags.")
+    parser.add_argument('--exclude', type=split_tag_list, default='none', metavar='tags',
+                        help="Do not run tests with the specified tags.")
+
     parser.add_argument('tests', type=str, nargs='+', help="Glob patterns; tests to run.")
 
     args = parser.parse_args()
 
-    handlers = {0: pass_handler, 1: args.failure_handler, 2: skip_handler}
+    print("Querying Gadgetron capabilities...")
+    capabilities = query_gadgetron_capabilities(args)
 
-    tests = sorted(set(itertools.chain(*[glob.glob(pattern) for pattern in args.tests])))
+    files = sorted(set(itertools.chain(*[glob.glob(pattern) for pattern in args.tests])))
+    tests = [read_test_details(file) for file in files]
+    tests = [test for test in tests if not should_skip_test(test, capabilities, args, skip_handler)]
+
+    handlers = {0: pass_handler, 1: args.failure_handler}
+
+    if skipped:
+        print("\nSkipped tests:")
+        for test, message in skipped:
+            print("\t{} ({})".format(test.get('file'), message))
 
     for i, test in enumerate(tests, start=1):
-        print("\nTest {} of {}: {}\n".format(i, len(tests), test))
+        print("\nTest {} of {}: {}\n".format(i, len(tests), test.get('file')))
 
         command = [sys.executable, str(subscript),
                    '-a', str(args.host),
                    '-d', str(args.data_folder),
                    '-t', str(args.test_folder),
-                   '-p', str(args.port)] + args.external + args.force + [test]
+                   '-p', str(args.port)] + args.external + [test.get('file')]
 
         with subprocess.Popen(command) as proc:
             try:
                 proc.wait(timeout=args.timeout)
-                handlers.get(proc.returncode)(test)
+                handlers.get(proc.returncode)(test.get('file'))
             except subprocess.TimeoutExpired:
-                print("Timeout happened during test: {}".format(test))
+                print("Timeout happened during test: {}".format(test.get('file')))
                 proc.kill()
-                args.failure_handler(test)
+                args.failure_handler(test.get('file'))
 
     if args.stats:
         output_csv(stats, args.stats)
@@ -125,7 +288,7 @@ def main():
     if failed:
         print("\nFailed tests:")
         for test in failed:
-            print("\t{}".format(test))
+            print("\t{}".format(test.get('file')))
 
     print("\n{} tests passed. {} tests failed. {} tests skipped.".format(len(passed), len(failed), len(skipped)))
     print("Total processing time: {:.2f} seconds.".format(sum(stat['processing_time'] for stat in stats)))

--- a/toolboxes/core/cpu/hoNDObjectArray.h
+++ b/toolboxes/core/cpu/hoNDObjectArray.h
@@ -11,5 +11,4 @@ if delete_data_on_destruct == true, the object will be released; otherwise, only
 namespace Gadgetron
 {
     template<class T> using hoNDObjectArray = hoNDArray<T>;
-
 }


### PR DESCRIPTION
I've moved the test requirements logic to the top-level test script, in order to do a few things. 
 * Test now have tags, i.e.: python, matlab, distributed, slow, fast, etc. 
 * You can exclude tests based on tags: run_tests.py --exclude=slow cases/*
 * You can run tests only if it carries a tag: run_tests.py --only=distributed cases/*
 * You can force tests to run, regardless of Gadgetron capabilities: run_tests.py --ignore-requirements=cuda cases/* (This replaces the old --force flag)
 
I set up the pipeline to always run Python and CUDA tests, regardless of Gadgetron capabilities. 
 