### PR TITLE
Convert PseudoReplicatorGadet to ChannelGadget

### DIFF
--- a/gadgets/debugging/PseudoReplicatorGadget.h
+++ b/gadgets/debugging/PseudoReplicatorGadget.h
@@ -1,28 +1,18 @@
-/*
- * PseudoReplicator.h
+/**
+    \brief  Appends defined number of noisy pseudoreplicas to incoming IsmrmrdReconData
+    \test   Untested 
+*/
 
- *
- *  Created on: Jun 23, 2015
- *      Author: David Hansen
- */
 #pragma once
-#include "Gadget.h"
+#include "Node.h"
 #include "mri_core_data.h"
-#include "gadgetron_debugging_export.h"
+#include <random>
 
-namespace Gadgetron {
-
-class EXPORTGADGETSDEBUGGING PseudoReplicatorGadget : public Gadget1<IsmrmrdReconData>{
-public:
-	GADGET_PROPERTY(repetitions,int,"Number of pseudoreplicas to produce",10);
-	PseudoReplicatorGadget()  ;
-	virtual ~PseudoReplicatorGadget();
-
-	virtual int process_config(ACE_Message_Block *);
-	virtual int process(GadgetContainerMessage<IsmrmrdReconData>*);
-
-private:
-	int repetitions_;
-};
-
-} /* namespace Gadgetron */
+namespace Gadgetron{
+    class PseudoReplicatorGadget : public Core::ChannelGadget<IsmrmrdReconData> {
+    public:
+      using Core::ChannelGadget<IsmrmrdReconData>::ChannelGadget;
+      void process(Core::InputChannel<IsmrmrdReconData>& input, Core::OutputChannel& out) override;
+      NODE_PROPERTY(repetitions,int,"Number of pseudoreplicas to produce",10);
+    };
+}


### PR DESCRIPTION
Continuing #1087, this PR converts PsuedoReplicatorGadget to a ChannelGadget using the conventions established in #1090 and #1094.

Note, there's no existing test for this gadget, and the gadget's "debugging" purpose requires random number generation. Does anyone have any ideas for a good Integration Test for this gadget? Off the top of my head, we could add a seed input to the Gadget properties so we can generate repeatable noise for the test.