### PR TITLE
Addressing issue with race condition when MKL tries to load memkind

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: gadgetron
 channels:
   - conda-forge
   - defaults
+  - intel
 dependencies:
   - armadillo=9.900.5             # dev
   - boost=1.76.0
@@ -23,6 +24,7 @@ dependencies:
   - libxslt=1.1.33                # dev
   - make=4.3                      # dev
   - matplotlib=3.4.3              # dev
+  - memkind=1.10.1
   - mkl=2022.0.1
   - mkl-include=2022.0.1          # dev
   - ninja=1.10.2                  # dev

--- a/environment.yml
+++ b/environment.yml
@@ -23,12 +23,11 @@ dependencies:
   - libxslt=1.1.33                # dev
   - make=4.3                      # dev
   - matplotlib=3.4.3              # dev
-  - mkl=2021.4.0
-  - mkl-include=2021.4.0          # dev
-  - mkl-service=2.4.0
+  - mkl=2022.0.1
+  - mkl-include=2022.0.1          # dev
   - ninja=1.10.2                  # dev
   - nlohmann_json=3.10.4          # dev
-  - numpy=1.21.2
+  - numpy=1.22.1
   - pip=21.2.4
   - pugixml=1.11.4                # dev
   - pyfftw=0.12.0


### PR DESCRIPTION
The issue raised in #1045 

Based on description by @dchansen, there could be a race condition when both Gadgetron and external process (e.g. Python) tries to load memkind (which it doesn't find in current images). 

This PR adds memkind and also updates MKL to 2022.0.1.

(sort of) fixes #1045 