### PR TITLE
Extend pipeline timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ pr:
 
 jobs:
 - job: BuildAndTest
+  timeoutInMinutes: 120
   displayName: "Build, Unit and Integration tests"
   strategy:
     matrix:


### PR DESCRIPTION
We have a problem that the CI builds often go beyond 60 minutes which is the default duration. This gives the pipeline plenty of time. 