### PR TITLE
Pinning ISMRMRD version

### DIFF
--- a/docker/build_gadgetron_dependencies.sh
+++ b/docker/build_gadgetron_dependencies.sh
@@ -41,9 +41,6 @@ cd ${WORKDIR} && \
     ninja && \
     ninja install
 
-# Install Python interfaces.
-pip3 install ismrmrd multimethod 
-
 #SIEMENS_TO_ISMRMRD
 cd ${WORKDIR} && \
     rm -rf siemens_to_ismrmrd && \

--- a/docker/install_ubuntu_dependencies.sh
+++ b/docker/install_ubuntu_dependencies.sh
@@ -87,7 +87,7 @@ pip3 install \
   tk-tools \
   junitparser
 
-env LC_ALL=C.UTF-8 LANG=C.UTF-8 pip3 install ismrmrd==1.9.3
+env LC_ALL=C.UTF-8 LANG=C.UTF-8 pip3 install ismrmrd==1.9.5
 
 pip3 install git+https://github.com/gadgetron/gadgetron-python.git
 

--- a/docker/install_ubuntu_dependencies.sh
+++ b/docker/install_ubuntu_dependencies.sh
@@ -87,7 +87,7 @@ pip3 install \
   tk-tools \
   junitparser
 
-env LC_ALL=C.UTF-8 LANG=C.UTF-8 pip3 install git+https://github.com/ismrmrd/ismrmrd-python.git
+env LC_ALL=C.UTF-8 LANG=C.UTF-8 pip3 install ismrmrd==1.9.3
 
 pip3 install git+https://github.com/gadgetron/gadgetron-python.git
 


### PR DESCRIPTION
This PR pins the version of (Python) `ismrmrd` to `1.9.5` since a recent problem in xsdata is causing issues. Version `1.9.5` of python-ismrmrd fixes the problem and pins the xsdata version.