### PR TITLE
Clang-compatible extension of Gadgetron::Core::IO namespace

### DIFF
--- a/toolboxes/mri_image/hoMRImage.h
+++ b/toolboxes/mri_image/hoMRImage.h
@@ -189,16 +189,20 @@ namespace Gadgetron
     };
 }
 
-template<class T, unsigned int D>
-void Gadgetron::Core::IO::read(std::istream &stream, Gadgetron::hoMRImage<T, D> &image);
+namespace Gadgetron::Core::IO {
 
-template<class T, unsigned int D>
-void Gadgetron::Core::IO::read(std::istream &stream, Gadgetron::hoNDArray< Gadgetron::hoMRImage<T, D> > &image);
+    template<class T, unsigned int D>
+    void read(std::istream &stream, Gadgetron::hoMRImage<T, D> &image);
 
-template<class T, unsigned int D>
-void Gadgetron::Core::IO::write(std::ostream &stream, const Gadgetron::hoMRImage<T, D> &image);
+    template<class T, unsigned int D>
+    void read(std::istream &stream, Gadgetron::hoNDArray< Gadgetron::hoMRImage<T, D> > &image);
 
-template<class T, unsigned int D>
-void Gadgetron::Core::IO::write(std::ostream &stream, const Gadgetron::hoNDArray< Gadgetron::hoMRImage<T, D> > &image);
+    template<class T, unsigned int D>
+    void write(std::ostream &stream, const Gadgetron::hoMRImage<T, D> &image);
+
+    template<class T, unsigned int D>
+    void write(std::ostream &stream, const Gadgetron::hoNDArray< Gadgetron::hoMRImage<T, D> > &image);
+
+}
 
 #include "hoMRImage.hxx"


### PR DESCRIPTION
These changes allow compilation of another 25 or so of remaining targets when building on macOS with Clang.