### PR TITLE
Minor code consistency improvements

### DIFF
--- a/gadgets/dicom/dicom_ismrmrd_utility.cpp
+++ b/gadgets/dicom/dicom_ismrmrd_utility.cpp
@@ -205,7 +205,7 @@ namespace Gadgetron
             // Accession Number
             key.set(0x0008, 0x0050);
             if (study_info.accessionNumber) {
-                snprintf(buf, BUFSIZE, "%ld", *study_info.accessionNumber);
+                snprintf(buf, BUFSIZE, "%lld", *study_info.accessionNumber);
                 write_dcm_string(dataset, key, buf);
             }
             else {

--- a/toolboxes/mri_core/mri_core_utility.cpp
+++ b/toolboxes/mri_core/mri_core_utility.cpp
@@ -1231,6 +1231,7 @@ namespace Gadgetron
 
         return DIM_NONE;
     }
+
     namespace {
         template<class T> std::map<std::string, decltype(T::value)> to_map_internal(const std::vector<T>& userparameters){
             std::map<std::string, decltype(T::value)> output_map;
@@ -1241,7 +1242,7 @@ namespace Gadgetron
         }
     }
 
-    std::map<std::string, long> to_map(const std::vector<ISMRMRD::UserParameterLong> & userparameters) {
+    std::map<std::string, std::int64_t> to_map(const std::vector<ISMRMRD::UserParameterLong> & userparameters) {
         return to_map_internal(userparameters);
     }
 
@@ -1252,6 +1253,7 @@ namespace Gadgetron
     std::map<std::string, std::string> to_map(const std::vector<ISMRMRD::UserParameterString> & userparameters) {
         return to_map_internal(userparameters);
     }
+
     ISMRMRD::ImageHeader image_header_from_acquisition(
         const ISMRMRD::AcquisitionHeader& acq_header, const ISMRMRD::IsmrmrdHeader& header, const hoNDArray<std::complex<float>>& data) {
 

--- a/toolboxes/mri_core/mri_core_utility.h
+++ b/toolboxes/mri_core/mri_core_utility.h
@@ -97,10 +97,9 @@ namespace Gadgetron
     // given the name, get the ismrmrd dim
     IsmrmrdDIM EXPORTMRICORE get_ismrmrd_dim_from_name(const std::string& name);
 
-    EXPORTMRICORE std::map<std::string,long> to_map(const std::vector<ISMRMRD::UserParameterLong>&);
+    EXPORTMRICORE std::map<std::string,std::int64_t> to_map(const std::vector<ISMRMRD::UserParameterLong>&);
     EXPORTMRICORE std::map<std::string,double> to_map(const std::vector<ISMRMRD::UserParameterDouble>&);
     EXPORTMRICORE std::map<std::string,std::string> to_map(const std::vector<ISMRMRD::UserParameterString>&);
-
 
     ISMRMRD::ImageHeader image_header_from_acquisition(const ISMRMRD::AcquisitionHeader& acq_header,const ISMRMRD::IsmrmrdHeader& header, const hoNDArray<std::complex<float>>& data );
 }


### PR DESCRIPTION
With recent changes pushed to ISMRMRD and Gadgetron, some minor inconsistencies were introduced that were not caught by the default compilation stream, but show up when building with Clang and LLVM.

The changes to ISMRMRD::UserParameterLong type tracks changes introduced to ISMRMRD [here](https://github.com/ismrmrd/ismrmrd/commit/838840dd17a1267304785b09783646d3d19ee678#diff-0499892cd7c35d5b912bdb67890e8f0c2addd905def1a312cd67585d54e33864L345).