### PR TITLE
ImageArraySplitGadget->ChannelGadget Conversion

### DIFF
--- a/gadgets/mri_core/ImageArraySplitGadget.cpp
+++ b/gadgets/mri_core/ImageArraySplitGadget.cpp
@@ -1,30 +1,17 @@
 #include "ImageArraySplitGadget.h"
 
-namespace Gadgetron{
+using namespace Gadgetron;
+using namespace Gadgetron::Core;
 
-ImageArraySplitGadget::ImageArraySplitGadget()
-{
+namespace {
 
+void doProcessing(AnyImage image, Core::OutputChannel& out) {
+    out.push(image);
 }
 
-int ImageArraySplitGadget::process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1)
-{
-    if (this->next()->putq(m1) < 0)
-    {
-        m1->release();
-        return GADGET_FAIL;
-    }
-
-    return GADGET_OK;
-}
-
-int ImageArraySplitGadget::process( GadgetContainerMessage<IsmrmrdImageArray>* m1)
-{
+void doProcessing(IsmrmrdImageArray imagearr, Core::OutputChannel& out) {
     
-    //Grab a reference to the buffer containing the imaging data
-    IsmrmrdImageArray & imagearr = *m1->getObjectPtr();
-
-    //7D, fixed order [X, Y, Z, CHA, N, S, LOC]
+    // 7D, fixed order [X, Y, Z, CHA, N, S, LOC]
     uint16_t X = imagearr.data_.get_size(0);
     uint16_t Y = imagearr.data_.get_size(1);
     uint16_t Z = imagearr.data_.get_size(2);
@@ -33,60 +20,56 @@ int ImageArraySplitGadget::process( GadgetContainerMessage<IsmrmrdImageArray>* m
     uint16_t S = imagearr.data_.get_size(5);
     uint16_t LOC = imagearr.data_.get_size(6);
 
-    //Each image will be [X,Y,Z,CHA] big
+    // Each image will be [X,Y,Z,CHA] big
     std::vector<size_t> img_dims(4);
     img_dims[0] = X;
     img_dims[1] = Y;
     img_dims[2] = Z;
     img_dims[3] = CHA;
 
-    //Loop over N, S and LOC
-    for (uint16_t loc=0; loc < LOC; loc++) {
-        for (uint16_t s=0; s < S; s++) {                
-            for (uint16_t n=0; n < N; n++) {
-        
-                //Create a new image header and copy the header for this n, s and loc
-                GadgetContainerMessage<ISMRMRD::ImageHeader>* cm1 = 
-                        new GadgetContainerMessage<ISMRMRD::ImageHeader>();
-                memcpy(cm1->getObjectPtr(), &imagearr.headers_(n,s,loc), sizeof(ISMRMRD::ImageHeader));
+    // Loop over N, S and LOC
+    for (uint16_t loc = 0; loc < LOC; loc++) {
+        for (uint16_t s = 0; s < S; s++) {
+            for (uint16_t n = 0; n < N; n++) {
+                // Create a new image header and copy the header for this n, s and loc
+                auto imageHeader = ISMRMRD::ImageHeader();
+                memcpy(&imageHeader, &imagearr.headers_(n, s, loc), sizeof(ISMRMRD::ImageHeader));
 
-                //Create a new image image
-                // and the 4D data block [X,Y,Z,CHA] for this n, s and loc
-                GadgetContainerMessage< hoNDArray< std::complex<float> > >* cm2 = 
-                        new GadgetContainerMessage<hoNDArray< std::complex<float> > >();
+                // Create a new image image
+                //  and the 4D data block [X,Y,Z,CHA] for this n, s and loc
+                auto imageData = hoNDArray<std::complex<float>>(img_dims);
+                memcpy(imageData.get_data_ptr(), &imagearr.data_(0, 0, 0, 0, n, s, loc),
+                       X * Y * Z * CHA * sizeof(std::complex<float>));
 
-                try{cm2->getObjectPtr()->create(img_dims);}
-                catch (std::runtime_error &err){
-                    GEXCEPTION(err,"Unable to allocate new image\n");
-                    cm1->release();
-                    cm2->release();
-                    return GADGET_FAIL;
-                }
-                memcpy(cm2->getObjectPtr()->get_data_ptr(), &imagearr.data_(0,0,0,0,n,s,loc), X*Y*Z*CHA*sizeof(std::complex<float>));
-                //Chain them
-                cm1->cont(cm2);
-
-                //Create a new meta container if needed and copy
-                if (imagearr.meta_.size()>0) {
-                    GadgetContainerMessage< ISMRMRD::MetaContainer >* cm3 = 
-                            new GadgetContainerMessage< ISMRMRD::MetaContainer >();
-                    size_t mindex = loc*N*S + s*N + n;
-                    *cm3->getObjectPtr() = imagearr.meta_[mindex];
-                    cm2->cont(cm3);
+                // Create a new meta container if needed and copy
+                auto imageMetaContainer = std::optional<ISMRMRD::MetaContainer>(); // TODO: Should this be empty? Seems like it should be populated somehow
+                if (imagearr.meta_.size() > 0) {
+                    size_t mindex = loc * N * S + s * N + n;
+                    imageMetaContainer = imagearr.meta_[mindex];
                 }
 
-                //Pass the image down the chain
-                if (this->next()->putq(cm1) < 0) {
-                    return GADGET_FAIL;
-                }
+                // Pass the image down the chain
+                out.push(Core::Image<std::complex<float>>(std::move(imageHeader), std::move(imageData), std::move(imageMetaContainer)));
             }
         }
     }
-    
-    m1->release();
-    return GADGET_OK;  
-
 }
 
-GADGET_FACTORY_DECLARE(ImageArraySplitGadget)
+} // namespace
+
+namespace Gadgetron {
+
+void ImageArraySplitGadget::process(Core::InputChannel<ImageOrImageArray>& in, Core::OutputChannel& out) {
+
+    // Lambda, adds image and correct index to vector of ImageEntries 
+    auto lambda = [&](auto message){ 
+        doProcessing(message, out);
+    };
+
+    for (auto msg : in) {
+        visit(lambda, msg);
+    }
 }
+
+GADGETRON_GADGET_EXPORT(ImageArraySplitGadget);
+} // namespace Gadgetron

--- a/gadgets/mri_core/ImageArraySplitGadget.cpp
+++ b/gadgets/mri_core/ImageArraySplitGadget.cpp
@@ -56,11 +56,8 @@ void splitInputData(IsmrmrdImageArray imagearr, Core::OutputChannel& out) {
 namespace Gadgetron {
 
 void ImageArraySplitGadget::process(Core::InputChannel<ImageOrImageArray>& in, Core::OutputChannel& out) {
-    auto lambda = [&](auto message){ 
-        splitInputData(message, out);
-    };
     for (auto msg : in) {
-        visit(lambda, msg);
+        visit([&](auto message){splitInputData(message, out);}, msg);
     }
 }
 

--- a/gadgets/mri_core/ImageArraySplitGadget.h
+++ b/gadgets/mri_core/ImageArraySplitGadget.h
@@ -1,24 +1,28 @@
-#ifndef IMAGEARRAYSPLIT_H
-#define IMAGEARRAYSPLIT_H
+/**
+    \brief  Splits an ImageArray and outputs separate images
+    \author Original: David Christoffer Hansen
+    \author ChannelGadget Conversion: Andrew Dupuis
+    \test   simple_gre_3d.cfg, distributed_simple_gre.cfg, and others
+*/
+
+#pragma once
 
 #include "Gadget.h"
 #include "hoNDArray.h"
-#include "gadgetron_mricore_export.h"
-
-#include "mri_core_data.h"
+#include "GadgetMRIHeaders.h"
+#include "Node.h"
+#include "Types.h"
+#include <mri_core_data.h>
+#include "hoNDArray_math.h"
 
 namespace Gadgetron{
 
-  class EXPORTGADGETSMRICORE ImageArraySplitGadget : 
-  public Gadget1Of2<IsmrmrdImageArray, ISMRMRD::ImageHeader >
+  using ImageOrImageArray = Core::variant<Core::AnyImage, IsmrmrdImageArray>;
+
+  class ImageArraySplitGadget : public Core::ChannelGadget<ImageOrImageArray> 
     {
-    public:
-      GADGET_DECLARE(ImageArraySplitGadget)
-      ImageArraySplitGadget();
-	
-    protected:
-      virtual int process(GadgetContainerMessage<IsmrmrdImageArray>* m1);
-      virtual int process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1);
+      public:
+        using Core::ChannelGadget<ImageOrImageArray>::ChannelGadget;
+        void process(Core::InputChannel<ImageOrImageArray>& input, Core::OutputChannel& output) override;  
     };
 }
-#endif //IMAGEARRAYSPLIT_H

--- a/gadgets/mri_core/ImageArraySplitGadget.h
+++ b/gadgets/mri_core/ImageArraySplitGadget.h
@@ -1,7 +1,5 @@
 /**
     \brief  Splits an ImageArray and outputs separate images
-    \author Original: David Christoffer Hansen
-    \author ChannelGadget Conversion: Andrew Dupuis
     \test   simple_gre_3d.cfg, distributed_simple_gre.cfg, and others
 */
 


### PR DESCRIPTION
Continuing #1087, this PR converts ImageArraySplitGadget to a ChannelGadget using the conventions established in #1090 and #1094.