### PR TITLE
Updated test scripts to run ismrmrd client multiple times.

### DIFF
--- a/apps/gadgetron/system_info.cpp
+++ b/apps/gadgetron/system_info.cpp
@@ -152,7 +152,7 @@ namespace Gadgetron::Server::Info {
               os << "      - Device " << dev << ": " << CUDA::cuda_device_name(dev) << std::endl;
               os << "         + CUDA Driver Version / Runtime Version: " << CUDA::cuda_driver_version() << "/" << CUDA::cuda_runtime_version() << std::endl;
               os << "         + CUDA Capability Major / Minor version number: " <<  CUDA::cuda_device_capabilities(dev) << std::endl;
-              os << "         + Total amount of global GPU memory: " << CUDA::cuda_device_memory(dev) / (1024 * 1024) << " MB" << std::endl;
+              os << "         + Total amount of global GPU memory: " << std::to_string(CUDA::cuda_device_memory(dev) / (1024 * 1024)) << " MB" << std::endl;
             }
         }
     }

--- a/test/integration/cases/cmr_cine_binning.cfg
+++ b/test/integration/cases/cmr_cine_binning.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=cmr/CineBinning/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=cmr/CineBinning/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=cmr/CineBinning/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8.dat
+measurement=2
+
+[reconstruction.client]
 configuration=CMR_2DT_RTCine_KspaceBinning.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=cmr/CineBinning/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8/ref_20160604.h5
 reference_dataset=CMR_2DT_RTCine_KspaceBinning.xml/image_2/data
 output_dataset=CMR_2DT_RTCine_KspaceBinning.xml/image_2/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=16384
 
-[TAGS]
+[tags]
 tags=slow

--- a/test/integration/cases/cmr_cine_binning_2slices.cfg
+++ b/test/integration/cases/cmr_cine_binning_2slices.cfg
@@ -1,17 +1,18 @@
-[SIEMENS]
-data_file=cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
-data_measurement=2
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
+measurement=2
+
+[reconstruction.client]
 configuration=CMR_2DT_RTCine_KspaceBinning.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/ref_20160604.h5
 reference_dataset=CMR_2DT_RTCine_KspaceBinning.xml/image_2/data
 output_dataset=CMR_2DT_RTCine_KspaceBinning.xml/image_2/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=8192
 
-[TAGS]
+[tags]
 tags=slow

--- a/test/integration/cases/cmr_cine_binning_2slices_distributed.cfg
+++ b/test/integration/cases/cmr_cine_binning_2slices_distributed.cfg
@@ -1,20 +1,21 @@
-[SIEMENS]
-data_file=cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
-data_measurement=2
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
+measurement=2
+
+[reconstruction.client]
 configuration=CMR_2DT_RTCine_KspaceBinning_Cloud.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/ref_20160604.h5
 reference_dataset=CMR_2DT_RTCine_KspaceBinning.xml/image_2/data
 output_dataset=CMR_2DT_RTCine_KspaceBinning_Cloud.xml/image_2/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=8192
 
-[TAGS]
+[tags]
 tags=slow,distributed
 
-[DISTRIBUTED]
+[distributed]
 nodes=2

--- a/test/integration/cases/cmr_mapping_t1_sr.cfg
+++ b/test/integration/cases/cmr_mapping_t1_sr.cfg
@@ -1,32 +1,41 @@
-[SIEMENS]
-data_file=cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256.dat
-dependency_measurement=1
-data_measurement=2
 
+[dependency.siemens]
+data_file=cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256.dat
+measurement=2
 parameter_xsl=IsmrmrdParameterMap_Siemens_T1Mapping_SASHA.xsl
 
-
-[CLIENT]
+[reconstruction.client]
 configuration=CMR_2DT_T1Mapping_SASHA.xml
 
-[TEST]
+[reconstruction.test.1]
 reference_file=cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.h5
 reference_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_1/data
 output_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_1/data
