### PR TITLE
Addresses '-Werror,-Wfinal-dtor-non-final-class' error thrown by Clang

### DIFF
--- a/core/readers/ImageReader.cpp
+++ b/core/readers/ImageReader.cpp
@@ -7,15 +7,15 @@
 namespace {
     using namespace Gadgetron;
     template<class T> inline constexpr uint16_t ismrmrd_data_type(){ return 0;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<unsigned short>(){return ISMRMRD::ISMRMRD_USHORT;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<unsigned int>(){return ISMRMRD::ISMRMRD_UINT;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<int>(){return ISMRMRD::ISMRMRD_INT;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<float>(){return ISMRMRD::ISMRMRD_FLOAT;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<double>(){return ISMRMRD::ISMRMRD_DOUBLE;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<std::complex<float>>(){return ISMRMRD::ISMRMRD_CXFLOAT;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<std::complex<double>>(){return ISMRMRD::ISMRMRD_CXDOUBLE;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<complext<float>>(){return ISMRMRD::ISMRMRD_CXFLOAT;}
-    template<> inline constexpr uint16_t ismrmrd_data_type<complext<double>>(){return ISMRMRD::ISMRMRD_CXDOUBLE;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<unsigned short>(){return ISMRMRD::ISMRMRD_USHORT;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<unsigned int>(){return ISMRMRD::ISMRMRD_UINT;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<int>(){return ISMRMRD::ISMRMRD_INT;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<float>(){return ISMRMRD::ISMRMRD_FLOAT;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<double>(){return ISMRMRD::ISMRMRD_DOUBLE;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<std::complex<float>>(){return ISMRMRD::ISMRMRD_CXFLOAT;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<std::complex<double>>(){return ISMRMRD::ISMRMRD_CXDOUBLE;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<complext<float>>(){return ISMRMRD::ISMRMRD_CXFLOAT;}
+    // template<> inline constexpr uint16_t ismrmrd_data_type<complext<double>>(){return ISMRMRD::ISMRMRD_CXDOUBLE;}
 
 
     using image_datatypes = Core::variant<unsigned short, unsigned int, int, float, double, std::complex<float>,std::complex<double>>;

--- a/gadgets/mri_core/readers/GadgetIsmrmrdReader.h
+++ b/gadgets/mri_core/readers/GadgetIsmrmrdReader.h
@@ -17,13 +17,11 @@ namespace Gadgetron {
     /**
     Default implementation of GadgetMessageReader for IsmrmrdAcquisition messages
     */
-class EXPORTGADGETSMRICORE GadgetIsmrmrdAcquisitionMessageReader : public Core::Reader {
+class EXPORTGADGETSMRICORE GadgetIsmrmrdAcquisitionMessageReader final : public Core::Reader {
 
     public:
 
         Core::Message read(std::istream& stream) final;
-
-
         uint16_t slot() final;
         ~GadgetIsmrmrdAcquisitionMessageReader() final = default;
     };
@@ -33,7 +31,7 @@ class EXPORTGADGETSMRICORE GadgetIsmrmrdAcquisitionMessageReader : public Core::
 
 
 
-class EXPORTGADGETSMRICORE GadgetIsmrmrdWaveformMessageReader : public Core::Reader {
+class EXPORTGADGETSMRICORE GadgetIsmrmrdWaveformMessageReader final : public Core::Reader {
 
     public:
 


### PR DESCRIPTION
Clang has an issue with the class destructor being marked as 'final', but the class itself not being marked in the same way.

Removing the 'final' designation on the class destructor also removed this error.  However, the change as submitted in this PR seems more consistent with the original intent of the class being defined in the way it was.