### PR TITLE
remove explicit include_directories of HDF5_INCLUDE_DIR

### DIFF
--- a/apps/clients/gadgetron_ismrmrd_client/CMakeLists.txt
+++ b/apps/clients/gadgetron_ismrmrd_client/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 
 
 add_executable(gadgetron_ismrmrd_client gadgetron_ismrmrd_client.cpp)
-include_directories(${HDF5_INCLUDE_DIR})
 target_link_libraries(gadgetron_ismrmrd_client ISMRMRD::ISMRMRD Boost::program_options gadgetron_mricore )
 
 if (ZFP_FOUND)

--- a/gadgets/mri_core/CMakeLists.txt
+++ b/gadgets/mri_core/CMakeLists.txt
@@ -4,8 +4,6 @@ endif ()
 
 find_package(ZFP)
 
-include_directories(${HDF5_INCLUDE_DIR})
-
 if(MSVC)
   set_source_files_properties(CompressedFloatBufferAvx2.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX2")
 else()


### PR DESCRIPTION
The name of the variable is wrong (should be `HDF5_INCLUDE_DIRS`) and in any case it is obsolete as we use the `ISMRMRD` target now.

Fixes #1042 