-[TEST2]
+
+[reconstruction.test.2]
 reference_file=cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.h5
 reference_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_12/data
 output_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_12/data
-[TEST3]
+
+[reconstruction.test.3]
 reference_file=cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.h5
 reference_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_11/data
 output_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_11/data
-[TEST4]
+
+[reconstruction.test.4]
 reference_file=cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.h5
 reference_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_20/data
 output_dataset=CMR_2DT_T1Mapping_SASHA.xml/image_20/data
-[REQUIREMENTS]
+
+[requirements]
 system_memory=16384
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/cpu_grappa_simple.cfg
+++ b/test/integration/cases/cpu_grappa_simple.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
-data_file=rtgrappa/acc_data_with_device_2.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=rtgrappa/acc_data_with_device_2.dat
+measurement=1
+
+[reconstruction.client]
 configuration=grappa_float_cpu.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=rtgrappa/grappa_rate2_cpu_out.h5
 reference_dataset=grappa_float_cpu.xml/image_0/data
 output_dataset=grappa_float_cpu.xml/image_0/data
 value_comparison_threshold=1e-1
 scale_comparison_threshold=1e-2
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/distributed_buffer_simple_gre.cfg
+++ b/test/integration/cases/distributed_buffer_simple_gre.cfg
@@ -1,26 +1,23 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=distributed_generic_default.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out_20150110_msh.h5
 reference_dataset=default.xml/image_0/data
 output_dataset=distributed_generic_default.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 
-[TAGS]
+[tags]
 tags=fast,distributed
 
-[DISTRIBUTED]
+[distributed]
 nodes=1
-
-
-
-

--- a/test/integration/cases/distributed_image_simple_gre.cfg
+++ b/test/integration/cases/distributed_image_simple_gre.cfg
@@ -1,22 +1,23 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=distributed_image_default.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out_20150110_msh.h5
 reference_dataset=default.xml/image_0/data
 output_dataset=distributed_image_default.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 
-[TAGS]
+[tags]
 tags=fast,distributed
 
-[DISTRIBUTED]
+[distributed]
 nodes=2

--- a/test/integration/cases/distributed_simple_gre.cfg
+++ b/test/integration/cases/distributed_simple_gre.cfg
@@ -1,23 +1,24 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=distributed_default.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out_20150110_msh.h5
 reference_dataset=default.xml/image_0/data
 output_dataset=distributed_default.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 
-[TAGS]
+[tags]
 tags=fast,distributed
 
-[DISTRIBUTED]
+[distributed]
 nodes=2
 

--- a/test/integration/cases/epi_2d.cfg
+++ b/test/integration/cases/epi_2d.cfg
@@ -1,21 +1,28 @@
-[SIEMENS]
-data_file=epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
-parameter_xsl=IsmrmrdParameterMap_Siemens_EPI.xsl
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
+measurement=2
+parameter_xsl=IsmrmrdParameterMap_Siemens_EPI.xsl
+
+[reconstruction.client]
 configuration=epi.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=epi/epi_2d_out_20161020_pjv.h5
 reference_dataset=epi.xml/image_0/data
 output_dataset=epi.xml/image_0/data
 value_comparison_threshold=1e-3
 scale_comparison_threshold=1e-3
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 
-[TAGS]
+[tags]
 tags=

--- a/test/integration/cases/external_equivalent_example.cfg
+++ b/test/integration/cases/external_equivalent_example.cfg
@@ -1,18 +1,19 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=external_equivalent_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_equivalent_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 
-[TAGS]
+[tags]
 tags=fast,external

--- a/test/integration/cases/external_matlab_acquisition_example.cfg
+++ b/test/integration/cases/external_matlab_acquisition_example.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=external_matlab_acquisition_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_matlab_acquisition_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 matlab_support=1
 
-[TAGS]
+[tags]
 tags=external

--- a/test/integration/cases/external_matlab_bucket_example.cfg
+++ b/test/integration/cases/external_matlab_bucket_example.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=external_matlab_bucket_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_matlab_bucket_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 matlab_support=1
 
