### PR TITLE
sprintf removal from code base

### DIFF
--- a/gadgets/debugging/ImageWriterGadget.cpp
+++ b/gadgets/debugging/ImageWriterGadget.cpp
@@ -13,16 +13,16 @@ process( GadgetContainerMessage< ISMRMRD::ImageHeader>* m1,
     char filename[1024];
     switch (sizeof(T)) {
      case (8): //Complex float
-     	sprintf(filename, "out_%05d.cplx", (int)this->calls_);
+     	snprintf(filename, 1024, "out_%05d.cplx", (int)this->calls_);
      	break;
      case (4): //Real floats
- 		sprintf(filename, "out_%05d.real", (int)this->calls_);
+ 		snprintf(filename, 1024, "out_%05d.real", (int)this->calls_);
  		break;
      case (2): //Unsigned short
- 		sprintf(filename, "out_%05d.short", (int)this->calls_);
+ 		snprintf(filename, 1024, "out_%05d.short", (int)this->calls_);
  		break;
      default:
-     	sprintf(filename, "out_%05d.cplx", (int)this->calls_);
+     	snprintf(filename, 1024, "out_%05d.cplx", (int)this->calls_);
      	break;
      }
 

--- a/gadgets/moco/RegistrationAveragingGadget.h
+++ b/gadgets/moco/RegistrationAveragingGadget.h
@@ -216,38 +216,20 @@ namespace Gadgetron{
 
             // Deform moving images based on the registration
             //
-	  
+
             boost::shared_ptr<ARRAY_TYPE> deformed_moving;
             {
               GadgetronTimer timer("Applying deformation");
               deformed_moving = this->of_solver_->deform( &moving_image, deformations );
             }
-	  
-            /*{
-            // The debug code below only compiles for cuNDArrays.
-            // To use (temporarily) comment out
-            // list(APPEND CPU_GADGETS cpuRegistrationAveragingGadget.cpp)
-            // in the CMakeList.txt
-            //
-            char filename[256];
-            sprintf((char*)filename, "fixed_%d.real", phase);
-            write_nd_array<float>( fixed_image.to_host().get(), filename );
-            sprintf((char*)filename, "moving_%d.real", phase);
-            write_nd_array<float>( moving_image.to_host().get(), filename );
-            sprintf((char*)filename, "deformed_moving_%d.real", phase);
-            write_nd_array<float>( deformed_moving->to_host().get(), filename );
-            sprintf((char*)filename, "deformation_%d.real", phase);
-            write_nd_array<float>( deformations->to_host().get(), filename );
-            } */
 
-	 
             // Accumulate the deformed moving images (into one image) and add this image to the fixed image. 
             // Then divide by the number of images to get the average.
             //	  
-	  
+
             fixed_image += ((deformed_moving->get_number_of_dimensions() == 3) ? *sum(deformed_moving.get(), 2) : *deformed_moving);
             fixed_image /= ((typename ARRAY_TYPE::element_type)num_images);
-	  
+
             // Pass along averaged image
             //
 	  

--- a/gadgets/moco/RegistrationScatteringGadget.h
+++ b/gadgets/moco/RegistrationScatteringGadget.h
@@ -239,24 +239,6 @@ namespace Gadgetron{
               deformed_moving = this->of_solver_->deform( &moving_image, deformations );
             }
 	  
-            /*{
-            // The debug code below only compiles for cuNDArrays.
-            // To use (temporarily) comment out
-            // list(APPEND CPU_GADGETS cpuRegistrationScatteringGadget.cpp)
-            // in the CMakeList.txt
-            //
-            char filename[256];
-            sprintf((char*)filename, "fixed_%d.real", phase);
-            write_nd_array<float>( fixed_image.to_host().get(), filename );
-            sprintf((char*)filename, "moving_%d.real", phase);
-            write_nd_array<float>( moving_image.to_host().get(), filename );
-            sprintf((char*)filename, "deformed_moving_%d.real", phase);
-            write_nd_array<float>( deformed_moving->to_host().get(), filename );
-            sprintf((char*)filename, "deformation_%d.real", phase);
-            write_nd_array<float>( deformations->to_host().get(), filename );
-            } */
-
-
             // Pass along the deformed moving images
             //	  
 	  

--- a/gadgets/pmri/gpuCgKtSenseGadget.cpp
+++ b/gadgets/pmri/gpuCgKtSenseGadget.cpp
@@ -223,13 +223,6 @@ namespace Gadgetron{
     // Goto from x-f to x-t space
     cuNDFFT<float>::instance()->fft( cgresult.get(), 2,true );
 
-    /*
-    static int counter = 0;
-    char filename[256];
-    sprintf((char*)filename, "recon_%d.real", counter);
-    write_nd_array<float>( abs(cgresult.get())->to_host().get(), filename );
-    counter++; */
-
     // If the recon matrix size exceeds the sequence matrix size then crop
     if( matrix_size_seq_ != matrix_size_ )
       *cgresult = crop<float_complext,2>( (matrix_size_-matrix_size_seq_)>>1, matrix_size_seq_, *cgresult );

--- a/gadgets/pmri/gpuCgSenseGadget.cpp
+++ b/gadgets/pmri/gpuCgSenseGadget.cpp
@@ -178,23 +178,6 @@ namespace Gadgetron{
     //Apply dcw weights
     *device_samples *= *dcw;
 
-
-    /*{
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "_traj_%d.real", counter);
-      write_nd_array<floatd2>( traj->to_host().get(), filename );
-      sprintf((char*)filename, "_dcw_%d.real", counter);
-      write_nd_array<float>( dcw->to_host().get(), filename );
-      sprintf((char*)filename, "_csm_%d.cplx", counter);
-      write_nd_array<float_complext>( csm->to_host().get(), filename );
-      sprintf((char*)filename, "_samples_%d.cplx", counter);
-      write_nd_array<float_complext>( device_samples->to_host().get(), filename );
-      sprintf((char*)filename, "_reg_%d.cplx", counter);
-      write_nd_array<float_complext>( reg_image->to_host().get(), filename );
-      counter++; 
-      }*/
-
     // Invoke solver
     // 
     boost::shared_ptr< cuNDArray<float_complext> > cgresult;
@@ -214,14 +197,6 @@ namespace Gadgetron{
       GDEBUG("Iterative_sense_compute failed\n");
       return GADGET_FAIL;
     }
-
-    /*
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "recon_%d.real", counter);
-      write_nd_array<float>( abs(cgresult.get())->to_host().get(), filename );
-      counter++; 
-    */
 
     // If the recon matrix size exceeds the sequence matrix size then crop
     if( matrix_size_seq_ != matrix_size_ )

--- a/gadgets/pmri/gpuCgSpiritGadget.cpp
+++ b/gadgets/pmri/gpuCgSpiritGadget.cpp
@@ -182,22 +182,6 @@ namespace Gadgetron{
     D_->set_weights( precon_weights );
     */
 
-    /*{
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "_traj_%d.real", counter);
-      write_nd_array<floatd2>( traj->to_host().get(), filename );
-      sprintf((char*)filename, "_dcw_%d.real", counter);
-      write_nd_array<float>( dcw->to_host().get(), filename );
-      sprintf((char*)filename, "_csm_%d.cplx", counter);
-      write_nd_array<float_complext>( csm->to_host().get(), filename );
-      sprintf((char*)filename, "_samples_%d.cplx", counter);
-      write_nd_array<float_complext>( device_samples->to_host().get(), filename );
-      sprintf((char*)filename, "_reg_%d.cplx", counter);
-      write_nd_array<float_complext>( reg_image->to_host().get(), filename );
-      counter++; 
-      }*/
-
     // Invoke solver
     // 
 
@@ -218,14 +202,6 @@ namespace Gadgetron{
       GDEBUG("Iterative_spirit_compute failed\n");
       return GADGET_FAIL;
     }
-
-    /*
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "recon_%d.real", counter);
-      write_nd_array<float>( abs(cgresult.get())->to_host().get(), filename );
-      counter++; 
-    */
 
     // If the recon matrix size exceeds the sequence matrix size then crop
     if( matrix_size_seq_ != matrix_size_ )

--- a/gadgets/pmri/gpuGenericSensePrepGadget.cpp
+++ b/gadgets/pmri/gpuGenericSensePrepGadget.cpp
@@ -560,13 +560,6 @@ namespace Gadgetron{
           traj.reshape(&dims);
           dcw.reshape(&dims);
         }
-	
-        /*
-          static int counter = 0;
-          char filename[256];
-          sprintf((char*)filename, "reg_%d.cplx", counter);
-          write_nd_array<float_complext>( &reg_host_[idx], filename );
-          counter++; */
 
         buffer_update_needed_[idx] = false;
       }

--- a/gadgets/pmri/gpuLALMSenseGadget.cpp
+++ b/gadgets/pmri/gpuLALMSenseGadget.cpp
@@ -246,13 +246,6 @@ int gpuLALMSenseGadget::process(GadgetContainerMessage<ISMRMRD::ImageHeader> *m1
 		return GADGET_FAIL;
 	}
 
-	/*
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "recon_sb_%d.cplx", counter);
-      write_nd_array<float_complext>( sbresult->to_host().get(), filename );
-      counter++; */
-
 	// If the recon matrix size exceeds the sequence matrix size then crop
 	if( matrix_size_seq_ != matrix_size_ )
 		*result = crop<float_complext,2>( (matrix_size_-matrix_size_seq_)>>1, matrix_size_seq_, *result );

--- a/gadgets/pmri/gpuNlcgSenseGadget.cpp
+++ b/gadgets/pmri/gpuNlcgSenseGadget.cpp
@@ -290,13 +290,6 @@ namespace Gadgetron{
       return GADGET_FAIL;
     }
 
-    /*
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "recon_sb_%d.cplx", counter);
-      write_nd_array<float_complext>( sbresult->to_host().get(), filename );
-      counter++; */
-
     // If the recon matrix size exceeds the sequence matrix size then crop
     if( matrix_size_seq_ != matrix_size_ )
       *result = crop<float_complext,2>( (matrix_size_-matrix_size_seq_)>>1, matrix_size_seq_, *result );

--- a/gadgets/pmri/gpuOsSenseGadget.cpp
+++ b/gadgets/pmri/gpuOsSenseGadget.cpp
@@ -247,13 +247,6 @@ int gpuOsSenseGadget::process(GadgetContainerMessage<ISMRMRD::ImageHeader> *m1, 
 		return GADGET_FAIL;
 	}
 
-	/*
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "recon_sb_%d.cplx", counter);
-      write_nd_array<float_complext>( sbresult->to_host().get(), filename );
-      counter++; */
-
 	// If the recon matrix size exceeds the sequence matrix size then crop
 	if( matrix_size_seq_ != matrix_size_ )
 		*result = crop<float_complext,2>( (matrix_size_-matrix_size_seq_)>>1, matrix_size_seq_, *result );

--- a/gadgets/pmri/gpuSbSenseGadget.cpp
+++ b/gadgets/pmri/gpuSbSenseGadget.cpp
@@ -338,13 +338,6 @@ namespace Gadgetron{
       GDEBUG("\nSplit Bregman solver failed\n");
       return GADGET_FAIL;
     }
-    
-    /*
-      static int counter = 0;
-      char filename[256];
-      sprintf((char*)filename, "recon_sb_%d.cplx", counter);
-      write_nd_array<float_complext>( sbresult->to_host().get(), filename );
-      counter++; */
 
     // If the recon matrix size exceeds the sequence matrix size then crop
     if( matrix_size_seq_ != matrix_size_ )

--- a/gadgets/radial/gpuRadialPrepGadget.cpp
+++ b/gadgets/radial/gpuRadialPrepGadget.cpp
@@ -463,13 +463,6 @@ namespace Gadgetron{
         //
         
         reg_host_[set*slices_+slice] = *compute_reg( set, slice, new_frame_detected );
-		
-        /*
-          static int counter = 0;
-          char filename[256];
-          sprintf((char*)filename, "_reg_%d.real", counter);
-          write_nd_array<float>( abs(&reg_host_[set*slices_+slice]).get(), filename );
-          counter++; */
 
         buffer_update_needed_[set*slices_+slice] = false;
       }

--- a/gadgets/radial/gpuRadialSpiritPrepGadget.cpp
+++ b/gadgets/radial/gpuRadialSpiritPrepGadget.cpp
@@ -33,28 +33,6 @@ namespace Gadgetron{
     boost::shared_ptr< cuNDArray<float_complext> > csm =       
       estimate_spirit_kernels( csm_data.get(), 7 ); // TODO: let the kernel size be user defined
 
-
-
-/*
-    // --> START debug output
-    boost::shared_ptr< cuSpirit2DOperator<float> > C( new cuSpirit2DOperator<float>() );
-		C->set_calibration_kernels(csm);
-    static int counter = 0;
-    char filename[256];
-    cuNDFFT<float>::instance()->ifft( csm_data.get(), &dims_to_xform );
-    //boost::shared_ptr< cuSpirit2DOperator<float> > C( new cuSpirit2DOperator<float>() );
-    //C->set_calibration_kernels(csm);
-    sprintf((char*)filename, "_before_%d.real", counter);
-    write_nd_array<float>( abs(csm_data.get())->to_host().get(), filename );
-    cuNDArray<float_complext> after(csm_data->get_dimensions()); C->mult_M(csm_data.get(),&after);
-    sprintf((char*)filename, "_after_%d.real", counter);
-    write_nd_array<float>( abs(&after)->to_host().get(), filename );
-    sprintf((char*)filename, "_spirit_calibration_%d.real", counter);
-    write_nd_array<float>( abs(csm.get())->to_host().get(), filename );    
-    counter++;
-    // <-- END debug output
-*/
-
     return csm->to_host(); 
   }
   

--- a/gadgets/radial/gpuRetroGatedSensePrepGadget.cpp
+++ b/gadgets/radial/gpuRetroGatedSensePrepGadget.cpp
@@ -453,13 +453,6 @@ namespace Gadgetron{
         }            
 	
         reg_host_[set*slices_+slice] = *(reg_image->to_host());
-        
-        /*
-          static int counter = 0;
-          char filename[256];
-          sprintf((char*)filename, "reg_%d.real", counter);
-          write_nd_array<float>( abs(&reg_host_[set*slices_+slice]).get(), filename );
-          counter++;  */
 
         buffer_update_needed_[set*slices_+slice] = false;        
       }

--- a/toolboxes/log/log.cpp
+++ b/toolboxes/log/log.cpp
@@ -99,9 +99,9 @@ namespace Gadgetron
       int micros = std::chrono::duration_cast<std::chrono::microseconds>(duration).count() % 1000000;
 
       //Time the format MM-DD HH:MM:SS.uuu
-      char timestr[66];sprintf(timestr, "%02d-%02d %02d:%02d:%02d.%03d ",
-			       timeinfo->tm_mon+1, timeinfo->tm_mday,
-			       timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, micros/1000);
+      char timestr[66];snprintf(timestr, 66, "%02d-%02d %02d:%02d:%02d.%03d ",
+                                timeinfo->tm_mon+1, timeinfo->tm_mday,
+                                timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, micros/1000);
 
       fmt_str += std::string(timestr);
       append_cformatting_needed = true;
@@ -142,7 +142,7 @@ namespace Gadgetron
       } else {
 	fmt_str += std::string("[") + std::string(filename);
       }
-      char linenostr[8];sprintf(linenostr, "%d", lineno);
+      char linenostr[8];snprintf(linenostr, 8, "%d", lineno);
       fmt_str += std::string(":") + std::string(linenostr);
       fmt_str += std::string("] ");
       append_cformatting_needed = true;

--- a/toolboxes/mri/pmri/gpu/cuSpiritBuffer.cpp
+++ b/toolboxes/mri/pmri/gpu/cuSpiritBuffer.cpp
@@ -45,7 +45,7 @@ namespace Gadgetron {
 
     static int counter = 0;
     char filename[256];
-    sprintf((char*)filename, "_coil_images_%d.real", counter);
+    snprintf((char*)filename, 256, "_coil_images_%d.real", counter);
     write_nd_array<REAL>( abs(this->acc_image_.get())->to_host().get(), filename );
     counter++;
 

--- a/toolboxes/mri/pmri/gpu/spirit_calibration.cu
+++ b/toolboxes/mri/pmri/gpu/spirit_calibration.cu
@@ -198,14 +198,6 @@ namespace Gadgetron {
 
     CHECK_FOR_CUDA_ERROR();    
 
-    /*
-    static int counter = 0;
-    char filename[256];
-    sprintf((char*)filename, "_A_%d.cplx", counter);
-    write_nd_array<float_complext>( A.to_host().get(), filename );
-    counter++;
-    */
-
     // Compute A^H A
     //
 
@@ -242,14 +234,6 @@ namespace Gadgetron {
       throw std::runtime_error("estimate_spirit_kernels: CUBLAS error computing A^HA");
     }
 
-    /*
-    static int counter = 0;
-    char filename[256];
-    sprintf((char*)filename, "_AHA_%d.cplx", counter);
-    write_nd_array<float_complext>( AHA.to_host().get(), filename );
-    counter++;
-    */
-
     // Multiply A^H with each coil image (to form the rhs)
     //
 
@@ -271,15 +255,6 @@ namespace Gadgetron {
       throw std::runtime_error("estimate_spirit_kernels: CUBLAS error computing rhs");
     }
     
-    /*
-    static int counter = 0;
-    char filename[256];
-    sprintf((char*)filename, "_rhs_%d.cplx", counter);
-    write_nd_array<float_complext>( rhs.to_host().get(), filename );
-    counter++;
-    */
-
-
 
     //CGELS is used rather than a more conventional solver as it is part of CULA free.
     /*
@@ -335,14 +310,6 @@ namespace Gadgetron {
     dims_to_xform.push_back(0); dims_to_xform.push_back(1);    
     cuNDFFT<float>::instance()->ifft( kernel_images.get(), &dims_to_xform, false );
     
-    /*
-    static int counter = 0;
-    char filename[256];
-    sprintf((char*)filename, "_kernels_%d.cplx", counter);
-    write_nd_array<float_complext>( kernel_images->to_host().get(), filename );
-    counter++;
-    */
-
     return kernel_images;
   }
 }


### PR DESCRIPTION
Replace active instances of sprintf in codebase, with snprintf.

Remove commented out blocks of code, also containing sprintf.