### PR TITLE
IsmrmrdDumpGadget: fix locale in get_date_time_string()

### DIFF
--- a/gadgets/mri_core/IsmrmrdDumpGadget.cpp
+++ b/gadgets/mri_core/IsmrmrdDumpGadget.cpp
@@ -17,6 +17,7 @@ namespace Gadgetron
         timeinfo = localtime(&rawtime);
 
         std::stringstream str;
+        str.imbue(std::locale::classic());
         str << timeinfo->tm_year + 1900
             << std::setw(2) << std::setfill('0') << timeinfo->tm_mon + 1
             << std::setw(2) << std::setfill('0') << timeinfo->tm_mday


### PR DESCRIPTION
Depending on the system's default locale, it can happen that decimal separators are used in the year string, e.g. "2023" becomes "2,023". This leads to ugly ISMRMD file names. This commit fixes this issue by making sure that the date_time string uses the "C" locale.