-[TAGS]
+[tags]
 tags=external

--- a/test/integration/cases/external_matlab_buffer_example.cfg
+++ b/test/integration/cases/external_matlab_buffer_example.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=external_matlab_buffer_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_matlab_buffer_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 matlab_support=1
 
-[TAGS]
+[tags]
 tags=external

--- a/test/integration/cases/external_matlab_tiny_example.cfg
+++ b/test/integration/cases/external_matlab_tiny_example.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=external_matlab_tiny_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_matlab_tiny_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 matlab_support=1
 
-[TAGS]
+[tags]
 tags=external

--- a/test/integration/cases/external_python_acquisition_example.cfg
+++ b/test/integration/cases/external_python_acquisition_example.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=external_python_acquisition_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_python_acquisition_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast,external

--- a/test/integration/cases/external_python_bucket_example.cfg
+++ b/test/integration/cases/external_python_bucket_example.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=external_python_bucket_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_python_bucket_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast,external

--- a/test/integration/cases/external_python_buffer_example.cfg
+++ b/test/integration/cases/external_python_buffer_example.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
-data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
 
-[CLIENT]
+[reconstruction.siemens]
+data_file=simple_gre/meas_MiniGadgetron_GRE.dat
+measurement=1
+
+[reconstruction.client]
 configuration=external_python_buffer_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=simple_recon/image_0/data
 output_dataset=external_python_buffer_example.xml/image_0/data
 value_comparison_threshold=1e-4
 scale_comparison_threshold=1e-4
 
-[REQUIREMENTS]
+[requirements]
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast,external

--- a/test/integration/cases/fs_csi.cfg
+++ b/test/integration/cases/fs_csi.cfg
@@ -1,18 +1,19 @@
-[COPY]
+
+[reconstruction.copy]
 source=matlab/Kidney4cmSlice.h5
 
-[CLIENT]
+[reconstruction.client]
 configuration=FS-CSI.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=hyper/Kidney4cmSlice_sb_outV3.h5
 reference_dataset=FS-CSI.xml/image_0/data
 output_dataset=FS-CSI.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=

--- a/test/integration/cases/generic_cartesian_cine_denoise.cfg
+++ b/test/integration/cases/generic_cartesian_cine_denoise.cfg
@@ -1,21 +1,27 @@
-[SIEMENS]
-data_file=generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_Cine_Denoise.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=denoise/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/ref_20180709_denoised.h5
 reference_dataset=denoise/image_1/data
 output_dataset=Generic_Cartesian_Grappa_Cine_Denoise.xml/image_1/data
 value_comparison_threshold=0.005
 scale_comparison_threshold=0.001
 
-[REQUIREMENTS]
+[requirements]
 system_memory=6000
 
-[TAGS]
+[tags]
 tags=generic
-

--- a/test/integration/cases/generic_cartesian_cine_python.cfg
+++ b/test/integration/cases/generic_cartesian_cine_python.cfg
@@ -1,21 +1,28 @@
-[SIEMENS]
-data_file=generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_RealTimeCine_Python.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/ref/ref_20180709.h5
 reference_dataset=Generic_Cartesian_Grappa_RealTimeCine_Python.xml/image_1/data
 output_dataset=Generic_Cartesian_Grappa_RealTimeCine_Python.xml/image_1/data
 value_comparison_threshold=0.005
 scale_comparison_threshold=0.001
 
-[REQUIREMENTS]
+[requirements]
 system_memory=6384
 python_support=1
 
-[TAGS]
+[tags]
 tags=generic

--- a/test/integration/cases/generic_grappa2x1_3d.cfg
+++ b/test/integration/cases/generic_grappa2x1_3d.cfg
@@ -1,16 +1,17 @@
-[COPY]
+
+[reconstruction.copy]
 source=grappa_3d/gre_3D_Grappa2x1.h5
 
