### PR TITLE
add limits

### DIFF
--- a/core/io/from_string.h
+++ b/core/io/from_string.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <limits>
 
 namespace Gadgetron::Core::IO {
 


### PR DESCRIPTION
Adds `#include <limits>` to `core/io/from_string.h`

closes #1205 