### PR TITLE
AsymmetricEchoAdjustROGadget -> ChannelGadget

### DIFF
--- a/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
+++ b/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
@@ -76,7 +76,7 @@ namespace Gadgetron {
                     header.center_sample = header.number_of_samples / 2;
                 }
             }
-            out.push(Core::Acquisition{header, acq, traj});
+            out.push(Core::Acquisition{std::move(header), std::move(acq), std::move(traj)});
         }
     }
     GADGETRON_GADGET_EXPORT(AsymmetricEchoAdjustROGadget)

--- a/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
+++ b/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
@@ -76,7 +76,7 @@ namespace Gadgetron {
                     header.center_sample = header.number_of_samples / 2;
                 }
             }
-            out.push(Core::Acquisition{header, std::move(acq), std::move(traj)});
+            out.push(Core::Acquisition{header, acq, traj});
         }
     }
     GADGETRON_GADGET_EXPORT(AsymmetricEchoAdjustROGadget)

--- a/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
+++ b/gadgets/mri_core/AsymmetricEchoAdjustROGadget.cpp
@@ -1,147 +1,83 @@
 #include "AsymmetricEchoAdjustROGadget.h"
-#include "ismrmrd/xml.h"
 
-namespace Gadgetron
-{
-
-AsymmetricEchoAdjustROGadget::AsymmetricEchoAdjustROGadget() : maxRO_(0)
-{
-
-}
-
-int AsymmetricEchoAdjustROGadget::process_config(ACE_Message_Block* mb)
-{
-  ISMRMRD::IsmrmrdHeader h;
-  deserialize(mb->rd_ptr(),h);
-
-  maxRO_.resize(h.encoding.size() );
-
-  for (size_t e = 0; e < h.encoding.size(); e++)
-  {
-      ISMRMRD::EncodingSpace e_space = h.encoding[e].encodedSpace;
-      maxRO_[e] = e_space.matrixSize.x;
-      GDEBUG_STREAM("max RO for encoding space  " << e << " : " << maxRO_[e]);
-  }
-
-  return GADGET_OK;
-}
-
-int addPrePostZeros(size_t centre_column, size_t samples)
-{
-    // 1 : pre zeros
-    // 2 : post zeros
-    // 0 : no zeros
-    if ( 2*centre_column == samples )
-    {
+namespace {
+    int addPrePostZeros(size_t centre_column, size_t samples) {
+        // 1 : pre zeros
+        // 2 : post zeros
+        // 0 : no zeros
+        if (2 * centre_column == samples) {
+            return 0;
+        }
+        if (2 * centre_column < samples) {
+            return 1;
+        }
+        if (2 * centre_column > samples) {
+            return 2;
+        }
         return 0;
     }
+} // namespace
 
-    if ( 2*centre_column < samples )
-    {
-        return 1;
+namespace Gadgetron {
+    AsymmetricEchoAdjustROGadget::AsymmetricEchoAdjustROGadget(const Core::Context& context, const Core::GadgetProperties& props): Core::ChannelGadget<Core::Acquisition>(context, props) {
+        auto current_ismrmrd_header = (context.header);
+        maxRO_.resize(current_ismrmrd_header.encoding.size());
+        for (size_t e = 0; e < current_ismrmrd_header.encoding.size(); e++) {
+            ISMRMRD::EncodingSpace e_space = current_ismrmrd_header.encoding[e].encodedSpace;
+            maxRO_[e] = e_space.matrixSize.x;
+            GDEBUG_STREAM("max RO for encoding space  " << e << " : " << maxRO_[e]);
+        }
     }
-
-    if ( 2*centre_column > samples )
-    {
-        return 2;
-    }
-
-    return 0;
-}
-
-int AsymmetricEchoAdjustROGadget
-::process(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1,
-        GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2)
-{
-
-    bool is_noise = ISMRMRD::FlagBit(ISMRMRD::ISMRMRD_ACQ_IS_NOISE_MEASUREMENT).isSet(m1->getObjectPtr()->flags);
-    long long channels = (long long)m1->getObjectPtr()->active_channels;
-    size_t samples = m1->getObjectPtr()->number_of_samples;
-    size_t centre_column = m1->getObjectPtr()->center_sample;
-
-    if (!is_noise) 
-    {
-        unsigned int encoding_ref = m1->getObjectPtr()->encoding_space_ref;
-
-        // adjust the center echo
-        int az = addPrePostZeros(centre_column, samples);
-
-        if (az != 0 && samples < maxRO_[encoding_ref])
-        {
-            GadgetContainerMessage< hoNDArray< std::complex<float> > >* m3 = new GadgetContainerMessage< hoNDArray< std::complex<float> > >();
-            if (!m3)
-            {
-                return GADGET_FAIL;
-            }
-
-            std::vector<size_t> data_out_dims = *m2->getObjectPtr()->get_dimensions();
-            data_out_dims[0] = maxRO_[encoding_ref];
-            try
-            {
-                m3->getObjectPtr()->create(data_out_dims);
-            }
-            catch(...)
-            {
-                GDEBUG("Unable to create new data array for downsampled data\n");
-                return GADGET_FAIL;
-            }
-            m3->getObjectPtr()->fill(0);
-
-            std::complex<float>* pM3 = m3->getObjectPtr()->get_data_ptr();
-            std::complex<float>* pM2 = m2->getObjectPtr()->get_data_ptr();
-
-            long long c;
-            size_t numOfBytes = sizeof( std::complex<float> )*samples;
-
-            if ( az == 1 ) // pre zeros
-            {
-                //#pragma omp parallel for default(none) private(c) shared(channels, pM3, pM2, samples, numOfBytes)
-                for ( c=0; c<channels; c++ )
-                {
-                    memcpy(pM3 + c*maxRO_[encoding_ref] + maxRO_[encoding_ref] - samples, pM2 + c*samples, numOfBytes);
+    void AsymmetricEchoAdjustROGadget::process(Core::InputChannel<Core::Acquisition>& in, Core::OutputChannel& out) {
+        for (auto [header, acq, traj] : in) {
+            bool is_noise = ISMRMRD::FlagBit(ISMRMRD::ISMRMRD_ACQ_IS_NOISE_MEASUREMENT).isSet(header.flags);
+            long long channels = (long long)header.active_channels;
+            size_t samples = header.number_of_samples;
+            size_t centre_column = header.center_sample;
+            if (!is_noise) {
+                unsigned int encoding_ref = header.encoding_space_ref;
+                // adjust the center echo
+                int az = addPrePostZeros(centre_column, samples);
+                if (az != 0 && samples < maxRO_[encoding_ref]) {
+                    std::vector<size_t> data_out_dims = *acq.get_dimensions();
+                    data_out_dims[0] = maxRO_[encoding_ref];
+                    hoNDArray<std::complex<float>> temp;
+                    try {
+                        temp = hoNDArray<std::complex<float>>(data_out_dims);
+                    } catch (...) {
+                        GDEBUG("Unable to create new data array for downsampled data\n");
+                    }
+                    temp.fill(0);
+                    std::complex<float>* pM3 = temp.get_data_ptr();
+                    std::complex<float>* pM2 = acq.get_data_ptr();
+                    long long c;
+                    size_t numOfBytes = sizeof(std::complex<float>) * samples;
+                    if (az == 1) // pre zeros
+                    {
+                        //#pragma omp parallel for default(none) private(c) shared(channels, pM3, pM2, samples, numOfBytes)
+                        for (c = 0; c < channels; c++) {
+                            memcpy(pM3 + c * maxRO_[encoding_ref] + maxRO_[encoding_ref] - samples, pM2 + c * samples,
+                                numOfBytes);
+                        }
+                        header.discard_pre = maxRO_[encoding_ref] - samples;
+                        header.discard_post = 0;
+                    }
+                    if (az == 2) // post zeros
+                    {
+                        //#pragma omp parallel for default(none) private(c) shared(channels, pM3, pM2, samples, numOfBytes)
+                        for (c = 0; c < channels; c++) {
+                            memcpy(pM3 + c * maxRO_[encoding_ref], pM2 + c * samples, numOfBytes);
+                        }
+                        header.discard_pre = 0;
+                        header.discard_post = maxRO_[encoding_ref] - samples;
+                    }
+                    acq = temp;
+                    header.number_of_samples = (uint16_t)data_out_dims[0];
+                    header.center_sample = header.number_of_samples / 2;
                 }
-
-                m1->getObjectPtr()->discard_pre = maxRO_[encoding_ref] - samples;
-                m1->getObjectPtr()->discard_post = 0;
             }
-
-            if ( az == 2 ) // post zeros
-            {
-                //#pragma omp parallel for default(none) private(c) shared(channels, pM3, pM2, samples, numOfBytes)
-                for ( c=0; c<channels; c++ )
-                {
-                    memcpy(pM3 + c*maxRO_[encoding_ref], pM2 + c*samples, numOfBytes);
-                }
-
-                m1->getObjectPtr()->discard_pre = 0;
-                m1->getObjectPtr()->discard_post = maxRO_[encoding_ref] - samples;
-            }
-
-            m2->release(); //We are done with this data
-
-            m1->cont(m3);
-            m1->getObjectPtr()->number_of_samples = (uint16_t)data_out_dims[0];
-            m1->getObjectPtr()->center_sample = m1->getObjectPtr()->number_of_samples / 2;
-        }
-
-        if (this->next()->putq(m1) == -1) 
-        {
-	  GERROR("NoiseAdjustGadget::process, passing data on to next gadget");
-	  return -1;
+            out.push(Core::Acquisition{header, std::move(acq), std::move(traj)});
         }
     }
-    else
-    {
-        if (this->next()->putq(m1) == -1) 
-        {
-	  GERROR("NoiseAdjustGadget::process, passing data on to next gadget");
-	  return -1;
-        }
-    }
-
-    return GADGET_OK;
-}
-
-GADGET_FACTORY_DECLARE(AsymmetricEchoAdjustROGadget)
-
-}
+    GADGETRON_GADGET_EXPORT(AsymmetricEchoAdjustROGadget)
+} // namespace Gadgetron

--- a/gadgets/mri_core/AsymmetricEchoAdjustROGadget.h
+++ b/gadgets/mri_core/AsymmetricEchoAdjustROGadget.h
@@ -1,32 +1,27 @@
+/**
+    \brief  Re-aligns the readout data with the center of the echo at the center of the incoming array (if not a noise scan and partial fourier along readout is detected)
+    \author Original: Hui Xue
+    \author ChannelGadget Conversion: Andrew Dupuis
+    \test   Tested by: gpu_grappa_simple.cfg, cpu_grappa_simple.cfg, generic_cartesian_cine_denoise.cfg, and others 
+*/
 
 #pragma once
 
 #include "Gadget.h"
 #include "hoNDArray.h"
-#include "ismrmrd/ismrmrd.h"
-#include "gadgetron_mricore_export.h"
+#include "GadgetMRIHeaders.h"
+#include "Node.h"
+#include "Types.h"
 
-namespace Gadgetron
-{
-
-/// for incoming readout
-/// if not the noise scan and the partial fourier along readout is detected
-/// the readout data will be realigned with center of echo at the centre of incoming 1D array
-class EXPORTGADGETSMRICORE AsymmetricEchoAdjustROGadget : public Gadgetron::Gadget2<ISMRMRD::AcquisitionHeader, hoNDArray< std::complex<float> > >
-{
-public:
-
-    GADGET_DECLARE(AsymmetricEchoAdjustROGadget);
-
-    AsymmetricEchoAdjustROGadget();
-
-protected:
-
-    virtual int process_config(ACE_Message_Block* mb);
-    virtual int process(Gadgetron::GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1,
-        Gadgetron::GadgetContainerMessage< Gadgetron::hoNDArray< std::complex<float> > >* m2);
-
-    std::vector<unsigned int> maxRO_;
-};
-
+namespace Gadgetron{
+  class AsymmetricEchoAdjustROGadget : public Core::ChannelGadget<Core::Acquisition> 
+    {
+      public:
+        using Core::ChannelGadget<Core::Acquisition>::ChannelGadget;
+        AsymmetricEchoAdjustROGadget(const Core::Context& context, const Core::GadgetProperties& props);
+        ~AsymmetricEchoAdjustROGadget() override = default;
+        void process(Core::InputChannel<Core::Acquisition>& input, Core::OutputChannel& output) override;
+      protected:
+        std::vector<unsigned int> maxRO_;
+    };
 }


### PR DESCRIPTION
Continuing #1087, this PR updates AsymmetricEchoAdjustROGadget to a ChannelGadget, leaving the existing operational logic the same as much as possible. The only major change is that local method addPrePostZeros has been moved out of the Gadgetron namespace into the unnamed namespace. 

The new ChannelGadget accepts Core::Acquisition and outputs Core::Acquisition. 

One question: since usage in the existing codebase varies, should the output function be:
` out.push(Core::Acquisition{header, acq, traj});`
or 
` out.push(Core::Acquisition{std::move(header), std::move(acq), std::move(traj)});`