### PR TITLE
install IsmrmrdContextVariables.h

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -71,6 +71,7 @@ install(FILES
         variant.hpp
         MessageID.h
         Storage.h
+        IsmrmrdContextVariables.h
         Process.h
         DESTINATION ${GADGETRON_INSTALL_INCLUDE_PATH} COMPONENT main)
 


### PR DESCRIPTION
Hi forks,

The IsmrmrdContextVariables.h need be installed, or the out of tree gadget build will be failed.

The MWE is https://github.com/medlab/gadgetron-4-fun/tree/main/gadgetron-cpp-demo/imagepassthroughgadget . 

The file is needed by Gadget.h, as  Gadget.h > Context.h > Storage.h > IsmrmrdContextVariables.h

Tks,
Cong
