### PR TITLE
Addresses '-Werror,-Wfinal-dtor-non-final-class' error with Clang build

### DIFF
--- a/gadgets/mri_core/readers/GadgetIsmrmrdReader.h
+++ b/gadgets/mri_core/readers/GadgetIsmrmrdReader.h
@@ -17,13 +17,11 @@ namespace Gadgetron {
     /**
     Default implementation of GadgetMessageReader for IsmrmrdAcquisition messages
     */
-class EXPORTGADGETSMRICORE GadgetIsmrmrdAcquisitionMessageReader : public Core::Reader {
+class EXPORTGADGETSMRICORE GadgetIsmrmrdAcquisitionMessageReader final : public Core::Reader {
 
     public:
 
         Core::Message read(std::istream& stream) final;
-
-
         uint16_t slot() final;
         ~GadgetIsmrmrdAcquisitionMessageReader() final = default;
     };
@@ -33,7 +31,7 @@ class EXPORTGADGETSMRICORE GadgetIsmrmrdAcquisitionMessageReader : public Core::
 
 
 
-class EXPORTGADGETSMRICORE GadgetIsmrmrdWaveformMessageReader : public Core::Reader {
+class EXPORTGADGETSMRICORE GadgetIsmrmrdWaveformMessageReader final : public Core::Reader {
 
     public:
 


### PR DESCRIPTION
Resubmitting this PR with **just** these changes.

Clang has an issue with the class destructor being marked as 'final', but the class itself not being marked in the same way.

Removing the 'final' designation on the class destructor also removed this error. However, the change as submitted in this PR seems more consistent with the original intent of the class being defined in the way it was.