### PR TITLE
Convert RemoveROOversamplingGadget->ChannelGadget

### DIFF
--- a/gadgets/mri_core/RemoveROOversamplingGadget.cpp
+++ b/gadgets/mri_core/RemoveROOversamplingGadget.cpp
@@ -1,145 +1,101 @@
 #include "RemoveROOversamplingGadget.h"
-#include "hoNDFFT.h"
-#include "ismrmrd/xml.h"
 
-#ifdef USE_OMP
-    #include "omp.h"
-#endif // USE_OMP
+namespace Gadgetron {
 
-namespace Gadgetron{
+RemoveROOversamplingGadget::RemoveROOversamplingGadget(const Core::Context& context,
+                                                       const Core::GadgetProperties& props)
+    : Core::ChannelGadget<Core::Acquisition>(context, props) {
+    auto h = (context.header);
 
-    RemoveROOversamplingGadget::RemoveROOversamplingGadget()
-    {
+    if (h.encoding.size() == 0) {
+        GDEBUG("Number of encoding spaces: %d\n", h.encoding.size());
+        GERROR("This Gadget needs an encoding description\n");
+        return;
     }
 
-    RemoveROOversamplingGadget::~RemoveROOversamplingGadget()
-    {
-    }
+    ISMRMRD::EncodingSpace e_space = h.encoding[0].encodedSpace;
+    ISMRMRD::EncodingSpace r_space = h.encoding[0].reconSpace;
 
-    int RemoveROOversamplingGadget::process_config(ACE_Message_Block* mb)
-    {
+    encodeNx_ = e_space.matrixSize.x;
+    encodeFOV_ = e_space.fieldOfView_mm.x;
+    reconNx_ = r_space.matrixSize.x;
+    reconFOV_ = r_space.fieldOfView_mm.x;
 
-	ISMRMRD::IsmrmrdHeader h;
-	ISMRMRD::deserialize(mb->rd_ptr(),h);
-
-	if (h.encoding.size() == 0) {
-	  GDEBUG("Number of encoding spaces: %d\n", h.encoding.size());
-	  GDEBUG("This Gadget needs an encoding description\n");
-	  return GADGET_FAIL;
-	}
-
-	
-	ISMRMRD::EncodingSpace e_space = h.encoding[0].encodedSpace;
-	ISMRMRD::EncodingSpace r_space = h.encoding[0].reconSpace;
-
-        encodeNx_  = e_space.matrixSize.x;
-        encodeFOV_ = e_space.fieldOfView_mm.x;
-        reconNx_   = r_space.matrixSize.x;
-        reconFOV_  = r_space.fieldOfView_mm.x;
-
-        // limit the number of threads used to be 1
-#ifdef USE_OMP
-        omp_set_num_threads(1);
-        GDEBUG_STREAM("RemoveROOversamplingGadget:omp_set_num_threads(1) ... ");
+#ifdef USE_OMP  // TODO: Should this be removed? Its from the old version
+    omp_set_num_threads(1);
+    GDEBUG_STREAM("RemoveROOversamplingGadget:omp_set_num_threads(1) ... ");
 #endif // USE_OMP
 
     // If the encoding and recon matrix size and FOV are the same
     // then the data is not oversampled and we can safely pass
     // the data onto the next gadget
-    if ( (encodeNx_ == reconNx_) && (encodeFOV_ == reconFOV_) )
-    {
-      dowork_ = false;
+    if ((encodeNx_ == reconNx_) && (encodeFOV_ == reconFOV_)) {
+        dowork_ = false;
+    } else {
+        dowork_ = true;
     }
-    else {
-      dowork_ = true;
-    }
+}
 
-        return GADGET_OK;
-    }
-
-    int RemoveROOversamplingGadget
-        ::process(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1,
-        GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2)
-    {
-
-      // If we have work to do, do it, otherwise do nothing
-      if (dowork_) {
-
-        GadgetContainerMessage< hoNDArray< std::complex<float> > >* m3 
-            = new GadgetContainerMessage< hoNDArray< std::complex<float> > >();
-
-        if (!m3)
-        {
-            return GADGET_FAIL;
-        }
-
-        std::vector<size_t> data_out_dims = *m2->getObjectPtr()->get_dimensions();
-        if ( !ifft_buf_.dimensions_equal(&data_out_dims) )
-        {
-            ifft_buf_.create(data_out_dims);
-            ifft_res_.create(data_out_dims);
-        }
-
-        float ratioFOV = encodeFOV_/reconFOV_;
-
-        data_out_dims[0] = (size_t)(data_out_dims[0]/ratioFOV);
-        if ( !fft_buf_.dimensions_equal(&data_out_dims) )
-        {
-            fft_buf_.create(data_out_dims);
-            fft_res_.create(data_out_dims);
-        }
-
-        try{ m3->getObjectPtr()->create(data_out_dims);}
-        catch (std::runtime_error &err)
-        {
-            GEXCEPTION(err,"Unable to create new data array for downsampled data\n");
-            return GADGET_FAIL;
-        }
-
-        size_t sRO = m2->getObjectPtr()->get_size(0);
-        size_t start = (size_t)( (m2->getObjectPtr()->get_size(0)-data_out_dims[0]) / 2 );
-
-        size_t dRO = m3->getObjectPtr()->get_size(0);
-        size_t numOfBytes = data_out_dims[0]*sizeof(std::complex<float>);
-
-        int c;
-
-        int CHA = (int)(data_out_dims[1]);
-
-        std::complex<float>* data_in, *data_out;
-
-        hoNDFFT<float>::instance()->ifft1c(*m2->getObjectPtr(), ifft_res_, ifft_buf_);
-        data_in  = ifft_res_.get_data_ptr();
-        data_out = m3->getObjectPtr()->get_data_ptr();
-
-        for ( c=0; c<CHA; c++)
-        {
-            memcpy( data_out+c*dRO, data_in+c*sRO+start, numOfBytes );
-        }
-
-        hoNDFFT<float>::instance()->fft1c(*m3->getObjectPtr(), fft_res_, fft_buf_);
-
-        memcpy(m3->getObjectPtr()->begin(), fft_res_.begin(), fft_res_.get_number_of_bytes());
-
-        m2->release(); //We are done with this data
-
-        m1->cont(m3);
-        m1->getObjectPtr()->number_of_samples = data_out_dims[0];
-        m1->getObjectPtr()->center_sample = (uint16_t)(m1->getObjectPtr()->center_sample/ratioFOV);
-        m1->getObjectPtr()->discard_pre = (uint16_t)(m1->getObjectPtr()->discard_pre / ratioFOV);
-        m1->getObjectPtr()->discard_post = (uint16_t)(m1->getObjectPtr()->discard_post / ratioFOV);
-
-      } // end if (dowork_)
-
-      if (this->next()->putq(m1) == -1)
+void RemoveROOversamplingGadget::process(Core::InputChannel<Core::Acquisition>& in, Core::OutputChannel& out) {
+  for (auto [header, acq, traj] : in) {
+    if(dowork_){
+      hoNDArray<std::complex<float>>* temp = new hoNDArray<std::complex<float>>();
+      if (!temp)
       {
-        GERROR("RemoveROOversamplingGadget::process, passing data on to next gadget");
-        return GADGET_FAIL;
+        GERROR("Error creating new temp  array");
+        return;
+      }
+      std::vector<size_t> data_out_dims = *acq.get_dimensions();
+      if (!ifft_buf_.dimensions_equal(&data_out_dims) )
+      {
+          ifft_buf_.create(data_out_dims);
+          ifft_res_.create(data_out_dims);
+      }
+      float ratioFOV = encodeFOV_/reconFOV_;
+      data_out_dims[0] = (size_t)(data_out_dims[0]/ratioFOV);
+      if ( !fft_buf_.dimensions_equal(&data_out_dims) )
+      {
+          fft_buf_.create(data_out_dims);
+          fft_res_.create(data_out_dims);
+      }
+      try{ temp->create(data_out_dims);}
+      catch (std::runtime_error &err)
+      {
+          GEXCEPTION(err,"Unable to create new data array for downsampled data\n");
+          return;
+      }
+      size_t sRO = acq.get_size(0);
+      size_t start = (size_t)((acq.get_size(0)-data_out_dims[0]) / 2);
+
+      size_t dRO = temp->get_size(0);
+      size_t numOfBytes = data_out_dims[0]*sizeof(std::complex<float>);
+
+      int c;   
+      int CHA = (int)(data_out_dims[1]);
+
+      std::complex<float>* data_in, *data_out;
+      hoNDFFT<float>::instance()->ifft1c(acq, ifft_res_, ifft_buf_);
+      data_in  = ifft_res_.get_data_ptr();
+      data_out = temp->get_data_ptr();
+
+      for (c=0; c<CHA; c++)
+      {
+          memcpy( data_out+c*dRO, data_in+c*sRO+start, numOfBytes );
       }
 
-      return GADGET_OK;
+      hoNDFFT<float>::instance()->fft1c(*temp, fft_res_, fft_buf_);
+
+      memcpy(temp->begin(), fft_res_.begin(), fft_res_.get_number_of_bytes());
+
+      header.number_of_samples = data_out_dims[0];
+      header.center_sample = (uint16_t)(header.center_sample/ratioFOV);
+      header.discard_pre = (uint16_t)(header.discard_pre / ratioFOV);
+      header.discard_post = (uint16_t)(header.discard_post / ratioFOV);
+
+      acq = *temp;
     }
-
-
-    GADGET_FACTORY_DECLARE(RemoveROOversamplingGadget)
+    out.push(Core::Acquisition{header, std::move(acq), std::move(traj)});
+  }
 }
+GADGETRON_GADGET_EXPORT(RemoveROOversamplingGadget)
+} // namespace Gadgetron

--- a/gadgets/mri_core/RemoveROOversamplingGadget.h
+++ b/gadgets/mri_core/RemoveROOversamplingGadget.h
@@ -1,43 +1,41 @@
+/**
+    \brief  Removes readout oversampling
+    \test   Tested by: simple_gre.cfg, generic_cartesian_cine_denoise.cfg, and others
+*/
+
 #pragma once
 
 #include "Gadget.h"
+#include "GadgetMRIHeaders.h"
+#include "Node.h"
+#include "Types.h"
 #include "hoNDArray.h"
-#include "gadgetron_mricore_export.h"
+#include "hoNDFFT.h"
+#include "ismrmrd/xml.h"
+#ifdef USE_OMP // TODO: Should this be removed? Its from the old version
+#include "omp.h"
+#endif // USE_OMP
 
-#include <ismrmrd/ismrmrd.h>
-#include <complex>
+namespace Gadgetron {
+class RemoveROOversamplingGadget : public Core::ChannelGadget<Core::Acquisition> {
+  public:
+    using Core::ChannelGadget<Core::Acquisition>::ChannelGadget;
+    RemoveROOversamplingGadget(const Core::Context& context, const Core::GadgetProperties& props);
+    ~RemoveROOversamplingGadget() override = default;
+    void process(Core::InputChannel<Core::Acquisition>& input, Core::OutputChannel& output) override;
 
-namespace Gadgetron{
+  protected:
+    hoNDArray<std::complex<float>> fft_res_;
+    hoNDArray<std::complex<float>> ifft_res_;
 
-    class EXPORTGADGETSMRICORE RemoveROOversamplingGadget :
-        public Gadget2<ISMRMRD::AcquisitionHeader,hoNDArray< std::complex<float> > >
-    {
-    public:
-        GADGET_DECLARE(RemoveROOversamplingGadget);
+    hoNDArray<std::complex<float>> fft_buf_;
+    hoNDArray<std::complex<float>> ifft_buf_;
 
-        RemoveROOversamplingGadget();
-        virtual ~RemoveROOversamplingGadget();
+    int encodeNx_;
+    float encodeFOV_;
+    int reconNx_;
+    float reconFOV_;
 
-    protected:
-
-        virtual int process_config(ACE_Message_Block* mb);
-
-        virtual int process(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1,
-            GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2);
-
-        hoNDArray< std::complex<float> > fft_res_;
-        hoNDArray< std::complex<float> > ifft_res_;
-
-        hoNDArray< std::complex<float> > fft_buf_;
-        hoNDArray< std::complex<float> > ifft_buf_;
-
-        int   encodeNx_;
-        float encodeFOV_;
-        int   reconNx_;
-        float reconFOV_;
-
-	// if true the gadget performs the operation
-	// otherwise, it just passes the data on
-	bool dowork_;
-    };
-}
+    bool dowork_;    // if true the gadget performs the operation, otherwise, it just passes the data on
+};
+} // namespace Gadgetron


### PR DESCRIPTION
Continuing #1087, this PR converts RemoveROOversamplingGadget to a ChannelGadget using the conventions established in #1090 and #1094 