### PR TITLE
Minor white space clean-up, and removing recursive header inclusion.

### DIFF
--- a/toolboxes/core/cpu/image/hoNDImage.hxx
+++ b/toolboxes/core/cpu/image/hoNDImage.hxx
@@ -3,8 +3,6 @@
     \author     Hui Xue
 */
 
-#include "hoNDImage.h"
-
 namespace Gadgetron
 {
     template <typename T, unsigned int D> 

--- a/toolboxes/core/vector_td_utilities.h
+++ b/toolboxes/core/vector_td_utilities.h
@@ -49,7 +49,7 @@ namespace Gadgetron{
     return (a<b)?b:a;
   }
 
-    //
+  //
   // In-place operations
   //
 


### PR DESCRIPTION
Probably shouldn't have hoNDImage.h and hoNDImage.hxx including each other.