### PR TITLE
Harden storage server process management in integration tests.

### DIFF
--- a/test/integration/run_gadgetron_test.py
+++ b/test/integration/run_gadgetron_test.py
@@ -113,36 +113,43 @@ def send_data_to_gadgetron(echo_handler, gadgetron, *, input, output, configurat
                    stderr=log)
 
 
-def wait_for_storage_server(port, retries=20):
+def wait_for_storage_server(port, proc, retries=20):
     for i in range(retries):
         try:
             urllib.request.urlopen(f"http://localhost:{port}/healthcheck")
             return
         except (urllib.error.URLError, urllib.error.HTTPError) as e:
-            if i == retries - 1:
+            if i == retries - 1 or proc.poll() is not None:
                 raise RuntimeError("Unable to get a successful response from storage server.") from e
             time.sleep(0.2)
 
 
 def start_storage_server(*, log, port, storage_folder):
-    print("Starting MRD Storage Server on port", port)
-
     storage_server_environment = environment.copy()
     storage_server_environment["MRD_STORAGE_SERVER_PORT"] = port
     storage_server_environment["MRD_STORAGE_SERVER_STORAGE_CONNECTION_STRING"] = storage_folder
     storage_server_environment["MRD_STORAGE_SERVER_DATABASE_CONNECTION_STRING"] = storage_folder + "/metadata.db"
     
-    proc = subprocess.Popen(["mrd-storage-server"],
-                            stdout=log,
-                            stderr=log,
-                            env=storage_server_environment)
-    
-    try:
-        wait_for_storage_server(port)
-        return proc
-    except:
-        proc.kill()
-        raise
+    retries = 5
+    for i in range(retries):
+        print("Starting MRD Storage Server on port", port)
+        proc = subprocess.Popen(["mrd-storage-server", "--require-parent-pid", str(os.getpid())],
+                                stdout=log,
+                                stderr=log,
+                                env=storage_server_environment)
+        
+        try:
+            wait_for_storage_server(port, proc)
+            return proc
+        except:
+            # If the process has exited, it might be because the 
+            # port was in use. This can be because the previous storage server
+            # instance was just killed. So we try again.
+            if proc.poll() is not None and i < retries:
+                time.sleep(1)
+            else:
+                proc.kill()
+                raise
 
 
 def start_gadgetron_instance(*, log, port, storage_address, env=environment):


### PR DESCRIPTION
Each integration test gets its own storage server process. Sometimes, when starting a new server immediately after tearing the old one down, the port can still appear to be in use.

I considered keeping the same storage server process alive for the entire test suite, but that would have required more extensive changes. Instead, we simply add some retries. 

Addresses #1079