-[CLIENT]
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=grappa_3d/ref_grappa2x1.h5
 reference_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 output_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=slow,generic

--- a/test/integration/cases/generic_grappa2x2_3d.cfg
+++ b/test/integration/cases/generic_grappa2x2_3d.cfg
@@ -1,16 +1,17 @@
-[COPY]
+
+[reconstruction.copy]
 source=grappa_3d/gre_3D_Grappa2x2.h5
 
-[CLIENT]
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=grappa_3d/ref_grappa2x2.h5
 reference_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 output_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=slow,generic

--- a/test/integration/cases/generic_grappa_T2W.cfg
+++ b/test/integration/cases/generic_grappa_T2W.cfg
@@ -1,20 +1,27 @@
-[SIEMENS]
-data_file=T2W/meas_MID00057_T2w.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=T2W/meas_MID00057_T2w.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=T2W/meas_MID00057_T2w.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_T2W.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=T2W/generic_grappa_T2W_ref.h5
 reference_dataset=Generic_Cartesian_Grappa_T2W.xml/image_1/data
 output_dataset=Generic_Cartesian_Grappa_T2W.xml/image_1/data
 value_comparison_threshold=0.075
 scale_comparison_threshold=0.075
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_epi_ave.cfg
+++ b/test/integration/cases/generic_grappa_epi_ave.cfg
@@ -1,19 +1,20 @@
-[SIEMENS]
+
+[reconstruction.siemens]
 data_file=epi_ave/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron.dat
+measurement=1
 parameter_xsl=IsmrmrdParameterMap_Siemens_EPI_FLASHREF.xsl
-data_measurement=1
 data_conversion_flag=--flashPatRef
 
-[CLIENT]
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_EPI_AVE.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=epi_ave/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron/ref_20161020.h5
 reference_dataset=Generic_Cartesian_Grappa_EPI_AVE.xml/image_1/data
 output_dataset=Generic_Cartesian_Grappa_EPI_AVE.xml/image_1/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.cfg
@@ -1,19 +1,26 @@
-[SIEMENS]
-data_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 additional_arguments=-T 0.1
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV100_PERes120.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/meas_MID00423_FID114625_R1_PEFOV100_PERes120.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/meas_MID00423_FID114625_R1_PEFOV100_PERes120.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/meas_MID00423_FID114625_R1_PEFOV100_PERes120.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/meas_MID00394_FID114596_R1_PEFOV75_PERes75.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/meas_MID00394_FID114596_R1_PEFOV75_PERes75.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/meas_MID00394_FID114596_R1_PEFOV75_PERes75.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
+++ b/test/integration/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_spat__PEFOV100_PERes120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_spat__PEFOV100_PERes120.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
+++ b/test/integration/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_snr_R3_tpat__PEFOV100_PERes120.cfg
+++ b/test/integration/cases/generic_grappa_snr_R3_tpat__PEFOV100_PERes120.cfg
@@ -1,20 +1,27 @@
-[SIEMENS]
-data_file=generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa_SNR.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/ref_20160401.h5
 reference_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 output_dataset=Generic_Cartesian_Grappa_SNR.xml/image_300/data
 value_comparison_threshold=0.02
 scale_comparison_threshold=0.02
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_grappa_tse.cfg
+++ b/test/integration/cases/generic_grappa_tse.cfg
@@ -1,18 +1,25 @@
-[SIEMENS]
-data_file=tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_Grappa.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/ref_20160319.h5
 reference_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 output_dataset=Generic_Cartesian_Grappa.xml/image_1/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=fast,generic

