### PR TITLE
Accept package revisions when building package publish environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,7 @@ jobs:
     artifact: drop
   - script: |
       eval "$(conda shell.bash hook)"
-      conda create --name conda-push anaconda-client=1.8.0
+      conda create --name conda-push anaconda-client=1.8.0 -y
       conda activate conda-push
       set -euo pipefail
       cd conda && ./publish_package.sh -u $(gadgetron-user) -t $(gadgetron-token) -p `find $(Pipeline.Workspace)/drop/ -name gadgetron*.tar.bz2`

--- a/test/integration/get_data.py
+++ b/test/integration/get_data.py
@@ -39,7 +39,7 @@ def urlretrieve(url, filename, retries=5):
             with open(filename,'wb') as f:
                 for chunk in iter(lambda : connection.read(1024*1024), b''):
                     f.write(chunk)
-    except (urllib.error.URLError, ConnectionResetError, socket.Timeout) as exc:
+    except (urllib.error.URLError, ConnectionResetError, socket.timeout) as exc:
         print("Retrying connection for file {}, reason: {}".format(filename, str(exc)))
         urlretrieve(url, filename, retries=retries-1)
 


### PR DESCRIPTION
This change adds -y to the conda create command, which was timing out on successful CI builds waiting on input from stdin to accept new package revisions. 

Also fixed a typo made when adding the unhanded timeout exception. 