### PR TITLE
Build pipeline cleanup

### DIFF
--- a/conda/package.sh
+++ b/conda/package.sh
@@ -22,7 +22,6 @@ channels=(
   bioconda
   defaults
   intel
-  cefca
 )
 
 channel_directives=$(printf -- "-c %s " "${channels[@]}")

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - howardhinnant_date=3.0.1              # dev
   - ismrmrd::ismrmrd=1.12.0
   - ismrmrd::ismrmrd-python>=1.9.8
-  - junitparser==2.7.0
+  - junitparser=2.7.0
   - jupyter=1.0.0                         # dev
   - jq=1.6
   - libblas=*=*mkl

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ channels:
   - bioconda
   - defaults
   - intel
-  - cefca
 dependencies:
   - anaconda-client=1.8.0                 # dev
   - armadillo=9.900.5                     # dev
@@ -55,7 +54,7 @@ dependencies:
   - pyyaml=6.0                            # dev
   - pip=21.2.4                            # dev
   - packaging=21.3
-  - plplot=5.11.2
+  - plplot=5.15.0
   - pugixml=1.11.4                        # dev
   - pyfftw=0.12.0
   - python=3.9.7

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,7 +98,7 @@ include(GoogleTest)
                 python)
     endif ()
 
-    gtest_discover_tests(test_all)
+    gtest_discover_tests(test_all DISCOVERY_MODE PRE_TEST)
 
     install(TARGETS test_all DESTINATION bin COMPONENT main)
 


### PR DESCRIPTION
This PR removes the CEFCA channel from Gadgetron (newer version of plplot is available from conda-forge).  It also cleans up the conda environment specification, and finally - improves testing behavior when using GTest on macOS.