--- a/test/integration/cases/generic_nl_spirit_cartesian_sampling_cine.cfg
+++ b/test/integration/cases/generic_nl_spirit_cartesian_sampling_cine.cfg
@@ -1,20 +1,27 @@
-[SIEMENS]
-data_file=generic/meas_MID836_1slice_FID22517/meas_MID836_1slice_FID22517.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=generic/meas_MID836_1slice_FID22517/meas_MID836_1slice_FID22517.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=generic/meas_MID836_1slice_FID22517/meas_MID836_1slice_FID22517.dat
+measurement=2
+
+[reconstruction.client]
 configuration=Generic_Cartesian_NonLinear_Spirit_RealTimeCine.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID836_1slice_FID22517/ref_20160719.h5
 reference_dataset=Generic_Cartesian_NonLinear_Spirit_RealTimeCine.xml/image_1/data
 output_dataset=Generic_Cartesian_NonLinear_Spirit_RealTimeCine.xml/image_1/data
 value_comparison_threshold=0.005
 scale_comparison_threshold=0.001
 
-[REQUIREMENTS]
+[requirements]
 system_memory=16384
 
-[TAGS]
+[tags]
 tags=slow

--- a/test/integration/cases/generic_nl_spirit_random_sampling_cine.cfg
+++ b/test/integration/cases/generic_nl_spirit_random_sampling_cine.cfg
@@ -1,18 +1,18 @@
-[COPY]
+[reconstruction.copy]
 source=generic/meas_MID01095_FID40115/meas_MID01095_FID40115.h5
 
-[CLIENT]
+[reconstruction.client]
 configuration=Generic_Cartesian_RandomSampling_NonLinear_Spirit_RealTimeCine.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID01095_FID40115/ref_20160719.h5
 reference_dataset=Generic_Cartesian_RandomSampling_NonLinear_Spirit_RealTimeCine.xml/image_1/data
 output_dataset=Generic_Cartesian_RandomSampling_NonLinear_Spirit_RealTimeCine.xml/image_1/data
 value_comparison_threshold=0.01
 scale_comparison_threshold=0.001
 
-[REQUIREMENTS]
+[requirements]
 system_memory=16384
 
-[TAGS]
+[tags]
 tags=slow

--- a/test/integration/cases/generic_spirit_cartesian_sampling_spat2.cfg
+++ b/test/integration/cases/generic_spirit_cartesian_sampling_spat2.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=generic/meas_MID00062_FID114726_SAX_SASHA/meas_MID00062_FID114726_SAX_SASHA.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=Generic_Cartesian_Spirit_SASHA.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=generic/meas_MID00062_FID114726_SAX_SASHA/ref_20160426.h5
 reference_dataset=Generic_Cartesian_Spirit_SASHA.xml/image_1/data
 output_dataset=Generic_Cartesian_Spirit_SASHA.xml/image_1/data
 value_comparison_threshold=0.001
 scale_comparison_threshold=0.001
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 
-[TAGS]
+[tags]
 tags=slow

--- a/test/integration/cases/gpu_fixed_radial_mode1_cg.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_cg.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=fixed_radial_mode1_gpusense_cg.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=radial_phantom/fixed_radial_mode1.h5
 reference_dataset=cg/image_0.img
 output_dataset=fixed_radial_mode1_gpusense_cg.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_fixed_radial_mode1_ktsense.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_ktsense.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=fixed_radial_mode1_gpu_ktsense.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=radial_phantom/fixed_radial_mode1.h5
 reference_dataset=kt/image_0.img
 output_dataset=fixed_radial_mode1_gpu_ktsense.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_fixed_radial_mode1_realtime.cfg
+++ b/test/integration/cases/gpu_fixed_radial_mode1_realtime.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=fixed_radial_mode1_realtime.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=radial_phantom/fixed_radial_mode1.h5
 reference_dataset=realtime/image_0.img
 output_dataset=fixed_radial_mode1_realtime.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_cg.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_cg.cfg
