### PR TITLE
Update devcontainer.json to new spec

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,23 +10,44 @@
 		"DOCKER_BUILDKIT": "1",
 		"HOST_WORKSPACE_DIR": "${localWorkspaceFolder}", // The host's path to the repo's folder
 	},
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.inheritEnv": true, // this is so that the "code" executable is available from the integrated terminal
-		"cmake.configureOnOpen": true,
-		"cmake.preferredGenerators": [
-			"Ninja",
-			"Unix Makefiles"
-		],
-		"cmake.cmakePath": "/opt/conda/envs/gadgetron/bin/cmake",
-		"cmake.configureSettings": {
-			"USE_CUDA": "ON",
-			"USE_MKL": "ON",
-			"CMAKE_INSTALL_PREFIX": "/opt/conda/envs/gadgetron",
-			"BUILD_DOCUMENTATION": "ON"
-		},
-		"indentRainbow.includedLanguages": [ "yaml", "python" ]
+
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"terminal.integrated.inheritEnv": true, // this is so that the "code" executable is available from the integrated terminal
+				"cmake.configureOnOpen": true,
+				"cmake.preferredGenerators": [
+					"Ninja",
+					"Unix Makefiles"
+				],
+				"cmake.cmakePath": "/opt/conda/envs/gadgetron/bin/cmake",
+				"cmake.configureSettings": {
+					"USE_CUDA": "ON",
+					"USE_MKL": "ON",
+					"CMAKE_INSTALL_PREFIX": "/opt/conda/envs/gadgetron",
+					"BUILD_DOCUMENTATION": "ON"
+				},
+				"indentRainbow.includedLanguages": [ "yaml", "python" ]
+			},
+
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.cmake-tools",
+				"ms-vscode.live-server",
+				"eamodio.gitlens",
+				"esbenp.prettier-vscode",
+				"matepek.vscode-catch2-test-adapter",
+				"mhutchie.git-graph",
+				"ms-azuretools.vscode-docker",
+				"ms-python.python",
+				"oderwat.indent-rainbow",
+				"timonwong.shellcheck"
+			]
+		}
 	},
+
 	"runArgs": ["--init", "--network=host"],
 
 	// To enable your local GPUs in container if they are on enabled by default devcontainer will fail to start on hosts without GPU
@@ -40,20 +61,7 @@
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-vscode.cpptools",
-		"ms-vscode.cmake-tools",
-		"ms-vscode.live-server",
-		"eamodio.gitlens",
-		"esbenp.prettier-vscode",
-		"matepek.vscode-catch2-test-adapter",
-		"mhutchie.git-graph",
-		"ms-azuretools.vscode-docker",
-		"ms-python.python",
-		"oderwat.indent-rainbow",
-		"timonwong.shellcheck"
-	],
+
 	// Use the non-root user
 	"remoteUser": "vscode",
 	"features": {
@@ -67,5 +75,5 @@
 		"git": "os-provided",
 		"azure-cli": "latest"
 	},
-	"postCreateCommand": ".devcontainer/bootstrap-vscode.sh ",
+	"postCreateCommand": ".devcontainer/bootstrap-vscode.sh "
 }


### PR DESCRIPTION
This PR updates the devcontainer specification to the new json file structure to be compatible with recent versions of VScode. 

Per the devcontainer.json specification (https://containers.dev/implementors/json_reference/), all VScode customizations must be isolated to a specific "customizations" parent (https://containers.dev/supporting). 

We will likely need to modify this again to support codespaces or similar, but this should allow local VScode development containers to work with devcontainer extension versions newer than v0.275.1