### PR TITLE
Aymeric/mrd to dicom conversion keep other for patient sex

### DIFF
--- a/gadgets/dicom/dicom_ismrmrd_utility.cpp
+++ b/gadgets/dicom/dicom_ismrmrd_utility.cpp
@@ -342,11 +342,14 @@ namespace Gadgetron
             // Patient Sex
             key.set(0x0010, 0x0040);
             if (patient_info.patientGender) {
-                if (*patient_info.patientGender == "O") {
-                    status = dataset->insertEmptyElement(key);
+                std::string patientGenderUppercase = patient_info.patientGender.get();
+                std::transform(patientGenderUppercase.begin(), patientGenderUppercase.end(), patientGenderUppercase.begin(), ::toupper);
+
+                if (patientGenderUppercase == "M" || patientGenderUppercase == "F" || patientGenderUppercase == "O") {
+                    write_dcm_string(dataset, key, patientGenderUppercase.c_str());
                 }
                 else {
-                    write_dcm_string(dataset, key, patient_info.patientGender->c_str());
+                    write_dcm_string(dataset, key, "");
                 }
             }
             else {


### PR DESCRIPTION
Convert correctly mrd patient_info.patientGender into PatientSex dicom tag.

When patientGender = O then PatientSex must be also set to "O" as described in the standard https://dicom.innolitics.com/ciods/mr-image/patient/00100040

If patientGender is not O, F or M then PatientSex is set to an empty string because the type of this dicom tag is "Required, Empty if Unknown"
