### PR TITLE
Exported config fixes

### DIFF
--- a/cmake/gadgetron-config.cmake.in
+++ b/cmake/gadgetron-config.cmake.in
@@ -1,20 +1,15 @@
 @PACKAGE_INIT@
 
-find_package(Boost 1.65.0 COMPONENTS system program_options filesystem timer REQUIRED )
+find_package(Boost @Boost_VERSION_STRING@ COMPONENTS system program_options filesystem timer REQUIRED )
 
 if (@BUILD_PYTHON_SUPPORT@)
     find_package(PythonLibs 3  REQUIRED)
 
-    if (Boost_VERSION_STRING VERSION_LESS 1.67.0)
-        find_package(Boost 1.65.0 COMPONENTS python3 REQUIRED)
-        set(Boost_PYTHON3_TARGET Boost::python3)
-    else()
-        string(REGEX MATCH "^3\\.([0-9]+)\\.[0-9]+" PYTHON_MINOR_VERSION ${PYTHONLIBS_VERSION_STRING} )
-        set(PYTHON_MINOR_VERSION ${CMAKE_MATCH_1})
-        find_package(Boost 1.65.0 COMPONENTS "python3${PYTHON_MINOR_VERSION}" REQUIRED)
-        set(Boost_PYTHON3_FOUND TRUE)
-        set(Boost_PYTHON3_TARGET Boost::python3${PYTHON_MINOR_VERSION})
-    endif()
+    string(REGEX MATCH "^3\\.([0-9]+)\\.[0-9]+" PYTHON_MINOR_VERSION ${PYTHONLIBS_VERSION_STRING} )
+    set(PYTHON_MINOR_VERSION ${CMAKE_MATCH_1})
+    find_package(Boost @Boost_VERSION_STRING@ COMPONENTS "python3${PYTHON_MINOR_VERSION}" REQUIRED)
+    set(Boost_PYTHON3_FOUND TRUE)
+    set(Boost_PYTHON3_TARGET Boost::python3${PYTHON_MINOR_VERSION})
 endif()
 
 

--- a/cmake/gadgetron-config.cmake.in
+++ b/cmake/gadgetron-config.cmake.in
@@ -1,17 +1,20 @@
 @PACKAGE_INIT@
 
-
-find_package(PythonLibs 3  REQUIRED)
 find_package(Boost 1.65.0 COMPONENTS system program_options filesystem timer REQUIRED )
-if (Boost_VERSION_STRING VERSION_LESS 1.67.0)
-    find_package(Boost 1.65.0 COMPONENTS python3 REQUIRED)
-    set(Boost_PYTHON3_TARGET Boost::python3)
+
+if (@BUILD_PYTHON_SUPPORT@)
+    find_package(PythonLibs 3  REQUIRED)
+
+    if (Boost_VERSION_STRING VERSION_LESS 1.67.0)
+        find_package(Boost 1.65.0 COMPONENTS python3 REQUIRED)
+        set(Boost_PYTHON3_TARGET Boost::python3)
     else()
-    string(REGEX MATCH "^3\\.([0-9]+)\\.[0-9]+" PYTHON_MINOR_VERSION ${PYTHONLIBS_VERSION_STRING} )
-    set(PYTHON_MINOR_VERSION ${CMAKE_MATCH_1})
-    find_package(Boost 1.65.0 COMPONENTS "python3${PYTHON_MINOR_VERSION}" REQUIRED)
-    set(Boost_PYTHON3_FOUND TRUE)
-    set(Boost_PYTHON3_TARGET Boost::python3${PYTHON_MINOR_VERSION})
+        string(REGEX MATCH "^3\\.([0-9]+)\\.[0-9]+" PYTHON_MINOR_VERSION ${PYTHONLIBS_VERSION_STRING} )
+        set(PYTHON_MINOR_VERSION ${CMAKE_MATCH_1})
+        find_package(Boost 1.65.0 COMPONENTS "python3${PYTHON_MINOR_VERSION}" REQUIRED)
+        set(Boost_PYTHON3_FOUND TRUE)
+        set(Boost_PYTHON3_TARGET Boost::python3${PYTHON_MINOR_VERSION})
+    endif()
 endif()
 
 


### PR DESCRIPTION
Fixes #1211 in essentially the same way as @paskino's #1211 (which I hadn't seen when I started), but without removing the line
```
set(GADGETRON_INSTALL_PYTHON_MODULE_PATH "@GADGETRON_INSTALL_PYTHON_MODULE_PATH@" )
```
as requested by @Andrew-Dupuis 

Fixes #1228 although arguably we should have an `EXACT` version match (at least when using boost shared libraries), but as I don't understand that very well, I haven't put that in.