@@ -1,20 +1,20 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=golden_radial_mode2_gpusense_cg.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=radial_phantom/golden_radial_mode2.h5
 reference_dataset=cg/image_0.img
 output_dataset=golden_radial_mode2_gpusense_cg.xml/image_0/data
 scale_comparison_threashold=0.012
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_ktsense.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_ktsense.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=golden_radial_mode2_gpu_ktsense.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=radial_phantom/golden_radial_mode2.h5
 reference_dataset=kt/image_0.img
 output_dataset=golden_radial_mode2_gpu_ktsense.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_realtime.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_realtime.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=golden_radial_mode2_realtime.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=radial_phantom/golden_radial_mode2.h5
 reference_dataset=realtime/image_0.img
 output_dataset=golden_radial_mode2_realtime.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_golden_radial_mode2_sb.cfg
+++ b/test/integration/cases/gpu_golden_radial_mode2_sb.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=golden_radial_mode2_gpusense_sb.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=radial_phantom/golden_radial_mode2.h5
 reference_dataset=sb/image_0.img
 output_dataset=golden_radial_mode2_gpusense_sb.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=2048
 
-[TAGS]
+[tags]
 tags=slow

--- a/test/integration/cases/gpu_grappa_simple.cfg
+++ b/test/integration/cases/gpu_grappa_simple.cfg
@@ -1,21 +1,21 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=rtgrappa/acc_data_with_device_2.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=grappa_float.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=rtgrappa/grappa_rate2_cpu_out.h5
 reference_dataset=grappa_float_cpu.xml/image_0/data
 output_dataset=grappa_float.xml/image_0/data
 value_comparison_threshold=1e-1
 scale_comparison_threshold=1e-2
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast,realtime

--- a/test/integration/cases/gpu_spiral.cfg
+++ b/test/integration/cases/gpu_spiral.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=spiral_flow_gpusense_cg.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=spiral/simple_spiral_out_v2.h5
 reference_dataset=spiral_flow_gpusense_cg.xml/image_0/data
 output_dataset=spiral_flow_gpusense_cg.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_spiral_realtime_deblurring.cfg
+++ b/test/integration/cases/gpu_spiral_realtime_deblurring.cfg
@@ -1,21 +1,28 @@
-[SIEMENS]
+
+[dependency.siemens]
+data_file=spiral/meas_MID00080_FID16005_MiniIRT_B0.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
 data_file=spiral/meas_MID00080_FID16005_MiniIRT_B0.dat
 parameter_xsl=IsmrmrdParameterMap_Siemens_B0REF.xsl
-dependency_measurement=1
-data_measurement=2
+measurement=2
 
-[CLIENT]
+[reconstruction.client]
 configuration=deblurring_recon_acctrig.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=spiral/spiral_rt_deblurring_out.h5
 reference_dataset=deblurring_recon_acctrig.xml/image_1/data
 output_dataset=deblurring_recon_acctrig.xml/image_1/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/gpu_spiral_sb.cfg
+++ b/test/integration/cases/gpu_spiral_sb.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=spiral_flow_gpusense_sb.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=spiral/simple_spiral_out_sb_v2.h5
 reference_dataset=spiral_flow_gpusense_sb.xml/image_0/data
 output_dataset=spiral_flow_gpusense_sb.xml/image_0/data
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 gpu_support=1
 gpu_memory=1024
 
-[TAGS]
+[tags]
 tags=

--- a/test/integration/cases/grappa_T2W_python_passthrough.cfg
+++ b/test/integration/cases/grappa_T2W_python_passthrough.cfg
@@ -1,21 +1,28 @@
-[SIEMENS]
-data_file=T2W/meas_MID00057_T2w.dat
-dependency_measurement=1
-data_measurement=2
 
-[CLIENT]
+[dependency.siemens]
+data_file=T2W/meas_MID00057_T2w.dat
+measurement=1
+
+[dependency.client]
+configuration=default_measurement_dependencies.xml
+
+[reconstruction.siemens]
+data_file=T2W/meas_MID00057_T2w.dat
+measurement=2
+
+[reconstruction.client]
 configuration=python_passthrough.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=T2W/generic_grappa_T2W_ref.h5
 reference_dataset=Generic_Cartesian_Grappa_T2W.xml/image_1/data
 output_dataset=python_passthrough.xml/image_1/data
 value_comparison_threshold=0.075
 scale_comparison_threshold=0.075
 
