### PR TITLE
Update to CUDA 11.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: gadgetron
 channels:
   - conda-forge
   - defaults
+  - intel
 dependencies:
   - armadillo=9.900.5             # dev
   - boost=1.76.0
@@ -23,6 +24,7 @@ dependencies:
   - libxslt=1.1.33                # dev
   - make=4.3                      # dev
   - matplotlib=3.4.3              # dev
+  - memkind=1.10.1
   - mkl=2022.0.1
   - mkl-include=2022.0.1          # dev
   - ninja=1.10.2                  # dev

--- a/environment.yml
+++ b/environment.yml
@@ -23,12 +23,11 @@ dependencies:
   - libxslt=1.1.33                # dev
   - make=4.3                      # dev
   - matplotlib=3.4.3              # dev
-  - mkl=2021.4.0
-  - mkl-include=2021.4.0          # dev
-  - mkl-service=2.4.0
+  - mkl=2022.0.1
+  - mkl-include=2022.0.1          # dev
   - ninja=1.10.2                  # dev
   - nlohmann_json=3.10.4          # dev
-  - numpy=1.21.2
+  - numpy=1.22.1
   - pip=21.2.4
   - pugixml=1.11.4                # dev
   - pyfftw=0.12.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: gadgetron
 channels:
+  - nvidia/label/cuda-11.6.0
   - conda-forge
   - defaults
   - intel
@@ -7,8 +8,10 @@ dependencies:
   - armadillo=9.900.5             # dev
   - boost=1.76.0
   - cmake=3.21.3                  # dev
-  - cudatoolkit=11.2.2            # cuda
-  - cudatoolkit-dev=11.2.2        # cuda, dev
+  - cuda-libraries-dev            # cuda, dev
+  - cuda-libraries                # cuda
+  - cuda-runtime                  # cuda
+  - cuda-nvcc                     # cuda, dev
   - fftw=3.3.9
   - gcc_linux-64=9.4.0            # dev
   - gdb=11.1                      # dev

--- a/toolboxes/registration/optical_flow/gpu/cuResampleOperator.cu
+++ b/toolboxes/registration/optical_flow/gpu/cuResampleOperator.cu
@@ -7,8 +7,6 @@
 #include <thrust/binary_search.h>
 #include <thrust/iterator/counting_iterator.h>
 
-using namespace thrust;
-
 namespace Gadgetron{
 
   template<class T, unsigned int D> void 
@@ -33,22 +31,22 @@ namespace Gadgetron{
       _dims_disp.pop_back();
     }
   
-    device_vector<REAL> displacements
-      ( device_pointer_cast<REAL>(this->offsets_->get_data_ptr()), 
-        device_pointer_cast<REAL>(this->offsets_->get_data_ptr()+num_elements_disp) );
+    thrust::device_vector<REAL> displacements
+      ( thrust::device_pointer_cast<REAL>(this->offsets_->get_data_ptr()), 
+        thrust::device_pointer_cast<REAL>(this->offsets_->get_data_ptr()+num_elements_disp) );
   
     // Make sort keys/values array from the deformation field
     //
 
     unsigned int num_elements_sort = num_elements_disp/D;
   
-    this->lower_bounds_ = device_vector<unsigned int>(num_elements_sort);
-    this->upper_bounds_ = device_vector<unsigned int>(num_elements_sort);
+    this->lower_bounds_ = thrust::device_vector<unsigned int>(num_elements_sort);
+    this->upper_bounds_ = thrust::device_vector<unsigned int>(num_elements_sort);
   
-    this->indices_ = device_vector<unsigned int>(get_num_neighbors()*num_elements_sort);
-    this->weights_ = device_vector<REAL>(get_num_neighbors()*num_elements_sort);
+    this->indices_ = thrust::device_vector<unsigned int>(get_num_neighbors()*num_elements_sort);
+    this->weights_ = thrust::device_vector<REAL>(get_num_neighbors()*num_elements_sort);
 
-    device_vector<unsigned int> sort_keys = device_vector<unsigned int>
+    thrust::device_vector<unsigned int> sort_keys = thrust::device_vector<unsigned int>
       (get_num_neighbors()*num_elements_sort);
   
     // Fill arrays
@@ -59,23 +57,23 @@ namespace Gadgetron{
     // Make copy of sort_keys before the sort modifies it
     //
 
-    device_vector<unsigned int> sort_keys_copy(sort_keys);
+    thrust::device_vector<unsigned int> sort_keys_copy(sort_keys);
   
     // Sort (twice since we have two value arrays)
     //
 
-    sort_by_key(sort_keys.begin(), sort_keys.end(), this->indices_.begin() );
-    sort_by_key(sort_keys_copy.begin(), sort_keys_copy.end(), this->weights_.begin() );
+    thrust::sort_by_key(sort_keys.begin(), sort_keys.end(), this->indices_.begin() );
+    thrust::sort_by_key(sort_keys_copy.begin(), sort_keys_copy.end(), this->weights_.begin() );
   
     // Find start/end indices (buckets) in the two values arrays
     //
   
-    counting_iterator<unsigned int> search_begin(0);
+    thrust::counting_iterator<unsigned int> search_begin(0);
     
-    lower_bound( sort_keys.begin(), sort_keys.end(), 
+    thrust::lower_bound( sort_keys.begin(), sort_keys.end(), 
 		 search_begin, search_begin + num_elements_sort, this->lower_bounds_.begin() );
   
-    upper_bound( sort_keys.begin(), sort_keys.end(), 
+    thrust::upper_bound( sort_keys.begin(), sort_keys.end(), 
 		 search_begin, search_begin + num_elements_sort, this->upper_bounds_.begin() );
     
     this->preprocessed_ = true;


### PR DESCRIPTION
This PR updates to CUDA 11.6 and switches to the nvidia channels for CUDA. There is a small workaround for the thrust namespace in one .cu file. This should build on GPU and non-GPU machines.
