### PR TITLE
More generic search, and addition of compiler directives for Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ else ()
     include(CheckCXXCompilerFlag)
     if (APPLE)
         if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-array-bounds -Wno-switch -Wno-dynamic-class-memaccess -Wno-undefined-var-template")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-array-bounds -Wno-switch -Wno-dynamic-class-memaccess -Wno-undefined-var-template -Wno-parentheses")
         endif ()
     endif ()
 


### PR DESCRIPTION
Adding a few compiler directives here when cmake finds Clang as the compiler.

In the comments for each commit are the error and the file with the code throwing that error.  Adding these details, to allow us to look at these warnings/errors more closely, and see if they warrant fixing.