### PR TITLE
AutoScaleGadget->PureGadget Conversion

### DIFF
--- a/gadgets/mri_core/AutoScaleGadget.cpp
+++ b/gadgets/mri_core/AutoScaleGadget.cpp
@@ -1,80 +1,64 @@
-/*
- * AutoScaleGadget.cpp
- *
- *  Created on: Dec 19, 2011
- *      Author: Michael S. Hansen
- */
-
 #include "AutoScaleGadget.h"
 
-namespace Gadgetron{
+using namespace Gadgetron;
+using namespace Gadgetron::Core;
 
-AutoScaleGadget::AutoScaleGadget()
-	: histogram_bins_(100)
-	, current_scale_(1.0)
-	, max_value_(2048)
-{
-}
+namespace {
+    template<class T>
+    Image<T> autoscale(Image<T> &image, float max_value, unsigned int histogram_bins) {
 
-AutoScaleGadget::~AutoScaleGadget() {
-	// TODO Auto-generated destructor stub
-}
+		auto &header = std::get<ISMRMRD::ImageHeader>(image);
+        auto &data = std::get<hoNDArray<T>>(image);
+		auto &meta = std::get<optional<ISMRMRD::MetaContainer>>(image);
+		
+		if (header.image_type == ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE) { //Only scale magnitude images for now
+			auto max = *std::max_element(data.begin(), data.end());
+			auto current_scale_ = 1.0;
+			auto histogram_ = std::vector<size_t>(histogram_bins);
 
-int AutoScaleGadget::process_config(ACE_Message_Block* mb) {
-        max_value_ = max_value.value();
-	return GADGET_OK;
-}
-
-
-int AutoScaleGadget::process(GadgetContainerMessage<ISMRMRD::ImageHeader> *m1, GadgetContainerMessage<hoNDArray<float> > *m2)
-{
-	if (m1->getObjectPtr()->image_type == ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE) { //Only scale magnitude images for now
-		float max = 0.0f;
-		float* d = m2->getObjectPtr()->get_data_ptr();
-		for (unsigned long int i = 0; i < m2->getObjectPtr()->get_number_of_elements(); i++) {
-			if (d[i] > max) max = d[i];
-		}
-
-		if (histogram_.size() != histogram_bins_) {
-			histogram_ = std::vector<size_t>(histogram_bins_);
-		}
-
-		for (size_t i = 0; i < histogram_bins_; i++) {
-			histogram_[i] = 0;
-		}
-
-		for (unsigned long int i = 0; i < m2->getObjectPtr()->get_number_of_elements(); i++) {
-			size_t bin = static_cast<size_t>(std::floor((d[i]/max)*histogram_bins_));
-			if (bin >= histogram_bins_) {
-				bin = histogram_bins_-1;
+			if (histogram_.size() != histogram_bins) {
+				histogram_ = std::vector<size_t>(histogram_bins);
 			}
-			histogram_[bin]++;
+
+			for (size_t i = 0; i < histogram_bins; i++) {
+				histogram_[i] = 0;
+			}
+
+			for (auto& d : data) {
+				size_t bin = static_cast<size_t>(std::floor((d/max)*histogram_bins));
+				if (bin >= histogram_bins) {
+					bin = histogram_bins-1;
+				}
+				histogram_[bin]++;
+			}
+			
+			//Find 99th percentile
+			long long cumsum = 0;
+			size_t counter = 0;
+			while (cumsum < (0.99*data.get_number_of_elements())) {
+				cumsum += (long long)(histogram_[counter++]);
+			}
+			max = (counter+1)*(max/histogram_bins);
+			GDEBUG("Max: %f\n",max);
+			current_scale_ = max_value/max;
+
+			for (auto& d : data){
+				d *= current_scale_;
+			}
 		}
+        return Image<T>(header,data,meta);
+    }
 
-		//Find 99th percentile
-		long long cumsum = 0;
-		size_t counter = 0;
-		while (cumsum < (0.99*m2->getObjectPtr()->get_number_of_elements())) {
-			cumsum += (long long)(histogram_[counter++]);
-		}
-		max = (counter+1)*(max/histogram_bins_);
-		GDEBUG("Max: %f\n",max);
-
-		current_scale_ = max_value_/max;
-
-		for (unsigned long int i = 0; i < m2->getObjectPtr()->get_number_of_elements(); i++) {
-			d[i] *= current_scale_;
-		}
-	}
-
-	if (this->next()->putq(m1) < 0) {
-		GDEBUG("Failed to pass on data to next Gadget\n");
-		return GADGET_FAIL;
-	}
-
-	return GADGET_OK;
+    template<class T>
+    Image<std::complex<T>> autoscale(Image<std::complex<T>> &image, float max_value, unsigned int histogram_bins) {
+        GERROR("Autoscaling image is not well defined for complex images.");
+		return image;
+    }
 }
 
-GADGET_FACTORY_DECLARE(AutoScaleGadget)
-
+namespace Gadgetron {
+    AnyImage AutoScaleGadget::process_function(AnyImage image) const {
+        return visit([&](auto &image) -> AnyImage { return autoscale(image, max_value, histogram_bins); }, image);
+    }
+    GADGETRON_GADGET_EXPORT(AutoScaleGadget);
 }

--- a/gadgets/mri_core/AutoScaleGadget.cpp
+++ b/gadgets/mri_core/AutoScaleGadget.cpp
@@ -12,13 +12,8 @@ namespace {
 		if (header.image_type == ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE) { //Only scale magnitude images for now
 			auto max = *std::max_element(data.begin(), data.end());
 			auto current_scale_ = 1.0;
-			auto histogram_ = std::vector<size_t>(histogram_bins);
-			if (histogram_.size() != histogram_bins) {
-				histogram_ = std::vector<size_t>(histogram_bins);
-			}
-			for (size_t i = 0; i < histogram_bins; i++) {
-				histogram_[i] = 0;
-			}
+			auto histogram_ = std::vector<size_t>(histogram_bins);    
+			std::fill(histogram_.begin(), histogram_.end(), 0);
 			for (auto& d : data) {
 				size_t bin = static_cast<size_t>(std::floor((d/max)*histogram_bins));
 				if (bin >= histogram_bins) {

--- a/gadgets/mri_core/AutoScaleGadget.cpp
+++ b/gadgets/mri_core/AutoScaleGadget.cpp
@@ -4,26 +4,21 @@ using namespace Gadgetron;
 using namespace Gadgetron::Core;
 
 namespace {
-    template<class T>
-    Image<T> autoscale(Image<T> &image, float max_value, unsigned int histogram_bins) {
-
+	template<class T>
+	Image<T> autoscale(Image<T> &image, float max_value, unsigned int histogram_bins) {
 		auto &header = std::get<ISMRMRD::ImageHeader>(image);
-        auto &data = std::get<hoNDArray<T>>(image);
-		auto &meta = std::get<optional<ISMRMRD::MetaContainer>>(image);
-		
+		auto &data = std::get<hoNDArray<T>>(image);
+		auto &meta = std::get<optional<ISMRMRD::MetaContainer>>(image);	
 		if (header.image_type == ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE) { //Only scale magnitude images for now
 			auto max = *std::max_element(data.begin(), data.end());
 			auto current_scale_ = 1.0;
 			auto histogram_ = std::vector<size_t>(histogram_bins);
-
 			if (histogram_.size() != histogram_bins) {
 				histogram_ = std::vector<size_t>(histogram_bins);
 			}
-
 			for (size_t i = 0; i < histogram_bins; i++) {
 				histogram_[i] = 0;
 			}
-
 			for (auto& d : data) {
 				size_t bin = static_cast<size_t>(std::floor((d/max)*histogram_bins));
 				if (bin >= histogram_bins) {
@@ -31,7 +26,6 @@ namespace {
 				}
 				histogram_[bin]++;
 			}
-			
 			//Find 99th percentile
 			long long cumsum = 0;
 			size_t counter = 0;
@@ -41,13 +35,12 @@ namespace {
 			max = (counter+1)*(max/histogram_bins);
 			GDEBUG("Max: %f\n",max);
 			current_scale_ = max_value/max;
-
 			for (auto& d : data){
 				d *= current_scale_;
 			}
 		}
-        return Image<T>(header,data,meta);
-    }
+		return Image<T>(header,data,meta);
+	}
 
     template<class T>
     Image<std::complex<T>> autoscale(Image<std::complex<T>> &image, float max_value, unsigned int histogram_bins) {
@@ -57,8 +50,8 @@ namespace {
 }
 
 namespace Gadgetron {
-    AnyImage AutoScaleGadget::process_function(AnyImage image) const {
-        return visit([&](auto &image) -> AnyImage { return autoscale(image, max_value, histogram_bins); }, image);
-    }
-    GADGETRON_GADGET_EXPORT(AutoScaleGadget);
+	AnyImage AutoScaleGadget::process_function(AnyImage image) const {
+		return visit([&](auto &image) -> AnyImage { return autoscale(image, max_value, histogram_bins); }, image);
+	}
+	GADGETRON_GADGET_EXPORT(AutoScaleGadget);
 }

--- a/gadgets/mri_core/AutoScaleGadget.h
+++ b/gadgets/mri_core/AutoScaleGadget.h
@@ -1,35 +1,25 @@
-#ifndef AUTOSCALEGADGET_H_
-#define AUTOSCALEGADGET_H_
+/**
+    \brief  Autoscales real-type images based on a given max value and the 99th percentile of the data
+    \author Original: David Christoffer Hansen
+    \author PureGadget Conversion: Andrew Dupuis
+    \test   Tested by: epi_2d.cfg and others
+*/
 
-#include "Gadget.h"
-#include "hoNDArray.h"
-#include "gadgetron_mricore_export.h"
+#pragma once
 
-#include <ismrmrd/ismrmrd.h>
+#include "PureGadget.h"
+#include "Types.h"
+#include "hoNDArray_math.h"
 
 namespace Gadgetron{
-
-  class EXPORTGADGETSMRICORE AutoScaleGadget:
-    public Gadget2<ISMRMRD::ImageHeader,hoNDArray< float > >
-  {
-  public:
-    GADGET_DECLARE(AutoScaleGadget);
-
-    AutoScaleGadget();
-    virtual ~AutoScaleGadget();
-
-  protected:
-    GADGET_PROPERTY(max_value, float, "Maximum value (after scaling)", 2048);
-
-    virtual int process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1,
-			GadgetContainerMessage< hoNDArray< float > >* m2);
-    virtual int process_config(ACE_Message_Block *mb);
-
-    unsigned int histogram_bins_;
-    std::vector<size_t> histogram_;
-    float current_scale_;
-    float max_value_;
-  };
+    class AutoScaleGadget : public Core::PureGadget<Core::AnyImage, Core::AnyImage> {
+    public:
+      using Core::PureGadget<Core::AnyImage,Core::AnyImage>::PureGadget;
+        Core::AnyImage process_function(Core::AnyImage image) const override;
+    protected:
+        NODE_PROPERTY(max_value, float, "Maximum value (after scaling)", 2048);
+        NODE_PROPERTY(histogram_bins, unsigned int, "Number of Histogram Bins", 100);
+        float current_scale_;
+        std::vector<size_t> histogram_;
+    };
 }
-
-#endif /* AUTOSCALEGADGET_H_ */

--- a/gadgets/mri_core/AutoScaleGadget.h
+++ b/gadgets/mri_core/AutoScaleGadget.h
@@ -8,6 +8,7 @@
 #include "PureGadget.h"
 #include "Types.h"
 #include "hoNDArray_math.h"
+#include <algorithm>
 
 namespace Gadgetron{
     class AutoScaleGadget : public Core::PureGadget<Core::AnyImage, Core::AnyImage> {

--- a/gadgets/mri_core/AutoScaleGadget.h
+++ b/gadgets/mri_core/AutoScaleGadget.h
@@ -1,7 +1,5 @@
 /**
     \brief  Autoscales real-type images based on a given max value and the 99th percentile of the data
-    \author Original: David Christoffer Hansen
-    \author PureGadget Conversion: Andrew Dupuis
     \test   Tested by: epi_2d.cfg and others
 */
 
@@ -14,7 +12,7 @@
 namespace Gadgetron{
     class AutoScaleGadget : public Core::PureGadget<Core::AnyImage, Core::AnyImage> {
     public:
-      using Core::PureGadget<Core::AnyImage,Core::AnyImage>::PureGadget;
+        using Core::PureGadget<Core::AnyImage,Core::AnyImage>::PureGadget;
         Core::AnyImage process_function(Core::AnyImage image) const override;
     protected:
         NODE_PROPERTY(max_value, float, "Maximum value (after scaling)", 2048);


### PR DESCRIPTION
Continuing #1087, this PR converts AutoScaleGadget to a PureGadget using the conventions established in #1090 and #1094. 

