### PR TITLE
Obtain range-v3 using FetchContent instead of conda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif ()
 #VERSIONING AND INSTALL PATHS
 set(GADGETRON_VERSION_MAJOR 4)
 set(GADGETRON_VERSION_MINOR 4)
-set(GADGETRON_VERSION_PATCH 2)
+set(GADGETRON_VERSION_PATCH 3)
 set(GADGETRON_VERSION_STRING ${GADGETRON_VERSION_MAJOR}.${GADGETRON_VERSION_MINOR}.${GADGETRON_VERSION_PATCH})
 set(GADGETRON_SOVERSION ${GADGETRON_VERSION_MAJOR}.${GADGETRON_VERSION_MINOR})
 find_package(Git)
@@ -369,6 +369,17 @@ find_package(GLEW)
 find_package(GLUT)
 find_package(Qt4 4.6)
 find_package(PLplot)
+
+# Fetch the range-v3 header-only library and add its include directory
+# to all compilation targets
+include(FetchContent)
+FetchContent_Declare(
+        Range-v3
+        GIT_REPOSITORY "https://github.com/ericniebler/range-v3"
+        GIT_TAG "4989f3e9ff2efee1852942bb9328ef121369ba02" # release 0.11.0
+)
+FetchContent_MakeAvailable(Range-v3)
+link_libraries(range-v3)
 
 option(BUILD_TESTING "Enable test building" On)
 if (BUILD_TESTING)

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - pyfftw>=0.12.0
     - pyyaml>=6.0
     - python>=3.9.7
-    - gadgetron::range-v3>=0.11.0
     - sysroot_linux-64=2.17
   run:
     - armadillo>=9.900.5

--- a/environment.yml
+++ b/environment.yml
@@ -57,7 +57,6 @@ dependencies:
   - pugixml=1.11.4                        # dev
   - pyfftw=0.12.0
   - python=3.9.7
-  - gadgetron::range-v3=0.11.0
   - recommonmark=0.7.1                    # dev
   - scipy=1.7.1
   - shellcheck=0.7.2                      # dev

--- a/gadgets/T1/T1MocoGadget.cpp
+++ b/gadgets/T1/T1MocoGadget.cpp
@@ -13,7 +13,6 @@
 #include "mri_core_def.h"
 #include "t1fit.h"
 #include <range/v3/algorithm.hpp>
-#include <range/v3/range_concepts.hpp>
 namespace Gadgetron {
 
 class T1MocoGadget : public Core::ChannelGadget<IsmrmrdImageArray> {


### PR DESCRIPTION
Use CMake's FetchContent to clone the range-v3 repo at configure time, instead of using the conda package we create for it in the gadgetron channel. This should allow us to decommission the [gadgetron-conda-recipes ](https://github.com/gadgetron/gadgetron-conda-recipes) repo.