### PR TITLE
Update gadgetron-config.cmake.in

### DIFF
--- a/cmake/gadgetron-config.cmake.in
+++ b/cmake/gadgetron-config.cmake.in
@@ -1,8 +1,7 @@
 @PACKAGE_INIT@
-
+   
 if (BUILD_PYTHON_SUPPORT)
     find_package(PythonLibs 3  REQUIRED)
-    find_package(Boost 1.65.0 COMPONENTS system program_options filesystem timer REQUIRED )
     if (Boost_VERSION_STRING VERSION_LESS 1.67.0)
         find_package(Boost 1.65.0 COMPONENTS python3 REQUIRED)
         set(Boost_PYTHON3_TARGET Boost::python3)
@@ -15,6 +14,8 @@ if (BUILD_PYTHON_SUPPORT)
     endif()
     set(GADGETRON_INSTALL_PYTHON_MODULE_PATH "@GADGETRON_INSTALL_PYTHON_MODULE_PATH@" )
 endif()
+
+find_package(Boost 1.65.0 COMPONENTS system program_options filesystem timer REQUIRED )
 
 add_definitions(-DARMA_DONT_USE_WRAPPER -DARMA_USE_CXX11 -DARMA_64BIT_WORD)
 set(GADGETRON_INSTALL_CONFIG_PATH "@GADGETRON_INSTALL_CONFIG_PATH@" )

--- a/cmake/gadgetron-config.cmake.in
+++ b/cmake/gadgetron-config.cmake.in
@@ -1,24 +1,24 @@
 @PACKAGE_INIT@
 
-
-find_package(PythonLibs 3  REQUIRED)
-find_package(Boost 1.65.0 COMPONENTS system program_options filesystem timer REQUIRED )
-if (Boost_VERSION_STRING VERSION_LESS 1.67.0)
-    find_package(Boost 1.65.0 COMPONENTS python3 REQUIRED)
-    set(Boost_PYTHON3_TARGET Boost::python3)
+if (BUILD_PYTHON_SUPPORT)
+    find_package(PythonLibs 3  REQUIRED)
+    find_package(Boost 1.65.0 COMPONENTS system program_options filesystem timer REQUIRED )
+    if (Boost_VERSION_STRING VERSION_LESS 1.67.0)
+        find_package(Boost 1.65.0 COMPONENTS python3 REQUIRED)
+        set(Boost_PYTHON3_TARGET Boost::python3)
     else()
-    string(REGEX MATCH "^3\\.([0-9]+)\\.[0-9]+" PYTHON_MINOR_VERSION ${PYTHONLIBS_VERSION_STRING} )
-    set(PYTHON_MINOR_VERSION ${CMAKE_MATCH_1})
-    find_package(Boost 1.65.0 COMPONENTS "python3${PYTHON_MINOR_VERSION}" REQUIRED)
-    set(Boost_PYTHON3_FOUND TRUE)
-    set(Boost_PYTHON3_TARGET Boost::python3${PYTHON_MINOR_VERSION})
+        string(REGEX MATCH "^3\\.([0-9]+)\\.[0-9]+" PYTHON_MINOR_VERSION ${PYTHONLIBS_VERSION_STRING} )
+        set(PYTHON_MINOR_VERSION ${CMAKE_MATCH_1})
+        find_package(Boost 1.65.0 COMPONENTS "python3${PYTHON_MINOR_VERSION}" REQUIRED)
+        set(Boost_PYTHON3_FOUND TRUE)
+        set(Boost_PYTHON3_TARGET Boost::python3${PYTHON_MINOR_VERSION})
+    endif()
+    set(GADGETRON_INSTALL_PYTHON_MODULE_PATH "@GADGETRON_INSTALL_PYTHON_MODULE_PATH@" )
 endif()
-
 
 add_definitions(-DARMA_DONT_USE_WRAPPER -DARMA_USE_CXX11 -DARMA_64BIT_WORD)
 set(GADGETRON_INSTALL_CONFIG_PATH "@GADGETRON_INSTALL_CONFIG_PATH@" )
 set(GADGETRON_INSTALL_SCHEMA_PATH "@GADGETRON_INSTALL_SCHEMA_PATH@" )
-set(GADGETRON_INSTALL_PYTHON_MODULE_PATH "@GADGETRON_INSTALL_PYTHON_MODULE_PATH@" )
 find_package(ISMRMRD REQUIRED )
 
 if(NOT TARGET gadgetron::gadgetron)


### PR DESCRIPTION
doesn't require Python when exporting the Gadgetron configuration if BUILD_PYTHON_SUPPORT is set to OFF