### PR TITLE
Setting correct default base image for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/gadgetron/gadgetron/gadgetron_ubuntu_2004_cuda11_cudnn8_base
+ARG BASE_IMAGE=ghcr.io/gadgetron/gadgetron/gadgetron_ubuntu_dev_cuda:latest
 FROM ${BASE_IMAGE}
 
 # Options for setup script


### PR DESCRIPTION
This is a leftover cleanup of the default image for the devcontainer. 