### PR TITLE
E2E Compression Tests

### DIFF
--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.cfg
@@ -1,0 +1,19 @@
+[SIEMENS]
+data_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+dependency_measurement=1
+data_measurement=2
+
+[CLIENT]
+configuration=Generic_Cartesian_Grappa_SNR.xml
+additional_arguments=-T 0.1
+
+[TEST]
+reference_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/ref_20160401.h5
+reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
+output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
+
+[REQUIREMENTS]
+system_memory=4096
+
+[TAGS]
+tags=fast,generic

--- a/test/integration/run_gadgetron_test.py
+++ b/test/integration/run_gadgetron_test.py
@@ -73,7 +73,7 @@ def send_dependency_to_gadgetron(echo_handler, gadgetron, dependency, log):
                    check=True)
 
 
-def send_data_to_gadgetron(echo_handler, gadgetron, *, input, output, configuration, log):
+def send_data_to_gadgetron(echo_handler, gadgetron, *, input, output, configuration, log, additional_arguments):
     print("Passing data to Gadgetron: {} -> {}".format(input, output))
 
     command = ["gadgetron_ismrmrd_client",
@@ -83,6 +83,9 @@ def send_data_to_gadgetron(echo_handler, gadgetron, *, input, output, configurat
                "-o", output,
                "-c", configuration,
                "-G", configuration]
+
+    if additional_arguments:
+        command = command + additional_arguments.split()
 
     echo_handler(command)
     subprocess.run(command,
@@ -303,12 +306,20 @@ def run_gadgetron_client(args, config):
         with open(os.path.join(args.test_folder, 'client.log'), 'w') as log:
 
             start_time = time.time()
+
+            try:
+                additional_args = config['CLIENT']['additional_arguments']
+            except KeyError:
+                additional_args = None
+
             send_data_to_gadgetron(args.echo_handler,
                                    gadgetron,
                                    input=client_input,
                                    output=output_file,
                                    configuration=config['CLIENT']['configuration'],
-                                   log=log)
+                                   log=log,
+                                   additional_arguments=additional_args)
+
             end_time = time.time()
 
             processing_time = end_time - start_time


### PR DESCRIPTION
Motivation: We are prepping a PR with some performance improvements to the compression. To make sure we don't break anything, we will be adding unit tests for the compression, but we would also like at least one end to end test that uses compression. This will give us some test coverage as we move the compression improvements in. 

Adds:
* Ability to add `additional_arguments` to the `gadgetron_ismrmrd_client` when running integration (e2e) tests. 
* Added test case that uses compression in a simple reconstruction. 
