### PR TITLE
Publish conda package on CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
     artifact: drop
 - job: Publish
   displayName: "Publish Conda Package"
-  condition: and(succeeded(), eq(variables.IS_CI, 'true'))
+  condition: and(succeeded(), eq(variables.isCI, 'true'))
   dependsOn:
   - BuildAndTest
   - Package


### PR DESCRIPTION
The correct environment variable is 'isCI' not 'IS_CI', as defined at the top of the file - oops. 

