### PR TITLE
Convert ImageSortGadget to ChannelGadget

### DIFF
--- a/gadgets/mri_core/ImageSortGadget.cpp
+++ b/gadgets/mri_core/ImageSortGadget.cpp
@@ -1,70 +1,64 @@
 #include "ImageSortGadget.h"
+#include "Node.h"
+#include "Types.h"
+#include "log.h"
 
-namespace Gadgetron{
+using namespace Gadgetron::Core;
 
-  int ImageSortGadget::index(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1)
-  {
-    std::string sorting_dimension_local = sorting_dimension.value();
-    
-    if (sorting_dimension_local.size() == 0) {
-      return -1;
-    } else if (sorting_dimension_local.compare("average") == 0) {
-      return m1->getObjectPtr()->average;
-    } else if (sorting_dimension_local.compare("slice") == 0) {
-      return m1->getObjectPtr()->slice;
-    } else if (sorting_dimension_local.compare("contrast") == 0) {
-      return m1->getObjectPtr()->contrast;
-    } else if (sorting_dimension_local.compare("phase") == 0) {
-      return m1->getObjectPtr()->phase;
-    } else if (sorting_dimension_local.compare("repetition") == 0) {
-      return m1->getObjectPtr()->repetition;
-    } else if (sorting_dimension_local.compare("set") == 0) {
-      return m1->getObjectPtr()->set;
-    } else {
-      return -1;
+namespace Gadgetron {
+
+    ImageSortGadget::ImageSortGadget(const Context &context, const GadgetProperties &properties)
+        : ChannelGadget(context, properties) {}
+
+    void ImageSortGadget::process(InputChannel<Core::AnyImage> &input, OutputChannel &output) {
+        
+        // Lambda, gets index from correct field in ImageHeader based on parameterized sorting dimension
+        auto getImageIndex = [&](const auto& i){   
+          auto &header = std::get<ISMRMRD::ImageHeader>(i);
+          if (sorting_dimension.size() == 0) {
+              return uint16_t(-1);
+            } else if (sorting_dimension.compare("average") == 0) {
+              return header.average;
+            } else if (sorting_dimension.compare("slice") == 0) {
+              return header.slice;
+            } else if (sorting_dimension.compare("contrast") == 0) {
+              return header.contrast;
+            } else if (sorting_dimension.compare("phase") == 0) {
+              return header.phase;
+            } else if (sorting_dimension.compare("repetition") == 0) {
+              return header.repetition;
+            } else if (sorting_dimension.compare("set") == 0) {
+              return header.set;
+            } else {
+              return uint16_t(-1);
+            }
+          return uint16_t(-1);
+        };
+
+        // Lambda, adds image and correct index to vector of ImageEntries 
+        auto addToImages = [&](auto image){ 
+          if (getImageIndex(image) < 0) {
+            output.push(image);
+          }
+          images_.push_back(ImageEntry{image, getImageIndex(image)});
+        };
+
+        // Lambda, comparison method for ImageEntry indices
+        auto image_entry_compare = [](const auto& i, const auto& j) {return i.index_<j.index_; };
+
+        // Add all the images from input channel to vector of ImageEntries
+        for (auto image : input) {
+          visit(addToImages, image);
+        }
+
+        // If vector of ImageEntries isn't empty, sort them and write to output channel 
+        if (images_.size()) {
+          std::sort(images_.begin(),images_.end(), image_entry_compare);
+          for (auto it = images_.begin(); it != images_.end(); it++) {
+            visit([&](auto image){output.push(image);}, it->image_);
+          }
+          images_.clear();
+        }
     }
-
-    return -1;
-  }
-
-  int ImageSortGadget::close(unsigned long flags)
-  {
-    GDEBUG("++++++ close call with %d images\n", images_.size());
-    if (images_.size()) {
-      
-      std::sort(images_.begin(),images_.end(), image_entry_compare);
-      
-      for (auto it = images_.begin(); it != images_.end(); it++) {
-	if (this->next()->putq(it->mb_) == -1) {
-	  it->mb_->release();
-	  GERROR("Error passing data on to next gadget\n");
-	  return GADGET_FAIL;
-	}
-      }
-      
-      images_.clear();
-    }
-    return GADGET_OK;
-  }
-  
-  int ImageSortGadget::process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1)
-  {
-    if (index(m1) < 0) {
-      if (this->next()->putq(m1) == -1) {
-	m1->release();
-	GERROR("Error passing data on to next gadget\n");
-	return GADGET_FAIL;
-      }
-    }
-
-    ImageEntry i;
-    i.index_ = index(m1);
-    i.mb_ = m1;
-
-    images_.push_back(i);
-
-    return GADGET_OK;
-  }
-
-  GADGET_FACTORY_DECLARE(ImageSortGadget);
+    GADGETRON_GADGET_EXPORT(ImageSortGadget);
 }

--- a/gadgets/mri_core/ImageSortGadget.h
+++ b/gadgets/mri_core/ImageSortGadget.h
@@ -1,49 +1,32 @@
-#ifndef IMAGESORTGADGET_H
-#define IMAGESORTGADGET_H
+/**
+    \brief  Sorts all pipeline images by the selected sorting dimension flag
+    \test   Tested by: distributed_simple_gre.cfg, distributed_buffer_simple_gre.cfg
+*/
+
+#pragma once
 
 #include "Gadget.h"
 #include "hoNDArray.h"
 #include "GadgetMRIHeaders.h"
-#include "gadgetron_mricore_export.h"
-
-#include <ismrmrd/ismrmrd.h>
-#include <complex>
+#include "Node.h"
+#include "Types.h"
 
 namespace Gadgetron{
 
   struct ImageEntry
   {
+    Core::AnyImage image_;
     int index_;
-    GadgetContainerMessage<ISMRMRD::ImageHeader>* mb_;
   };
 
-  bool image_entry_compare(const ImageEntry& i, const ImageEntry& j)
-  {
-    return (i.index_<j.index_);
-  }
-
-  class EXPORTGADGETSMRICORE ImageSortGadget : public Gadget1 < ISMRMRD::ImageHeader >
-  {
-  public:
-    GADGET_DECLARE(ImageSortGadget);
-
-  protected:
-    GADGET_PROPERTY_LIMITS(sorting_dimension, std::string, "Dimension that data will be sorted by", "slice",
-			   GadgetPropertyLimitsEnumeration, 
-			   "average",
-			   "slice",
-			   "contrast",
-			   "phase",
-			   "repetition",
-			   "set");
-
-    virtual int close(unsigned long flags);
-    virtual int process(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1);
-    int index(GadgetContainerMessage<ISMRMRD::ImageHeader>* m1);
-    
-    std::vector<ImageEntry> images_;
-    
+  class ImageSortGadget : public Core::ChannelGadget<Core::AnyImage> {
+    public:
+      GADGET_DECLARE(ImageSortGadget);
+      ImageSortGadget(const Core::Context &, const Core::GadgetProperties &);
+      void process(Core::InputChannel<Core::AnyImage> &, Core::OutputChannel &) override;
+    protected:
+      // { "average", "slice", "contrast", "phase", "repetition", "set" }
+      NODE_PROPERTY(sorting_dimension, std::string, "Dimension that data will be sorted by", "slice"); 
+      std::vector<ImageEntry> images_;
   };
 }
-
-#endif //IMAGESORTGADGET_H


### PR DESCRIPTION
Continuing #1087, this PR converts ImageSortGadget to a ChannelGadget using the conventions established in #1090 and #1094, with the cache containing Image objects instead of the header pointers. 