-[REQUIREMENTS]
+[requirements]
 system_memory=4096
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/parallel_bypass_example.cfg
+++ b/test/integration/cases/parallel_bypass_example.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=parallel_bypass_example.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_output.h5
 reference_dataset=inverted/image_0/data
 output_dataset=parallel_bypass_example.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/simple_gre.cfg
+++ b/test/integration/cases/simple_gre.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=default.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out_20150110_msh.h5
 reference_dataset=default.xml/image_0/data
 output_dataset=default.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/simple_gre_3d.cfg
+++ b/test/integration/cases/simple_gre_3d.cfg
@@ -1,19 +1,19 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=gre_3d/meas_MID248_gre_FID30644.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=default_optimized.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=gre_3d/simple_gre_out_3d_20150110_msh.h5
 reference_dataset=default_optimized.xml/image_0/data
 output_dataset=default_optimized.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/simple_gre_python.cfg
+++ b/test/integration/cases/simple_gre_python.cfg
@@ -1,20 +1,20 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=python_short.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out.h5
 reference_dataset=python_short.xml/image_1.img
 output_dataset=python_short.xml/image_1/data
 value_comparison_threshold=0.002
 scale_comparison_threshold=0.001
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/simple_gre_python_buckets.cfg
+++ b/test/integration/cases/simple_gre_python_buckets.cfg
@@ -1,20 +1,20 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=python_buckets.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out_20150110_msh.h5
 reference_dataset=default.xml/image_0/data
 output_dataset=python_buckets.xml/image_0/data
 value_comparison_threshold=0.002
 scale_comparison_threshold=0.001
 
-[REQUIREMENTS]
+[requirements]
 system_memory=2048
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/simple_gre_python_image_array.cfg
+++ b/test/integration/cases/simple_gre_python_image_array.cfg
@@ -1,20 +1,20 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=python_image_array.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out_20150110_msh.h5
 reference_dataset=default.xml/image_0/data
 output_dataset=python_image_array.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/cases/simple_gre_python_image_array_recon.cfg
+++ b/test/integration/cases/simple_gre_python_image_array_recon.cfg
@@ -1,20 +1,20 @@
-[SIEMENS]
+[reconstruction.siemens]
 data_file=simple_gre/meas_MiniGadgetron_GRE.dat
-data_measurement=1
+measurement=1
 
-[CLIENT]
+[reconstruction.client]
 configuration=python_image_array_recon.xml
 
-[TEST]
+[reconstruction.test]
 reference_file=simple_gre/simple_gre_out_20150110_msh.h5
 reference_dataset=default.xml/image_0/data
 output_dataset=python_image_array_recon.xml/image_0/data
 value_comparison_threshold=1e-5
 scale_comparison_threshold=1e-5
 
-[REQUIREMENTS]
+[requirements]
 system_memory=1024
 python_support=1
 
-[TAGS]
+[tags]
 tags=fast

--- a/test/integration/run_tests.py
+++ b/test/integration/run_tests.py
@@ -148,10 +148,10 @@ def read_test_details(filename):
 
     return {
         'file': filename,
-        'tags': set(tags_from_tags(config['TAGS']) +
-                    tags_from_reqs(config['REQUIREMENTS']) +
+        'tags': set(tags_from_tags(config['tags']) +
+                    tags_from_reqs(config['requirements']) +
                     ['all']),
-        'reqs': rules_from_reqs(config['REQUIREMENTS'])
+        'reqs': rules_from_reqs(config['requirements'])
     }
 
 


### PR DESCRIPTION
Old scripts would only run the client once (unless you had a dependency, which it would run with a hardcoded config file). This update allows tests to specify multiple runs of converter, client, and test output validation.

These changes are made to improve the testing system, and make testing of storage feasible.

I also fixed a bug where a comma had crept into the GPU memory reported by Gadgetron, causing the test script to skip GPU tests in some cases.