### PR TITLE
Provide a job timeout for the package publish job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ variables:
   DOCKER_BUILDKIT: 1
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
   isCI: $[or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'))]
-  jobTimeout: 120
 
 pool: gadgetron-gpu-nodes
 
@@ -18,7 +17,7 @@ pr:
 
 jobs:
 - job: BuildAndTest
-  timeoutInMinutes: $(jobTimeout)
+  timeoutInMinutes: 120
   displayName: "Build, Unit and Integration tests"
   strategy:
     matrix:
@@ -65,7 +64,7 @@ jobs:
     displayName: 'Push images'
     condition: and(succeeded(), eq(variables.isCI, 'true'))
 - job: Package
-  timeoutInMinutes: $(jobTimeout)
+  timeoutInMinutes: 120
   displayName: "Create Conda Package"
   steps:
   - bash: echo "##vso[task.prependpath]/anaconda/bin"
@@ -85,7 +84,7 @@ jobs:
     displayName: 'Publish package'
     artifact: drop
 - job: Publish
-  timeoutInMinutes: $(jobTimeout)
+  timeoutInMinutes: 120
   displayName: "Publish Conda Package"
   condition: and(succeeded(), eq(variables.isCI, 'true'))
   dependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ variables:
   DOCKER_BUILDKIT: 1
   isPR: $[eq(variables['Build.Reason'], 'PullRequest')]
   isCI: $[or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'))]
+  jobTimeout: 120
 
 pool: gadgetron-gpu-nodes
 
@@ -17,7 +18,7 @@ pr:
 
 jobs:
 - job: BuildAndTest
-  timeoutInMinutes: 120
+  timeoutInMinutes: $(jobTimeout)
   displayName: "Build, Unit and Integration tests"
   strategy:
     matrix:
@@ -64,7 +65,7 @@ jobs:
     displayName: 'Push images'
     condition: and(succeeded(), eq(variables.isCI, 'true'))
 - job: Package
-  timeoutInMinutes: 120
+  timeoutInMinutes: $(jobTimeout)
   displayName: "Create Conda Package"
   steps:
   - bash: echo "##vso[task.prependpath]/anaconda/bin"
@@ -84,6 +85,7 @@ jobs:
     displayName: 'Publish package'
     artifact: drop
 - job: Publish
+  timeoutInMinutes: $(jobTimeout)
   displayName: "Publish Conda Package"
   condition: and(succeeded(), eq(variables.isCI, 'true'))
   dependsOn:

--- a/test/integration/get_data.py
+++ b/test/integration/get_data.py
@@ -3,12 +3,13 @@
 import os
 import os.path
 
-import sys
-import time
-import json
-import hashlib
 import argparse
 import functools
+import hashlib
+import json
+import socket
+import sys
+import time
 
 import urllib.error
 import urllib.request
@@ -34,12 +35,12 @@ def urlretrieve(url, filename, retries=5):
     if retries <= 0:
         raise RuntimeError("Download from {} failed".format(url))
     try:
-        with urllib.request.urlopen(url, timeout=120) as connection:
+        with urllib.request.urlopen(url, timeout=60) as connection:
             with open(filename,'wb') as f:
                 for chunk in iter(lambda : connection.read(1024*1024), b''):
                     f.write(chunk)
-    except (urllib.error.URLError, ConnectionResetError):
-        print("Retrying connection for file {}".format(filename))
+    except (urllib.error.URLError, ConnectionResetError, socket.Timeout) as exc:
+        print("Retrying connection for file {}, reason: {}".format(filename, str(exc)))
         urlretrieve(url, filename, retries=retries-1)
 
 def main():


### PR DESCRIPTION
Because the package publish is a job it was provided the default of 60 minutes.
However the test/package stages can exceed that period - meaning the
package job would exceed the default timeout and fail before it had an
opportunity to execute.