### PR TITLE
Add label tying Docker builds to repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 FROM ubuntu:20.04 AS gadgetron_baseimage
+LABEL org.opencontainers.image.source=https://github.com/gadgetron/gadgetron
 
 ARG USERNAME
 ARG USER_UID


### PR DESCRIPTION
As part of improving the packaging of Gadgetron docker images, we should add the repo label that Github expects for organization-owned Docker images per instructions here: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line. This should tie our docker images into the Package list within the repository's main page. 

There are likely other annotation key Labels we should use too (for versioning etc) per: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys, but I want to start with seeing if this label behaves as expected. 