### PR TITLE
Patches to address deprecation warnings (--> errors) when building with Clang

### DIFF
--- a/gadgets/T1/T1MocoGadget.cpp
+++ b/gadgets/T1/T1MocoGadget.cpp
@@ -332,7 +332,7 @@ class T1MocoGadget : public Core::ChannelGadget<IsmrmrdImageArray> {
         const hoNDArray<float> reference_frame = abs_data(slice, slice, arg_max_TI);
 
         const auto valid_transforms =
-            view::iota(size_t(0), abs_data.get_size(2)) |
+            views::iota(size_t(0), abs_data.get_size(2)) |
             views::filter([&arg_max_TI](auto index) { return index != arg_max_TI; }) | views::filter([&](auto index) {
                 return jensen_shannon_divergence(abs_data(slice, slice, index), reference_frame) < 0.2;
             }) |
@@ -345,7 +345,7 @@ class T1MocoGadget : public Core::ChannelGadget<IsmrmrdImageArray> {
             vfields[valid_transforms[i]] =
                 T1::register_groups_CMR(abs_data(slice, slice, valid_transforms[i]), reference_frame);
         }
-        auto missing_indices = view::iota(size_t(0), abs_data.get_size(2)) | view::filter([&](auto index) {
+        auto missing_indices = views::iota(size_t(0), abs_data.get_size(2)) | views::filter([&](auto index) {
                                    return !binary_search(valid_transforms, index) && (index != arg_max_TI);
                                });
 

--- a/test/cmr_analytical_strain_test.cpp
+++ b/test/cmr_analytical_strain_test.cpp
@@ -49,7 +49,7 @@ protected:
 
 typedef Types<float> realImplementations;
 
-TYPED_TEST_CASE(cmr_analytical_strain_test, realImplementations);
+TYPED_TEST_SUITE(cmr_analytical_strain_test, realImplementations);
 
 TYPED_TEST(cmr_analytical_strain_test, QuadarticStrain)
 {

--- a/test/cmr_mapping_test.cpp
+++ b/test/cmr_mapping_test.cpp
@@ -49,7 +49,7 @@ class cmr_mapping_test : public ::testing::Test
 
 typedef Types<float> realImplementations;
 
-TYPED_TEST_CASE(cmr_mapping_test, realImplementations);
+TYPED_TEST_SUITE(cmr_mapping_test, realImplementations);
 
 TYPED_TEST(cmr_mapping_test, T2Mapping)
 {

--- a/test/cmr_strain_test.cpp
+++ b/test/cmr_strain_test.cpp
@@ -49,7 +49,7 @@ protected:
 
 typedef Types<float> realImplementations;
 
-TYPED_TEST_CASE(cmr_strain_test, realImplementations);
+TYPED_TEST_SUITE(cmr_strain_test, realImplementations);
 
 TYPED_TEST(cmr_strain_test, Cine)
 {

--- a/test/cmr_thickening_test.cpp
+++ b/test/cmr_thickening_test.cpp
@@ -49,7 +49,7 @@ protected:
 
 typedef Types<float> realImplementations;
 
-TYPED_TEST_CASE(cmr_thickening_test, realImplementations);
+TYPED_TEST_SUITE(cmr_thickening_test, realImplementations);
 
 TYPED_TEST(cmr_thickening_test, 229201050_229201055_362_20190718_retro_cine)
 {

--- a/test/cuNDArray_Vector_td_test.cpp
+++ b/test/cuNDArray_Vector_td_test.cpp
@@ -31,7 +31,7 @@ template <typename T> class cuNDArray_vector_td_Test : public ::testing::Test {
 //typedef Types<float,double,float_complext,double_complext> Implementations;
 typedef Types<float> Implementations;
 
-TYPED_TEST_CASE(cuNDArray_vector_td_Test, Implementations);
+TYPED_TEST_SUITE(cuNDArray_vector_td_Test, Implementations);
 
 TYPED_TEST(cuNDArray_vector_td_Test,absTest){
 	this->cuData.fill(vector_td<TypeParam,3>(-2));

--- a/test/cuNDArray_blas_test.cpp
+++ b/test/cuNDArray_blas_test.cpp
@@ -23,7 +23,7 @@ protected:
 
 typedef Types<float, double> realImplementations;
 
-TYPED_TEST_CASE(cuNDArray_blas_Real, realImplementations);
+TYPED_TEST_SUITE(cuNDArray_blas_Real, realImplementations);
 
 TYPED_TEST(cuNDArray_blas_Real,dotTest){
   fill(&this->Array,TypeParam(1));
@@ -90,7 +90,7 @@ protected:
 
 typedef Types</*std::complex<float>, std::complex<double>,*/ float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(cuNDArray_blas_Cplx, cplxImplementations);
+TYPED_TEST_SUITE(cuNDArray_blas_Cplx, cplxImplementations);
 
 TYPED_TEST(cuNDArray_blas_Cplx,dotTest){
   fill(&this->Array,TypeParam(1,1));

--- a/test/cuNDArray_elemwise_test.cpp
+++ b/test/cuNDArray_elemwise_test.cpp
@@ -76,7 +76,7 @@ protected:
 typedef Types<float, double> realImplementations;
 typedef Types</*std::complex<float>, std::complex<double>,*/ float_complext> cplxImplementations;
 
-TYPED_TEST_CASE(cuNDArray_elemwise_TestReal, realImplementations);
+TYPED_TEST_SUITE(cuNDArray_elemwise_TestReal, realImplementations);
 
 TYPED_TEST(cuNDArray_elemwise_TestReal,fillTest){
   fill(&this->Array,TypeParam(1.1));
@@ -226,7 +226,7 @@ TYPED_TEST(cuNDArray_elemwise_TestReal,conjTest){
   EXPECT_FLOAT_EQ(TypeParam(1.2),real(&this->Array)->at(125));
 }
 
-TYPED_TEST_CASE(cuNDArray_elemwise_TestCplx, cplxImplementations);
+TYPED_TEST_SUITE(cuNDArray_elemwise_TestCplx, cplxImplementations);
 
 TYPED_TEST(cuNDArray_elemwise_TestCplx,fillTest){
   fill(&this->Array,TypeParam(1.1,2.2));
@@ -356,7 +356,7 @@ TYPED_TEST(cuNDArray_elemwise_TestCplx,shrink1Test){
   EXPECT_FLOAT_EQ(0.0,imag(&this->Array)->at(23125));
 }
 
-TYPED_TEST_CASE(cuNDArray_elemwise_TestCplx4, cplxImplementations);
+TYPED_TEST_SUITE(cuNDArray_elemwise_TestCplx4, cplxImplementations);
 
 TYPED_TEST(cuNDArray_elemwise_TestCplx4,shrinkdTest){
   fill(&this->Array,TypeParam(1.2,1.4));
@@ -369,7 +369,7 @@ TYPED_TEST(cuNDArray_elemwise_TestCplx4,shrinkdTest){
   EXPECT_FLOAT_EQ(0.0,imag(&this->Array)->at(23125));
 }
 
-TYPED_TEST_CASE(cuNDArray_elemwise_TestCplx3, cplxImplementations);
+TYPED_TEST_SUITE(cuNDArray_elemwise_TestCplx3, cplxImplementations);
 
 TYPED_TEST(cuNDArray_elemwise_TestCplx3,realToCplxTest){
   fill(&this->Array,TypeParam(3.4,4.2));

--- a/test/cuNDArray_operators_test.cpp
+++ b/test/cuNDArray_operators_test.cpp
@@ -38,7 +38,7 @@ protected:
 typedef Types<float, double> realImplementations;
 typedef Types</*std::complex<float>, std::complex<double>,*/ float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(cuNDArray_operators_TestReal, realImplementations);
+TYPED_TEST_SUITE(cuNDArray_operators_TestReal, realImplementations);
 
 TYPED_TEST(cuNDArray_operators_TestReal,equalsAddTest1){
   TypeParam v1 = TypeParam(46865.35435);
@@ -116,7 +116,7 @@ TYPED_TEST(cuNDArray_operators_TestReal,equalsDivideTest2){
   EXPECT_FLOAT_EQ(v1/v2,this->Array[idx]);
 }
 
-TYPED_TEST_CASE(cuNDArray_operators_TestCplx, cplxImplementations);
+TYPED_TEST_SUITE(cuNDArray_operators_TestCplx, cplxImplementations);
 
 TYPED_TEST(cuNDArray_operators_TestCplx,equalsAddTest1){
   TypeParam v1 = TypeParam(46865.35435, 534544.534523);

--- a/test/cuNDArray_test.cpp
+++ b/test/cuNDArray_test.cpp
@@ -32,7 +32,7 @@ template <typename T> class cuNDArray_Test : public ::testing::Test {
 
 typedef Types<float,double,float_complext,double_complext> Implementations;
 
-TYPED_TEST_CASE(cuNDArray_Test, Implementations);
+TYPED_TEST_SUITE(cuNDArray_Test, Implementations);
 
 TYPED_TEST(cuNDArray_Test,fillTest){
 	this->Array.fill(TypeParam(1));

--- a/test/cuNDArray_utils_test.cpp
+++ b/test/cuNDArray_utils_test.cpp
@@ -41,7 +41,7 @@ protected:
 typedef Types<float, double> realImplementations;
 typedef Types</*std::complex<float>, std::complex<double>,*/ float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(cuNDArray_utils_TestReal, realImplementations);
+TYPED_TEST_SUITE(cuNDArray_utils_TestReal, realImplementations);
 
 TYPED_TEST(cuNDArray_utils_TestReal,permuteTest){
 
@@ -111,7 +111,7 @@ TYPED_TEST(cuNDArray_utils_TestReal,meanTest){
   EXPECT_NEAR(v1,mean(&this->Array), 0.001);
 
 }
-TYPED_TEST_CASE(cuNDArray_utils_TestCplx, cplxImplementations);
+TYPED_TEST_SUITE(cuNDArray_utils_TestCplx, cplxImplementations);
 
 
 

--- a/test/cuNDFFT_test.cpp
+++ b/test/cuNDFFT_test.cpp
@@ -30,7 +30,7 @@ protected:
 
 };
 typedef Types<float, double> realImplementations;
-TYPED_TEST_CASE(cuNDFFT_test, realImplementations);
+TYPED_TEST_SUITE(cuNDFFT_test, realImplementations);
 
 TYPED_TEST(cuNDFFT_test,fftNrm2Test){
 	cuNDFFT<TypeParam>::instance()->fft(&this->Array);

--- a/test/cuSDC_test.cpp
+++ b/test/cuSDC_test.cpp
@@ -50,7 +50,7 @@ class cuSDC_test : public ::testing::Test
 
 typedef Types<float> realImplementations;
 
-TYPED_TEST_CASE(cuSDC_test, realImplementations);
+TYPED_TEST_SUITE(cuSDC_test, realImplementations);
 
 TYPED_TEST(cuSDC_test, randomTestOne)
 {

--- a/test/curveFitting_test.cpp
+++ b/test/curveFitting_test.cpp
@@ -29,7 +29,7 @@ protected:
 };
 
 typedef Types<float> realImplementations;
-TYPED_TEST_CASE(curveFitting_test, realImplementations);
+TYPED_TEST_SUITE(curveFitting_test, realImplementations);
 
 TYPED_TEST(curveFitting_test, T2SE)
 {

--- a/test/hoCuGTBLAS_test.cpp
+++ b/test/hoCuGTBLAS_test.cpp
@@ -27,7 +27,7 @@ template <typename T> class hoCuGTBLAS_Test : public ::testing::Test {
 
 typedef Types<float,double,float_complext,double_complext> Implementations;
 
-TYPED_TEST_CASE(hoCuGTBLAS_Test, Implementations);
+TYPED_TEST_SUITE(hoCuGTBLAS_Test, Implementations);
 
 
 TYPED_TEST(hoCuGTBLAS_Test,dotTest){

--- a/test/hoCuNDArray_elemwise_test.cpp
+++ b/test/hoCuNDArray_elemwise_test.cpp
@@ -21,7 +21,7 @@ protected:
 
 typedef Types<float, double> realImplementations;
 
-TYPED_TEST_CASE(hoCuNDArray_blas_Real, realImplementations);
+TYPED_TEST_SUITE(hoCuNDArray_blas_Real, realImplementations);
 
 TYPED_TEST(hoCuNDArray_blas_Real,dotTest){
   fill(&this->Array,TypeParam(1));
@@ -84,7 +84,7 @@ protected:
 
 typedef Types<float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(hoCuNDArray_blas_Cplx, cplxImplementations);
+TYPED_TEST_SUITE(hoCuNDArray_blas_Cplx, cplxImplementations);
 
 TYPED_TEST(hoCuNDArray_blas_Cplx,dotTest){
   fill(&this->Array,TypeParam(1,1));

--- a/test/hoNDArray_blas_test.cpp
+++ b/test/hoNDArray_blas_test.cpp
@@ -23,7 +23,7 @@ protected:
 
 typedef Types<float, double> realImplementations;
 
-TYPED_TEST_CASE(hoNDArray_blas_Real, realImplementations);
+TYPED_TEST_SUITE(hoNDArray_blas_Real, realImplementations);
 
 TYPED_TEST(hoNDArray_blas_Real,dotTest){
   fill(&this->Array,TypeParam(1));
@@ -92,7 +92,7 @@ protected:
 
 typedef Types<std::complex<float>, std::complex<double>, float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(hoNDArray_blas_Cplx, cplxImplementations);
+TYPED_TEST_SUITE(hoNDArray_blas_Cplx, cplxImplementations);
 
 TYPED_TEST(hoNDArray_blas_Cplx,dotTest){
   fill(&this->Array,TypeParam(1,1));

--- a/test/hoNDArray_elemwise_test.cpp
+++ b/test/hoNDArray_elemwise_test.cpp
@@ -78,7 +78,7 @@ typedef Types<std::complex<float>, std::complex<double>, float_complext, double_
 typedef Types<std::complex<float>, std::complex<double> > stdCplxImplementations;
 typedef Types<float_complext, double_complext> cplxtImplementations;
 
-TYPED_TEST_CASE(hoNDArray_elemwise_TestReal, realImplementations);
+TYPED_TEST_SUITE(hoNDArray_elemwise_TestReal, realImplementations);
 
 TYPED_TEST(hoNDArray_elemwise_TestReal,fillTest){
   fill(&this->Array,TypeParam(1.1));
@@ -223,7 +223,7 @@ TYPED_TEST(hoNDArray_elemwise_TestReal,conjTest){
   EXPECT_FLOAT_EQ(TypeParam(0.0),imag(&this->Array)->at(125));
 }
 
-TYPED_TEST_CASE(hoNDArray_elemwise_TestCplx, cplxImplementations);
+TYPED_TEST_SUITE(hoNDArray_elemwise_TestCplx, cplxImplementations);
 
 TYPED_TEST(hoNDArray_elemwise_TestCplx,fillTest){
   fill(&this->Array,TypeParam(1.1,2.2));
@@ -363,7 +363,7 @@ TYPED_TEST(hoNDArray_elemwise_TestCplx,axpyTest){
 
 }
 
-TYPED_TEST_CASE(hoNDArray_elemwise_TestCplx4, cplxImplementations);
+TYPED_TEST_SUITE(hoNDArray_elemwise_TestCplx4, cplxImplementations);
 
 TYPED_TEST(hoNDArray_elemwise_TestCplx4,shrinkdTest){
   fill(&this->Array,TypeParam(1.2,1.4));
@@ -376,7 +376,7 @@ TYPED_TEST(hoNDArray_elemwise_TestCplx4,shrinkdTest){
   EXPECT_FLOAT_EQ(0.0,imag(&this->Array)->get_data_ptr()[23125]);
 }
 
-TYPED_TEST_CASE(hoNDArray_elemwise_TestCplx2, stdCplxImplementations);
+TYPED_TEST_SUITE(hoNDArray_elemwise_TestCplx2, stdCplxImplementations);
 
 TYPED_TEST(hoNDArray_elemwise_TestCplx2,realToCplxTest){
   fill(&this->Array,TypeParam(3.4,4.2));
@@ -394,7 +394,7 @@ EXPECT_FLOAT_EQ(11,real(this->Array[33425]));
 EXPECT_FLOAT_EQ(-3,imag(this->Array[33425]));
 }
 
-TYPED_TEST_CASE(hoNDArray_elemwise_TestCplx3, cplxtImplementations);
+TYPED_TEST_SUITE(hoNDArray_elemwise_TestCplx3, cplxtImplementations);
 
 TYPED_TEST(hoNDArray_elemwise_TestCplx3,realToCplxTest){
   fill(&this->Array,TypeParam(3.4,4.2));
@@ -435,7 +435,7 @@ protected:
 typedef Types<float, double> realImplementations;
 typedef Types<std::complex<float>, std::complex<double>, float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(hoNDArray_operators_TestReal, realImplementations);
+TYPED_TEST_SUITE(hoNDArray_operators_TestReal, realImplementations);
 
 TYPED_TEST(hoNDArray_operators_TestReal,equalsAddTest1){
   TypeParam v1 = TypeParam(46865.35435);
@@ -515,7 +515,7 @@ TYPED_TEST(hoNDArray_operators_TestReal,equalsDivideTest2){
   EXPECT_FLOAT_EQ(v1/v2,this->Array.get_data_ptr()[idx]);
 }
 
-TYPED_TEST_CASE(hoNDArray_operators_TestCplx, cplxImplementations);
+TYPED_TEST_SUITE(hoNDArray_operators_TestCplx, cplxImplementations);
 
 TYPED_TEST(hoNDArray_operators_TestCplx,equalsAddTest1){
   TypeParam v1 = TypeParam(46865.35435, 534544.534523);

--- a/test/hoNDArray_linalg_test.cpp
+++ b/test/hoNDArray_linalg_test.cpp
@@ -25,7 +25,7 @@ protected:
 
 typedef Types<float, double> realImplementations;
 
-TYPED_TEST_CASE(hoNDArray_linalg_TestReal, realImplementations);
+TYPED_TEST_SUITE(hoNDArray_linalg_TestReal, realImplementations);
 
 TYPED_TEST(hoNDArray_linalg_TestReal, linFitTest)
 {

--- a/test/hoNDArray_operators_test.cpp
+++ b/test/hoNDArray_operators_test.cpp
@@ -43,7 +43,7 @@ protected:
 typedef Types<float, double> realImplementations;
 typedef Types<std::complex<float>, std::complex<double>, float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(hoNDArray_operators_TestReal, realImplementations);
+TYPED_TEST_SUITE(hoNDArray_operators_TestReal, realImplementations);
 
 TYPED_TEST(hoNDArray_operators_TestReal,equalsAddTest1){
   TypeParam v1 = TypeParam(46865.35435);
@@ -121,7 +121,7 @@ TYPED_TEST(hoNDArray_operators_TestReal,equalsDivideTest2){
   EXPECT_FLOAT_EQ(v1/v2,this->Array.get_data_ptr()[idx]);
 }
 
-TYPED_TEST_CASE(hoNDArray_operators_TestCplx, cplxImplementations);
+TYPED_TEST_SUITE(hoNDArray_operators_TestCplx, cplxImplementations);
 
 TYPED_TEST(hoNDArray_operators_TestCplx,equalsAddTest1){
   TypeParam v1 = TypeParam(46865.35435, 534544.534523);

--- a/test/hoNDArray_reductions_test.cpp
+++ b/test/hoNDArray_reductions_test.cpp
@@ -23,7 +23,7 @@ protected:
 };
 
 typedef Types<float, double> realImplementations;
-TYPED_TEST_CASE(hoNDArray_reductions_TestReal, realImplementations);
+TYPED_TEST_SUITE(hoNDArray_reductions_TestReal, realImplementations);
 
 TYPED_TEST(hoNDArray_reductions_TestReal, sortTest) {
     hoNDArray<TypeParam> x, r;

--- a/test/hoNDArray_utils_test.cpp
+++ b/test/hoNDArray_utils_test.cpp
@@ -37,7 +37,7 @@ protected:
 typedef Types<float, double> realImplementations;
 typedef Types</*std::complex<float>, std::complex<double>,*/ float_complext, double_complext> cplxImplementations;
 
-TYPED_TEST_CASE(hoNDArray_utils_TestReal, realImplementations);
+TYPED_TEST_SUITE(hoNDArray_utils_TestReal, realImplementations);
 
 TYPED_TEST(hoNDArray_utils_TestReal, fillTest)
 {
@@ -136,7 +136,7 @@ TYPED_TEST(hoNDArray_utils_TestReal,sumTest){
   EXPECT_FLOAT_EQ(19*v1,sum(this->Array,3)[idx]);
 }
 
-TYPED_TEST_CASE(hoNDArray_utils_TestCplx, cplxImplementations);
+TYPED_TEST_SUITE(hoNDArray_utils_TestCplx, cplxImplementations);
 
 TYPED_TEST(hoNDArray_utils_TestCplx,permuteTest){
 

--- a/test/hoNDFFT_test.cpp
+++ b/test/hoNDFFT_test.cpp
@@ -30,7 +30,7 @@ protected:
 
 };
 typedef Types<float, double> realImplementations;
-TYPED_TEST_CASE(hoNDFFT_test, realImplementations);
+TYPED_TEST_SUITE(hoNDFFT_test, realImplementations);
 
 TYPED_TEST(hoNDFFT_test,fftNrm2Test){
 	hoNDFFT<TypeParam>::instance()->fft(&this->Array);

--- a/test/hoNDWavelet_test.cpp
+++ b/test/hoNDWavelet_test.cpp
@@ -27,7 +27,7 @@ protected:
 };
 
 typedef Types<float, double> realImplementations;
-TYPED_TEST_CASE(hoNDWavelet_test, realImplementations);
+TYPED_TEST_SUITE(hoNDWavelet_test, realImplementations);
 
 TYPED_TEST(hoNDWavelet_test, hoNDHarrWaveletTest1D)
 {

--- a/test/hoNFFT_test.cpp
+++ b/test/hoNFFT_test.cpp
@@ -48,7 +48,7 @@ class hoNFFT_2D_NC2C_BACKWARDS : public ::testing::Test{
 
 typedef Types<float> realImplementations;
 
-TYPED_TEST_CASE(hoNFFT_2D_NC2C_BACKWARDS, realImplementations);
+TYPED_TEST_SUITE(hoNFFT_2D_NC2C_BACKWARDS, realImplementations);
 
 TYPED_TEST(hoNFFT_2D_NC2C_BACKWARDS, randomTestOne)
 {

--- a/test/hoSDC_test.cpp
+++ b/test/hoSDC_test.cpp
@@ -49,7 +49,7 @@ class hoSDC_test : public ::testing::Test
 
 typedef Types<float> realImplementations;
 
-TYPED_TEST_CASE(hoSDC_test, realImplementations);
+TYPED_TEST_SUITE(hoSDC_test, realImplementations);
 
 TYPED_TEST(hoSDC_test, randomTestOne)
 {

--- a/test/image_morphology_test.cpp
+++ b/test/image_morphology_test.cpp
@@ -19,7 +19,7 @@ protected:
 };
 
 typedef Types<float> realImplementations;
-TYPED_TEST_CASE(image_morphology_test, realImplementations);
+TYPED_TEST_SUITE(image_morphology_test, realImplementations);
 
 TYPED_TEST(image_morphology_test, bwlabel)
 {

--- a/test/pattern_recognition_test.cpp
+++ b/test/pattern_recognition_test.cpp
@@ -22,7 +22,7 @@ protected:
 };
 
 typedef Types<float> realImplementations;
-TYPED_TEST_CASE(pattern_recognition_test, realImplementations);
+TYPED_TEST_SUITE(pattern_recognition_test, realImplementations);
 
 TYPED_TEST(pattern_recognition_test, kmeans_test)
 {

--- a/test/vector_td_test.cpp
+++ b/test/vector_td_test.cpp
@@ -34,7 +34,7 @@ template <typename T> class vector_td_Test : public ::testing::Test {
 //typedef Types<float,double,float_complext,double_complext> Implementations;
 typedef Types<float> Implementations;
 
-TYPED_TEST_CASE(vector_td_Test, Implementations);
+TYPED_TEST_SUITE(vector_td_Test, Implementations);
 
 
 TYPED_TEST(vector_td_Test,absTest){

--- a/toolboxes/core/cpu/math/hoNDArray_reductions.cpp
+++ b/toolboxes/core/cpu/math/hoNDArray_reductions.cpp
@@ -484,14 +484,14 @@ namespace Gadgetron {
         const auto prob_p = normalized_histogram(dataset1);
         const auto prob_q = normalized_histogram(dataset2);
 
-        auto prob_m = view::zip_with([](auto val1, auto val2){return (val1+val2)/2;},prob_p, prob_q);
+        auto prob_m = views::zip_with([](auto val1, auto val2){return (val1+val2)/2;},prob_p, prob_q);
 
 
-        auto left = accumulate( view::zip_with([&rel_entr](const auto& d1,const auto& d2) -> float{
+        auto left = accumulate( views::zip_with([&rel_entr](const auto& d1,const auto& d2) -> float{
             return rel_entr(d1,d2);
         },prob_p,prob_m),0.0f);
 
-        auto right = accumulate( view::zip_with([&rel_entr](const auto& d1,const auto& d2){
+        auto right = accumulate( views::zip_with([&rel_entr](const auto& d1,const auto& d2){
             return rel_entr(d1,d2);
         },prob_q,prob_m),0.0f);
 

--- a/toolboxes/plplot/ut/plplot_test.cpp
+++ b/toolboxes/plplot/ut/plplot_test.cpp
@@ -69,7 +69,7 @@ typedef Types<std::complex<float>, std::complex<double>, float_complext, double_
 typedef Types<std::complex<float>, std::complex<double> > stdCplxImplementations;
 typedef Types<float_complext, double_complext> cplxtImplementations;
 
-TYPED_TEST_CASE(gt_plplot_Test, cpfloatImplementations);
+TYPED_TEST_SUITE(gt_plplot_Test, cpfloatImplementations);
 
 TYPED_TEST(gt_plplot_Test, plplot_noise_covariance_test)
 {


### PR DESCRIPTION
This should cleanly address function and macro deprecation picked up by Clang.