### PR TITLE
Removed unnecessary dependency runs

### DIFF
--- a/test/integration/cases/epi_2d.cfg
+++ b/test/integration/cases/epi_2d.cfg
@@ -1,11 +1,4 @@
 
-[dependency.siemens]
-data_file=epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
-measurement=1
-
-[dependency.client]
-configuration=default_measurement_dependencies.xml
-
 [reconstruction.siemens]
 data_file=epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
 measurement=2

--- a/test/integration/cases/generic_nl_spirit_cartesian_sampling_cine.cfg
+++ b/test/integration/cases/generic_nl_spirit_cartesian_sampling_cine.cfg
@@ -1,11 +1,4 @@
 
-[dependency.siemens]
-data_file=generic/meas_MID836_1slice_FID22517/meas_MID836_1slice_FID22517.dat
-measurement=1
-
-[dependency.client]
-configuration=default_measurement_dependencies.xml
-
 [reconstruction.siemens]
 data_file=generic/meas_MID836_1slice_FID22517/meas_MID836_1slice_FID22517.dat
 measurement=2


### PR DESCRIPTION
A couple of tests are running dependencies when they are not used (because the noise is inline in main data file). 