### PR TITLE
Enable non-root devcontainer user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/gadgetron/gadgetron/gadgetron_ubuntu_2004_cuda11_cudnn8_base
+
+# Options for setup script
+ARG INSTALL_ZSH="false"
+ARG UPGRADE_PACKAGES="false"
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ARG VSCODE_DEV_CONTAINERS_SCRIPT_LIBRARY_VERSION=v0.209.3
+
+# Install needed packages and setup non-root user.
+RUN script=$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/${VSCODE_DEV_CONTAINERS_SCRIPT_LIBRARY_VERSION}/script-library/common-debian.sh") && bash -c "$script" -- "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
+    && apt-get install -y gdb
+
+RUN update-locale LANG=en_US.UTF-8

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/gadgetron/gadgetron/gadgetron_ubuntu_2004_cuda11_cudnn8_base
+ARG BASE_IMAGE=ghcr.io/gadgetron/gadgetron/gadgetron_ubuntu_2004_cuda11_cudnn8_base
+FROM ${BASE_IMAGE}
 
 # Options for setup script
 ARG INSTALL_ZSH="false"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
-	"name": "ubuntu_2004_cuda11_cudnn8",
-	"image": "ghcr.io/gadgetron/gadgetron/gadgetron_ubuntu_2004_cuda11_cudnn8_base",
+	"name": "Gadgetron",
+
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
@@ -23,5 +26,8 @@
 		"eamodio.gitlens",
 	],
 
-	"postCreateCommand": "apt-get update && apt-get -y install locales gdb && locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8 && .devcontainer/bootstrap-vscode.sh ",
+	// Use the non-root user
+	"remoteUser": "vscode",
+
+	"postCreateCommand": ".devcontainer/bootstrap-vscode.sh ",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
 
 	"build": {
 		"dockerfile": "Dockerfile",
+		"args": {
+			"BASE_IMAGE": "ghcr.io/gadgetron/gadgetron/gadgetron_ubuntu_2004_cuda11_cudnn8_base"
+		}
 	},
 
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
This is a small change the devcontainer definition to have it use a non-root user. 

Any files created in the devcontainer within the repo by the previous root user are still going to be owned by root, because the repo directory is bind-mounted into the container from the host system and the root user in the container corresponds to the root user on the host. For that reason, you may get access denied errors after this change and will need to change the owner of the files within the repo. This can be done from within the devcontainer, after this change, by running `sudo chown -R vscode .` It can also be done from the host, specifying your username instead of "vscode".