### PR TITLE
Moving the test suit to use PyTest

### DIFF
--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,8 @@
+*#
+.#*
+*~
+data/
+test/
+*.log
+index.html
+test_cases.txt

--- a/test/e2e/cases/cmr_cine_binning.yml
+++ b/test/e2e/cases/cmr_cine_binning.yml
@@ -1,0 +1,24 @@
+cases:
+- name: cmr_cine_binning
+  tags:
+  - slow
+  dependency:
+    data_file: cmr/CineBinning/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8.dat
+    measurement: 1
+    data_file_hash: 8be03b636dc08f4f8cd0412874b9f101
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: cmr/CineBinning/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8.dat
+    measurement: 2
+    data_file_hash: 8be03b636dc08f4f8cd0412874b9f101
+    configuration: CMR_2DT_RTCine_KspaceBinning.xml
+  validation:
+    images:
+      CMR_2DT_RTCine_KspaceBinning.xml/image_2:
+        reference_file: cmr/CineBinning/meas_MID00247_FID39104_PK_realtime_gt_TPAT4_6_8/cmr_cine_binning_ref_20220817.mrd
+        reference_file_hash: 50f1fe4c36a5b7123c0358b8036d4a23
+        reference_image: CMR_2DT_RTCine_KspaceBinning.xml/image_2
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 16384

--- a/test/e2e/cases/cmr_cine_binning_2slices.yml
+++ b/test/e2e/cases/cmr_cine_binning_2slices.yml
@@ -1,0 +1,19 @@
+cases:
+- name: cmr_cine_binning_2slices
+  tags:
+  - slow
+  reconstruction:
+    data_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
+    measurement: 2
+    data_file_hash: 7f52ef8abeb44b7a23648b195307ccc8
+    configuration: CMR_2DT_RTCine_KspaceBinning.xml
+  validation:
+    images:
+      CMR_2DT_RTCine_KspaceBinning.xml/image_2:
+        reference_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd
+        reference_file_hash: ddd08991b7837dc37d7457cc74fb40cb
+        reference_image: CMR_2DT_RTCine_KspaceBinning.xml/image_2
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 8192

--- a/test/e2e/cases/cmr_cine_binning_2slices_distributed.yml
+++ b/test/e2e/cases/cmr_cine_binning_2slices_distributed.yml
@@ -18,4 +18,5 @@ cases:
         value_comparison_threshold: 0.01
   requirements:
     system_memory: 8192
-  nodes: 2
+  distributed:
+    nodes: 2

--- a/test/e2e/cases/cmr_cine_binning_2slices_distributed.yml
+++ b/test/e2e/cases/cmr_cine_binning_2slices_distributed.yml
@@ -1,0 +1,21 @@
+cases:
+- name: cmr_cine_binning_2slices_distributed
+  tags:
+  - slow
+  - distributed
+  reconstruction:
+    data_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
+    measurement: 2
+    data_file_hash: 7f52ef8abeb44b7a23648b195307ccc8
+    configuration: CMR_2DT_RTCine_KspaceBinning_Cloud.xml
+  validation:
+    images:
+      CMR_2DT_RTCine_KspaceBinning_Cloud.xml/image_2:
+        reference_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd
+        reference_file_hash: ddd08991b7837dc37d7457cc74fb40cb
+        reference_image: CMR_2DT_RTCine_KspaceBinning.xml/image_2
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 8192
+  nodes: 2

--- a/test/e2e/cases/cmr_mapping_t1_sr.yml
+++ b/test/e2e/cases/cmr_mapping_t1_sr.yml
@@ -1,0 +1,43 @@
+cases:
+- name: cmr_mapping_t1_sr
+  tags:
+  - fast
+  dependency:
+    data_file: cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256.dat
+    measurement: 1
+    data_file_hash: dc4f02e31f84b641e41a485c2762054f
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256.dat
+    measurement: 2
+    data_file_hash: dc4f02e31f84b641e41a485c2762054f
+    parameter_xsl: IsmrmrdParameterMap_Siemens_T1Mapping_SASHA.xsl
+    configuration: CMR_2DT_T1Mapping_SASHA.xml
+  validation:
+    images:
+      CMR_2DT_T1Mapping_SASHA.xml/image_1:
+        reference_file: cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.mrd
+        reference_file_hash: 3e213dd4c8f97baa9adfc6b2859147c5
+        reference_image: CMR_2DT_T1Mapping_SASHA.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+      CMR_2DT_T1Mapping_SASHA.xml/image_12:
+        reference_file: cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.mrd
+        reference_file_hash: 3e213dd4c8f97baa9adfc6b2859147c5
+        reference_image: CMR_2DT_T1Mapping_SASHA.xml/image_12
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+      CMR_2DT_T1Mapping_SASHA.xml/image_11:
+        reference_file: cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.mrd
+        reference_file_hash: 3e213dd4c8f97baa9adfc6b2859147c5
+        reference_image: CMR_2DT_T1Mapping_SASHA.xml/image_11
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+      CMR_2DT_T1Mapping_SASHA.xml/image_20:
+        reference_file: cmr/T1SRmapping/meas_MID00613_FID40909_pre_SASHA_10pt_TS600_256/ref_20170427.mrd
+        reference_file_hash: 3e213dd4c8f97baa9adfc6b2859147c5
+        reference_image: CMR_2DT_T1Mapping_SASHA.xml/image_20
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 16384

--- a/test/e2e/cases/convert.py
+++ b/test/e2e/cases/convert.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python3
+
+import json
+import configparser
+import os
+import sys
+import yaml
+
+from pathlib import Path
+
+def load_data(file:Path):
+    data_map = {}
+    
+    with open(file, 'r') as list:
+        entries = json.load(list)
+
+        for entry in entries:
+            data_map[entry['file']] = entry['md5']
+    
+    return data_map
+
+
+def read_config(file: Path, file_data):
+    config_data = {}
+
+    config = configparser.ConfigParser()
+    config.read(file)
+
+    filename = os.path.basename(file)
+    config_data['name'] = os.path.splitext(filename)[0]
+
+    config_data['tags'] = []
+
+    def lookup_hash(file_name):
+        if not file_name in file_data:
+            print("Hash not found for {}".format(file_name))
+            return ""
+
+        else:
+            return file_data[file_name]
+
+    def add_tags(tags):
+        config_data['tags'] += tags
+
+    for section in config:
+        config_section = section.split('.')[0]
+
+        if config_section == 'dependency' or config_section == 'reconstruction':
+            if not config_section in config_data:
+                config_data[config_section] = {}
+
+        if section == 'dependency.siemens' or section == 'reconstruction.siemens':
+            data_file = config[section]['data_file']
+
+            config_data[config_section]['data_file'] = data_file
+            config_data[config_section]['measurement'] = int(config[section]['measurement'])
+            config_data[config_section]['data_file_hash'] = lookup_hash(data_file)
+
+            if 'parameter_xml' in config[section]:
+                config_data[config_section]['parameter_xml'] = config[section]['parameter_xml']
+
+            if 'parameter_xsl' in config[section]:
+                config_data[config_section]['parameter_xsl'] = config[section]['parameter_xsl']
+
+            if 'data_conversion_flag' in config[section]:
+                config_data[config_section]['data_conversion_flag'] = config[section]['data_conversion_flag']
+
+            if 'additional_arguments' in config[section]:
+                config_data[config_section]['additional_arguments'] = config[section]['additional_arguments']
+
+        elif section == 'dependency.client' or section == 'reconstruction.client':
+            if 'configuration' in config[section]:
+                config_data[config_section]['configuration'] = config[section]['configuration']
+            
+            elif 'template' in config[section]:
+                config_data[config_section]['template'] = config[section]['template']
+            
+            else:
+                print("{} missing configuration or template".format(section))
+
+        elif section == 'reconstruction.copy':
+            copy_file = config[section]['source']
+
+            config_data[config_section]['copy_file'] = copy_file
+            config_data[config_section]['copy_file_hash'] = lookup_hash(copy_file)
+
+        elif section.startswith('reconstruction.test'):
+            if not 'validation' in config_data:
+                config_data['validation'] = {}
+            
+            if not 'images' in config_data['validation']:
+                config_data['validation']['images'] = {}
+
+            output_image = config[section]['output_images']
+            if output_image in config_data['validation']['images']:
+                print("output image {} duplicated".format(output_image))
+            
+            config_data['validation']['images'][output_image] = {}
+            output_group = config_data['validation']['images'][output_image]
+
+            reference_file = config[section]['reference_file']
+            output_group['reference_file'] = reference_file
+
+            output_group['reference_file_hash'] = lookup_hash(reference_file)
+
+            output_group['reference_image'] = config[section]['reference_images']
+            
+            if 'scale_comparison_threshold' in config[section]:
+                output_group['scale_comparison_threshold'] = float(config[section]['scale_comparison_threshold'])
+            else:
+                output_group['scale_comparison_threshold'] = 0.01
+
+            if 'value_comparison_threshold' in config[section]:
+                output_group['value_comparison_threshold'] = float(config[section]['value_comparison_threshold'])
+            else:
+                output_group['value_comparison_threshold'] = 0.01
+
+            if 'disable_image_header_test' in config[section]:
+                output_group['disable_image_header_test'] = bool(config[section]['disable_image_header_test'])
+
+            if 'disable_image_meta_test' in config[section]:
+                output_group['disable_image_meta_test'] = bool(config[section]['disable_image_meta_test'])
+
+        # elif section == 'dependency.stream':
+        #     config_data[config_section]['stream_configuration'] = config[section]['configuration']
+
+        #     if 'args' in config[section]:
+        #         config_data[config_section]['stream_args'] = config[section]['args']
+
+        #     add_tags(['stream'])
+
+        elif section.startswith('reconstruction.stream') or section.startswith('dependency.stream'):
+            if not 'stream' in config_data[config_section]:
+                config_data[config_section]['stream'] = []
+
+            stream_data = {}
+            stream_data['configuration'] = config[section]['configuration']
+
+            if 'args' in config[section]:
+                stream_data['args'] = config[section]['args']
+
+            config_data[config_section]['stream'].append(stream_data)
+
+            add_tags(['stream'])
+
+        elif section =='dependency.adapter' or section =='reconstruction.adapter':
+            config_data[config_section]['input_adapter'] = config[section]['input_adapter']
+            config_data[config_section]['output_adapter'] = config[section]['output_adapter']
+            config_data[config_section]['output_group'] = config[section]['output_group']
+
+            add_tags(['stream'])
+
+        elif section == 'reconstruction.equals':            
+            if not 'validation' in config_data:
+                config_data['validation'] = {}
+
+            config_data['validation']['equals'] = {}
+
+            reference_file = config[section]['reference_file']
+            config_data['validation']['equals']['reference_file'] = reference_file
+            config_data['validation']['equals']['reference_file_hash'] = lookup_hash(reference_file)
+            config_data['validation']['equals']['dataset_prefix'] = config[section]['dataset_prefix']
+            
+            add_tags(['validate'])
+
+            continue
+
+        elif section == 'tags':
+            tags = config[section]['tags'].split(',')
+            add_tags(tags)
+
+        elif section == 'requirements':
+            config_data['requirements'] = {}
+            
+            for entry in config[section]:
+                config_data['requirements'][entry] = int(config[section][entry])
+
+            continue
+
+        elif section == 'distributed':
+            config_data['nodes'] = int(config[section]['nodes'])
+
+        elif section != 'DEFAULT':
+            print(section)
+
+    config_data['tags'] = list(set(config_data['tags']))
+    
+    return config_data
+    
+
+case_path = "../../integration/cases/"
+
+def main():
+    file_data = load_data("../../integration/data.json")
+
+    # output = {}
+    # output['cases'] = []
+
+    cases = []
+
+    for file in os.listdir(case_path):
+        config = read_config(os.path.join(case_path, file), file_data)
+        cases.append(config)
+        # yaml.dump(config, sys.stdout)
+
+        # break
+
+    # def sort_funct(e):
+    #     return len(e)
+
+    cases.sort(key=lambda x: (x['name']))
+
+    for output in cases:
+        with open(output['name'] + '.yml', 'w') as out:
+            output_data = {}
+            output_data['cases'] = []
+            output_data['cases'].append(output)
+            yaml.dump(output_data, out, sort_keys=False)        
+
+
+    
+    # config = read_config(os.path.join(case_path, "external_matlab_tiny_example.cfg"), file_data)
+    output_data = {}
+    output_data['cases'] = cases
+
+    yaml.dump(output_data, sys.stdout, sort_keys=False)
+
+    
+
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+
+# import code
+
+# code.interact(local=locals())

--- a/test/e2e/cases/convert.py
+++ b/test/e2e/cases/convert.py
@@ -178,7 +178,10 @@ def read_config(file: Path, file_data):
             continue
 
         elif section == 'distributed':
-            config_data['nodes'] = int(config[section]['nodes'])
+            config_data['distributed'] = {}
+            config_data['distributed']['nodes'] = int(config[section]['nodes'])
+            if 'node_port_base' in config[section]:
+                config_data['distributed']['node_port_base'] = int(config[section]['node_port_base'])
 
         elif section != 'DEFAULT':
             print(section)

--- a/test/e2e/cases/cpu_grappa_simple.yml
+++ b/test/e2e/cases/cpu_grappa_simple.yml
@@ -1,0 +1,19 @@
+cases:
+- name: cpu_grappa_simple
+  tags:
+  - fast
+  reconstruction:
+    data_file: rtgrappa/acc_data_with_device_2.dat
+    measurement: 1
+    data_file_hash: ac0b59c6c8989c94738e41e2c4b5ec13
+    configuration: grappa_float_cpu.xml
+  validation:
+    images:
+      grappa_float_cpu.xml/image_0:
+        reference_file: rtgrappa/grappa_rate2_cpu_out.mrd
+        reference_file_hash: 5fb75eefe3828a74cffe7da6f521d841
+        reference_image: grappa_float_cpu.xml/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.1
+  requirements:
+    system_memory: 2048

--- a/test/e2e/cases/distributed_buffer_simple_gre.yml
+++ b/test/e2e/cases/distributed_buffer_simple_gre.yml
@@ -1,0 +1,21 @@
+cases:
+- name: distributed_buffer_simple_gre
+  tags:
+  - fast
+  - distributed
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: distributed_generic_default.xml
+  validation:
+    images:
+      distributed_generic_default.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: default.xml/image_0
+        scale_comparison_threshold: 1.0e-05
+        value_comparison_threshold: 1.0e-05
+  requirements:
+    system_memory: 1024
+  nodes: 1

--- a/test/e2e/cases/distributed_buffer_simple_gre.yml
+++ b/test/e2e/cases/distributed_buffer_simple_gre.yml
@@ -18,4 +18,5 @@ cases:
         value_comparison_threshold: 1.0e-05
   requirements:
     system_memory: 1024
-  nodes: 1
+  distributed:
+    nodes: 1

--- a/test/e2e/cases/distributed_image_simple_gre.yml
+++ b/test/e2e/cases/distributed_image_simple_gre.yml
@@ -1,0 +1,21 @@
+cases:
+- name: distributed_image_simple_gre
+  tags:
+  - fast
+  - distributed
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: distributed_image_default.xml
+  validation:
+    images:
+      distributed_image_default.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: default.xml/image_0
+        scale_comparison_threshold: 1.0e-05
+        value_comparison_threshold: 1.0e-05
+  requirements:
+    system_memory: 1024
+  nodes: 2

--- a/test/e2e/cases/distributed_image_simple_gre.yml
+++ b/test/e2e/cases/distributed_image_simple_gre.yml
@@ -18,4 +18,5 @@ cases:
         value_comparison_threshold: 1.0e-05
   requirements:
     system_memory: 1024
-  nodes: 2
+  distributed:
+    nodes: 2

--- a/test/e2e/cases/distributed_simple_gre.yml
+++ b/test/e2e/cases/distributed_simple_gre.yml
@@ -18,4 +18,5 @@ cases:
         value_comparison_threshold: 1.0e-05
   requirements:
     system_memory: 1024
-  nodes: 2
+  distributed:
+    nodes: 2

--- a/test/e2e/cases/distributed_simple_gre.yml
+++ b/test/e2e/cases/distributed_simple_gre.yml
@@ -1,0 +1,21 @@
+cases:
+- name: distributed_simple_gre
+  tags:
+  - fast
+  - distributed
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: distributed_default.xml
+  validation:
+    images:
+      distributed_default.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: default.xml/image_0
+        scale_comparison_threshold: 1.0e-05
+        value_comparison_threshold: 1.0e-05
+  requirements:
+    system_memory: 1024
+  nodes: 2

--- a/test/e2e/cases/epi_2d.yml
+++ b/test/e2e/cases/epi_2d.yml
@@ -1,0 +1,25 @@
+cases:
+- name: epi_2d
+  tags:
+  - ''
+  dependency:
+    data_file: epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
+    measurement: 1
+    data_file_hash: 8790d64a101acdc7b6990dd414b14be6
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
+    measurement: 2
+    data_file_hash: 8790d64a101acdc7b6990dd414b14be6
+    parameter_xsl: IsmrmrdParameterMap_Siemens_EPI.xsl
+    configuration: epi.xml
+  validation:
+    images:
+      epi.xml/image_0:
+        reference_file: epi/epi_2d_out_20161020_pjv.mrd
+        reference_file_hash: cd39f21d02ed6d434f91f8418632f64d
+        reference_image: epi.xml/image_0
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.001
+  requirements:
+    system_memory: 1024

--- a/test/e2e/cases/external_equivalent_example.yml
+++ b/test/e2e/cases/external_equivalent_example.yml
@@ -1,0 +1,19 @@
+cases:
+- name: external_equivalent_example
+  tags:
+  - external
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_equivalent_example.xml
+  validation:
+    images:
+      external_equivalent_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements: {}

--- a/test/e2e/cases/external_julia_acquisition_example.yml
+++ b/test/e2e/cases/external_julia_acquisition_example.yml
@@ -1,0 +1,19 @@
+cases:
+- name: external_julia_acquisition_example
+  tags:
+  - external
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_julia_acquisition_example.xml
+  validation:
+    images:
+      external_julia_acquisition_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements:
+    julia_support: 1

--- a/test/e2e/cases/external_matlab_acquisition_example.yml
+++ b/test/e2e/cases/external_matlab_acquisition_example.yml
@@ -1,0 +1,19 @@
+cases:
+- name: external_matlab_acquisition_example
+  tags:
+  - external
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_matlab_acquisition_example.xml
+  validation:
+    images:
+      external_matlab_acquisition_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements:
+    matlab_support: 1

--- a/test/e2e/cases/external_matlab_bucket_example.yml
+++ b/test/e2e/cases/external_matlab_bucket_example.yml
@@ -1,0 +1,19 @@
+cases:
+- name: external_matlab_bucket_example
+  tags:
+  - external
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_matlab_bucket_example.xml
+  validation:
+    images:
+      external_matlab_bucket_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements:
+    matlab_support: 1

--- a/test/e2e/cases/external_matlab_buffer_example.yml
+++ b/test/e2e/cases/external_matlab_buffer_example.yml
@@ -1,0 +1,19 @@
+cases:
+- name: external_matlab_buffer_example
+  tags:
+  - external
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_matlab_buffer_example.xml
+  validation:
+    images:
+      external_matlab_buffer_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements:
+    matlab_support: 1

--- a/test/e2e/cases/external_matlab_tiny_example.yml
+++ b/test/e2e/cases/external_matlab_tiny_example.yml
@@ -1,0 +1,21 @@
+cases:
+- name: external_matlab_tiny_example
+  tags:
+  - external
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_matlab_tiny_example.xml
+  validation:
+    images:
+      external_matlab_tiny_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+        disable_image_header_test: true
+        disable_image_meta_test: true
+  requirements:
+    matlab_support: 1

--- a/test/e2e/cases/external_python_acquisition_example.yml
+++ b/test/e2e/cases/external_python_acquisition_example.yml
@@ -1,0 +1,20 @@
+cases:
+- name: external_python_acquisition_example
+  tags:
+  - external
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_python_acquisition_example.xml
+  validation:
+    images:
+      external_python_acquisition_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements:
+    python_support: 1

--- a/test/e2e/cases/external_python_bucket_example.yml
+++ b/test/e2e/cases/external_python_bucket_example.yml
@@ -1,0 +1,20 @@
+cases:
+- name: external_python_bucket_example
+  tags:
+  - external
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_python_bucket_example.xml
+  validation:
+    images:
+      external_python_bucket_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements:
+    python_support: 1

--- a/test/e2e/cases/external_python_buffer_example.yml
+++ b/test/e2e/cases/external_python_buffer_example.yml
@@ -1,0 +1,20 @@
+cases:
+- name: external_python_buffer_example
+  tags:
+  - external
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: external_python_buffer_example.xml
+  validation:
+    images:
+      external_python_buffer_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.0001
+        value_comparison_threshold: 0.0001
+  requirements:
+    python_support: 1

--- a/test/e2e/cases/fs_csi.yml
+++ b/test/e2e/cases/fs_csi.yml
@@ -1,0 +1,20 @@
+cases:
+- name: fs_csi
+  tags:
+  - ''
+  reconstruction:
+    copy_file: matlab/Kidney4cmSlice.mrd
+    copy_file_hash: 54ffc7676ddfeb30349b59be4332dc7f
+    configuration: FS-CSI.xml
+  validation:
+    images:
+      FS-CSI.xml/image_0:
+        reference_file: hyper/Kidney4cmSlice_sb_outV4.mrd
+        reference_file_hash: 5d60164716a42f5d3b171a4caa41e098
+        reference_image: FS-CSI.xml/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/generic_cartesian_cine_denoise.yml
+++ b/test/e2e/cases/generic_cartesian_cine_denoise.yml
@@ -1,0 +1,24 @@
+cases:
+- name: generic_cartesian_cine_denoise
+  tags:
+  - generic
+  dependency:
+    data_file: generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+    measurement: 1
+    data_file_hash: a57b19a8913be3cf35d5b4827b5f5cea
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+    measurement: 2
+    data_file_hash: a57b19a8913be3cf35d5b4827b5f5cea
+    configuration: Generic_Cartesian_Grappa_Cine_Denoise.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_Cine_Denoise.xml/image_1:
+        reference_file: denoise/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/denoise_ref_20220817.mrd
+        reference_file_hash: 04ab1a2a97796132d7d395321ba65368
+        reference_image: Generic_Cartesian_Grappa_Cine_Denoise.xml/image_1
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.005
+  requirements:
+    system_memory: 6000

--- a/test/e2e/cases/generic_cartesian_cine_python.yml
+++ b/test/e2e/cases/generic_cartesian_cine_python.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_cartesian_cine_python
+  tags:
+  - generic
+  dependency:
+    data_file: generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+    measurement: 1
+    data_file_hash: a57b19a8913be3cf35d5b4827b5f5cea
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+    measurement: 2
+    data_file_hash: a57b19a8913be3cf35d5b4827b5f5cea
+    configuration: Generic_Cartesian_Grappa_RealTimeCine_Python.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_RealTimeCine_Python.xml/image_1:
+        reference_file: generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/ref/ref_20220831.mrd
+        reference_file_hash: 0ca254fd8815277028afaea9def05945
+        reference_image: Generic_Cartesian_Grappa_RealTimeCine_Python.xml/image_1
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.005
+  requirements:
+    system_memory: 6384
+    python_support: 1

--- a/test/e2e/cases/generic_grappa2x1_3d.yml
+++ b/test/e2e/cases/generic_grappa2x1_3d.yml
@@ -1,0 +1,19 @@
+cases:
+- name: generic_grappa2x1_3d
+  tags:
+  - slow
+  - generic
+  reconstruction:
+    copy_file: grappa_3d/gre_3D_Grappa2x1.mrd
+    copy_file_hash: b04554e30e3dc39b60d8f676f806ed7b
+    configuration: Generic_Cartesian_Grappa.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa.xml/image_1:
+        reference_file: grappa_3d/grappa2x1_ref_20210917.mrd
+        reference_file_hash: 24661b6b41a12577a484e74dbca6509b
+        reference_image: Generic_Cartesian_Grappa.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa2x2_3d.yml
+++ b/test/e2e/cases/generic_grappa2x2_3d.yml
@@ -1,0 +1,19 @@
+cases:
+- name: generic_grappa2x2_3d
+  tags:
+  - slow
+  - generic
+  reconstruction:
+    copy_file: grappa_3d/gre_3D_Grappa2x2.mrd
+    copy_file_hash: cf7ff3858fefebdd741036b5fb017407
+    configuration: Generic_Cartesian_Grappa.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa.xml/image_1:
+        reference_file: grappa_3d/grappa2x2_ref_20210917.mrd
+        reference_file_hash: 18ca7e1adc923ebdbe577ffada28add9
+        reference_image: Generic_Cartesian_Grappa.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_T2W.yml
+++ b/test/e2e/cases/generic_grappa_T2W.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_T2W
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: T2W/meas_MID00057_T2w.dat
+    measurement: 1
+    data_file_hash: 46aa75c471a41c793006328a224a4001
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: T2W/meas_MID00057_T2w.dat
+    measurement: 2
+    data_file_hash: 46aa75c471a41c793006328a224a4001
+    configuration: Generic_Cartesian_Grappa_T2W.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_T2W.xml/image_1:
+        reference_file: T2W/generic_grappa_T2W_ref_20220817_klk.mrd
+        reference_file_hash: b13b4d961a1fe24fec79f20e6d126bef
+        reference_image: Generic_Cartesian_Grappa_T2W.xml/image_1
+        scale_comparison_threshold: 0.075
+        value_comparison_threshold: 0.075
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_T2W.yml
+++ b/test/e2e/cases/generic_grappa_T2W.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_T2W
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: T2W/meas_MID00057_T2w.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_epi_ave.yml
+++ b/test/e2e/cases/generic_grappa_epi_ave.yml
@@ -1,0 +1,21 @@
+cases:
+- name: generic_grappa_epi_ave
+  tags:
+  - generic
+  reconstruction:
+    data_file: epi_ave/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron.dat
+    measurement: 1
+    data_file_hash: 7afdcf271e6aa53952ee8c0a0291acd9
+    parameter_xsl: IsmrmrdParameterMap_Siemens_EPI_FLASHREF.xsl
+    data_conversion_flag: --flashPatRef
+    configuration: Generic_Cartesian_Grappa_EPI_AVE.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_EPI_AVE.xml/image_1:
+        reference_file: epi_ave/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron/ref_20161020.mrd
+        reference_file_hash: 6bed66d191c14bd442b6214a6fd0db7d
+        reference_image: Generic_Cartesian_Grappa_EPI_AVE.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R1_PEFOV100_PERes100
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+    measurement: 1
+    data_file_hash: 9433b049a4de470c436cfab6f14405d1
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+    measurement: 2
+    data_file_hash: 9433b049a4de470c436cfab6f14405d1
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/ref_20160401.mrd
+        reference_file_hash: 4aed35caae0fd83ecc43a712f08df12b
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R1_PEFOV100_PERes100
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R1_PEFOV100_PERes100_compression
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes100_compression.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R1_PEFOV100_PERes100_compression
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+    measurement: 1
+    data_file_hash: 9433b049a4de470c436cfab6f14405d1
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+    measurement: 2
+    data_file_hash: 9433b049a4de470c436cfab6f14405d1
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/ref_20160401.mrd
+        reference_file_hash: 4aed35caae0fd83ecc43a712f08df12b
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes120.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R1_PEFOV100_PERes120
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/meas_MID00423_FID114625_R1_PEFOV100_PERes120.dat
+    measurement: 1
+    data_file_hash: ff15817263ff985ec854d606f1011f10
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/meas_MID00423_FID114625_R1_PEFOV100_PERes120.dat
+    measurement: 2
+    data_file_hash: ff15817263ff985ec854d606f1011f10
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/ref_20160401.mrd
+        reference_file_hash: 8942d065ca81d4433b3fe183016891bb
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV100_PERes120.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R1_PEFOV100_PERes120
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00423_FID114625_R1_PEFOV100_PERes120/meas_MID00423_FID114625_R1_PEFOV100_PERes120.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R1_PEFOV75_PERes75
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/meas_MID00394_FID114596_R1_PEFOV75_PERes75.dat
+    measurement: 1
+    data_file_hash: 115cf53bf0ff85db7344cbb0a6adac1c
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/meas_MID00394_FID114596_R1_PEFOV75_PERes75.dat
+    measurement: 2
+    data_file_hash: 115cf53bf0ff85db7344cbb0a6adac1c
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/ref_20160401.mrd
+        reference_file_hash: 9834d05bf10f7029b10a8aa3d1ba594f
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R1_PEFOV75_PERes75
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00394_FID114596_R1_PEFOV75_PERes75/meas_MID00394_FID114596_R1_PEFOV75_PERes75.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8.dat
+    measurement: 1
+    data_file_hash: 1a0756fdc5d707b02270067780bf0719
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8.dat
+    measurement: 2
+    data_file_hash: 1a0756fdc5d707b02270067780bf0719
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/ref_20160401.mrd
+        reference_file_hash: 0f5ccb2dc0644ededaab028450e188ee
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8/meas_MID00395_FID114597_R1_PEFOV75_PERes75_PF6_8.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 1
+    data_file_hash: f44eda3419c2e6aed97884aa658ad55c
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 2
+    data_file_hash: f44eda3419c2e6aed97884aa658ad55c
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00396_FID114598_R1_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20160401.mrd
+        reference_file_hash: 63ef2b89f3c4968efc8d2f368a45f85f
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
+++ b/test/e2e/cases/generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+    measurement: 1
+    data_file_hash: d237ab4536d8e59c2b9625ad8e67030b
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+    measurement: 2
+    data_file_hash: d237ab4536d8e59c2b9625ad8e67030b
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00397_FID114599_R1_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/ref_20160401.mrd
+        reference_file_hash: a5e1e4f479ca6c61bad7d27571b3b1eb
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120.dat
+    measurement: 1
+    data_file_hash: 31f3571d6f0f37d33a72f9336d89ad35
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120.dat
+    measurement: 2
+    data_file_hash: 31f3571d6f0f37d33a72f9336d89ad35
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/ref_20220817_klk.mrd
+        reference_file_hash: 7d9a0cac661301051b3a6f0c4e313c89
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PEOverSampling120
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120/meas_MID00077_FID115844_R2_ipat_PEFOV75_PERes75_PEOverSampling120.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 1
+    data_file_hash: 52be93bd932ef175375f4d74284acd0a
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 2
+    data_file_hash: 52be93bd932ef175375f4d74284acd0a
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00411_FID114613_R2_ipat_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20160401.mrd
+        reference_file_hash: ddee624846830fbaacd7d71a4d618284
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_spat_PEFOV100_PERes100
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100.dat
+    measurement: 1
+    data_file_hash: 2d955c2c6ae1ce40224ecf80c79d7d74
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100.dat
+    measurement: 2
+    data_file_hash: 2d955c2c6ae1ce40224ecf80c79d7d74
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/ref_20160401.mrd
+        reference_file_hash: 5f02a6ca8e1cce985f67ed9df8b747bb
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes100.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_spat_PEFOV100_PERes100
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100/meas_MID00398_FID114600_R2_spat_PEFOV100_PERes100.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes120.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_spat_PEFOV100_PERes120
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV100_PERes120.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_spat_PEFOV100_PERes120
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120.dat
+    measurement: 1
+    data_file_hash: e1ae8638846e3d133e84a8bbd8d8ed4a
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120.dat
+    measurement: 2
+    data_file_hash: e1ae8638846e3d133e84a8bbd8d8ed4a
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00424_FID114626_R2_spat__PEFOV100_PERes120/ref_20160401.mrd
+        reference_file_hash: 9674d7bdfee72b0508a955375a137de4
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_spat_PEFOV75_PERes75
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_spat_PEFOV75_PERes75
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75.dat
+    measurement: 1
+    data_file_hash: ca4683fa5a5bf2d057bc9d5e203643c7
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75.dat
+    measurement: 2
+    data_file_hash: ca4683fa5a5bf2d057bc9d5e203643c7
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00399_FID114601_R2_spat_PEFOV75_PERes75/ref_20160401.mrd
+        reference_file_hash: ae9a034a3ec57fb57229232cc06f2467
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8.dat
+    measurement: 1
+    data_file_hash: f3182562b4e202b0446dbb7a8a7deda4
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8.dat
+    measurement: 2
+    data_file_hash: f3182562b4e202b0446dbb7a8a7deda4
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/ref_20160401.mrd
+        reference_file_hash: d6e28bef0b899a95ab766c320cfb2f9c
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8/meas_MID00400_FID114602_R2_spat_PEFOV75_PERes75_PF6_8.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 1
+    data_file_hash: c12325e0bd2f24fd5d379ddebe3a97c0
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 2
+    data_file_hash: c12325e0bd2f24fd5d379ddebe3a97c0
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00401_FID114603_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20160401.mrd
+        reference_file_hash: bd389f001f645face35523932c6822ce
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+    measurement: 1
+    data_file_hash: beb93e9b2169ae4ea803a7727103b618
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON.dat
+    measurement: 2
+    data_file_hash: beb93e9b2169ae4ea803a7727103b618
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00402_FID114604_R2_spat_PEFOV75_PERes75_PF6_8_AsymStrong_InterpON/ref_20160401.mrd
+        reference_file_hash: 7abcd80112b08130407b92f26d36aea8
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_tpat_PEFOV100_PERes100
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100.dat
+    measurement: 1
+    data_file_hash: ea7ef158bed1725e470d9d7d8e50117a
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100.dat
+    measurement: 2
+    data_file_hash: ea7ef158bed1725e470d9d7d8e50117a
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/ref_20160401.mrd
+        reference_file_hash: 1565286f29c7be893cbf4b6126a1ec15
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV100_PERes100.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_tpat_PEFOV100_PERes100
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100/meas_MID00403_FID114605_R2_tpat_PEFOV100_PERes100.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_tpat_PEFOV75_PERes75
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_tpat_PEFOV75_PERes75
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75.dat
+    measurement: 1
+    data_file_hash: 1a571415de1fc6e7720fea782330ee0a
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75.dat
+    measurement: 2
+    data_file_hash: 1a571415de1fc6e7720fea782330ee0a
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00404_FID114606_R2_tpat_PEFOV75_PERes75/ref_20160401.mrd
+        reference_file_hash: 1e561169e535b81a0bb23eeda0c2f727
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8.dat
+    measurement: 1
+    data_file_hash: b42fc9a2dfcd63c9ec92a6888a064944
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8.dat
+    measurement: 2
+    data_file_hash: b42fc9a2dfcd63c9ec92a6888a064944
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/ref_20210921_klk.mrd
+        reference_file_hash: cb209f72d0a49f71b257ae99950887be
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8/meas_MID00405_FID114607_R2_tpat_PEFOV75_PERes75_PF6_8.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 1
+    data_file_hash: cbbde608f5dd92c1d058d8fa13c42fe3
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong.dat
+    measurement: 2
+    data_file_hash: cbbde608f5dd92c1d058d8fa13c42fe3
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00406_FID114608_R2_tpat_PEFOV75_PERes75_PF6_8_AsymStrong/ref_20210921_klk.mrd
+        reference_file_hash: eda85c95c9a7568839f1103aca701d05
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+    measurement: 1
+    data_file_hash: eb6983639ce8b5a07fbfa1030bdb189a
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+    measurement: 2
+    data_file_hash: eb6983639ce8b5a07fbfa1030bdb189a
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/ref_20160401.mrd
+        reference_file_hash: 5cd9d55e1c728a390e52dd1b89d5a75c
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00416_FID114618_R3_spat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes120.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R3_tpat_PEFOV100_PERes120
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes120.yml
+++ b/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes120.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R3_tpat_PEFOV100_PERes120
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120.dat
+    measurement: 1
+    data_file_hash: ef6beb47c0381f0ee352cbf6f7dd9f9e
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120.dat
+    measurement: 2
+    data_file_hash: ef6beb47c0381f0ee352cbf6f7dd9f9e
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00427_FID114629_R3_tpat__PEFOV100_PERes120/ref_20210923_klk.mrd
+        reference_file_hash: 334f1468a464a6068c36d5c5c394566b
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.02
+        value_comparison_threshold: 0.02
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
+++ b/test/e2e/cases/generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_snr_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+    measurement: 1
+    data_file_hash: 4066466e2d4a7127091ab632874ee5e8
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong.dat
+    measurement: 2
+    data_file_hash: 4066466e2d4a7127091ab632874ee5e8
+    configuration: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00421_FID114623_R3_tpat_PEFOV100_PERes75_PF6_8_AsymStrong/ref_20210923_klk.mrd
+        reference_file_hash: c13ee6326e81d11b66fc57daca470cc8
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_grappa_tse.yml
+++ b/test/e2e/cases/generic_grappa_tse.yml
@@ -1,8 +1,8 @@
 cases:
 - name: generic_grappa_tse
   tags:
-  - fast
   - generic
+  - fast
   dependency:
     data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
     measurement: 1

--- a/test/e2e/cases/generic_grappa_tse.yml
+++ b/test/e2e/cases/generic_grappa_tse.yml
@@ -1,0 +1,25 @@
+cases:
+- name: generic_grappa_tse
+  tags:
+  - fast
+  - generic
+  dependency:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 1
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 2
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    configuration: Generic_Cartesian_Grappa.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa.xml/image_1:
+        reference_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/ref_20220817_klk.mrd
+        reference_file_hash: a0701936b6454524afd5512d0776e78c
+        reference_image: Generic_Cartesian_Grappa.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/generic_nl_spirit_cartesian_sampling_cine.yml
+++ b/test/e2e/cases/generic_nl_spirit_cartesian_sampling_cine.yml
@@ -1,0 +1,24 @@
+cases:
+- name: generic_nl_spirit_cartesian_sampling_cine
+  tags:
+  - slow
+  dependency:
+    data_file: generic/meas_MID836_1slice_FID22517/meas_MID836_1slice_FID22517.dat
+    measurement: 1
+    data_file_hash: d573ca2d73ab7b5a66c7c5e2e1ba4825
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: generic/meas_MID836_1slice_FID22517/meas_MID836_1slice_FID22517.dat
+    measurement: 2
+    data_file_hash: d573ca2d73ab7b5a66c7c5e2e1ba4825
+    configuration: Generic_Cartesian_NonLinear_Spirit_RealTimeCine.xml
+  validation:
+    images:
+      Generic_Cartesian_NonLinear_Spirit_RealTimeCine.xml/image_1:
+        reference_file: generic/meas_MID836_1slice_FID22517/ref_20220817_klk.mrd
+        reference_file_hash: eec60f5ea69cd216116ebf909d4daf01
+        reference_image: Generic_Cartesian_NonLinear_Spirit_RealTimeCine.xml/image_1
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.005
+  requirements:
+    system_memory: 16384

--- a/test/e2e/cases/generic_nl_spirit_random_sampling_cine.yml
+++ b/test/e2e/cases/generic_nl_spirit_random_sampling_cine.yml
@@ -1,0 +1,18 @@
+cases:
+- name: generic_nl_spirit_random_sampling_cine
+  tags:
+  - slow
+  reconstruction:
+    copy_file: generic/meas_MID01095_FID40115/meas_MID01095_FID40115.mrd
+    copy_file_hash: 4d95a4121bf6f4a37b1d20a325cf709f
+    configuration: Generic_Cartesian_RandomSampling_NonLinear_Spirit_RealTimeCine.xml
+  validation:
+    images:
+      Generic_Cartesian_RandomSampling_NonLinear_Spirit_RealTimeCine.xml/image_1:
+        reference_file: generic/meas_MID01095_FID40115/ref_20210923_klk.mrd
+        reference_file_hash: 662a5160b31d5fd0a01b73c91b6c80e4
+        reference_image: Generic_Cartesian_RandomSampling_NonLinear_Spirit_RealTimeCine.xml/image_1
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 16384

--- a/test/e2e/cases/generic_rtcine_ai_landmark.yml
+++ b/test/e2e/cases/generic_rtcine_ai_landmark.yml
@@ -1,0 +1,26 @@
+cases:
+- name: generic_rtcine_ai_landmark
+  tags:
+  - slow
+  - generic
+  reconstruction:
+    copy_file: cmr/RTCine/CH4/rtcine_R4_CH2.mrd
+    copy_file_hash: fcf7253923df0fee8fff8fb68e410929
+    configuration: CMR_RTCine_LAX_AI.xml
+  validation:
+    images:
+      CMR_RTCine_LAX_AI.xml/image_1:
+        reference_file: cmr/RTCine/CH4/ref_20220124_173736.mrd
+        reference_file_hash: b5e9c37bbd3eb4be076d89fd7dd7db6d
+        reference_image: CMR_RTCine_LAX_AI.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+      CMR_RTCine_LAX_AI.xml/image_100:
+        reference_file: cmr/RTCine/CH4/ref_20220124_173736.mrd
+        reference_file_hash: b5e9c37bbd3eb4be076d89fd7dd7db6d
+        reference_image: CMR_RTCine_LAX_AI.xml/image_100
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096
+    python_support: 1

--- a/test/e2e/cases/generic_spirit_cartesian_sampling_spat2.yml
+++ b/test/e2e/cases/generic_spirit_cartesian_sampling_spat2.yml
@@ -1,0 +1,19 @@
+cases:
+- name: generic_spirit_cartesian_sampling_spat2
+  tags:
+  - slow
+  reconstruction:
+    data_file: generic/meas_MID00062_FID114726_SAX_SASHA/meas_MID00062_FID114726_SAX_SASHA.dat
+    measurement: 1
+    data_file_hash: 148a408bca29ac6ec967795341708d21
+    configuration: Generic_Cartesian_Spirit_SASHA.xml
+  validation:
+    images:
+      Generic_Cartesian_Spirit_SASHA.xml/image_1:
+        reference_file: generic/meas_MID00062_FID114726_SAX_SASHA/ref_20220817_klk.mrd
+        reference_file_hash: 1f2022cca5188a557d83d23d5fcca495
+        reference_image: Generic_Cartesian_Spirit_SASHA.xml/image_1
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.001
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/gpu_fixed_radial_mode1_cg.yml
+++ b/test/e2e/cases/gpu_fixed_radial_mode1_cg.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_fixed_radial_mode1_cg
+  tags:
+  - fast
+  reconstruction:
+    data_file: radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
+    measurement: 1
+    data_file_hash: 58f8de6b6e755c4d3dcd0c7dace3b8f6
+    configuration: fixed_radial_mode1_gpusense_cg.xml
+  validation:
+    images:
+      fixed_radial_mode1_gpusense_cg.xml/image_0:
+        reference_file: radial_phantom/fixed_radial_mode1_20210923_klk.mrd
+        reference_file_hash: 04faea502d73557fd0dd1bc629d95e87
+        reference_image: cg/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_fixed_radial_mode1_ktsense.yml
+++ b/test/e2e/cases/gpu_fixed_radial_mode1_ktsense.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_fixed_radial_mode1_ktsense
+  tags:
+  - fast
+  reconstruction:
+    data_file: radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
+    measurement: 1
+    data_file_hash: 58f8de6b6e755c4d3dcd0c7dace3b8f6
+    configuration: fixed_radial_mode1_gpu_ktsense.xml
+  validation:
+    images:
+      fixed_radial_mode1_gpu_ktsense.xml/image_0:
+        reference_file: radial_phantom/fixed_radial_mode1_20210923_klk.mrd
+        reference_file_hash: 04faea502d73557fd0dd1bc629d95e87
+        reference_image: kt/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_fixed_radial_mode1_realtime.yml
+++ b/test/e2e/cases/gpu_fixed_radial_mode1_realtime.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_fixed_radial_mode1_realtime
+  tags:
+  - fast
+  reconstruction:
+    data_file: radial_phantom/meas_MID00133_FID20080_CV_Radial_Fixed_Angle_128_x8_32phs.dat
+    measurement: 1
+    data_file_hash: 58f8de6b6e755c4d3dcd0c7dace3b8f6
+    configuration: fixed_radial_mode1_realtime.xml
+  validation:
+    images:
+      fixed_radial_mode1_realtime.xml/image_0:
+        reference_file: radial_phantom/fixed_radial_mode1_20210923_klk.mrd
+        reference_file_hash: 04faea502d73557fd0dd1bc629d95e87
+        reference_image: realtime/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_golden_radial_mode2_cg.yml
+++ b/test/e2e/cases/gpu_golden_radial_mode2_cg.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_golden_radial_mode2_cg
+  tags:
+  - fast
+  reconstruction:
+    data_file: radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+    measurement: 1
+    data_file_hash: 0326afbb168982f4144704781a08b3ec
+    configuration: golden_radial_mode2_gpusense_cg.xml
+  validation:
+    images:
+      golden_radial_mode2_gpusense_cg.xml/image_0:
+        reference_file: radial_phantom/golden_radial_mode2_20210923_klk.mrd
+        reference_file_hash: 8b296905309f2e6f1458d56417d5c365
+        reference_image: cg/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_golden_radial_mode2_ktsense.yml
+++ b/test/e2e/cases/gpu_golden_radial_mode2_ktsense.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_golden_radial_mode2_ktsense
+  tags:
+  - fast
+  reconstruction:
+    data_file: radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+    measurement: 1
+    data_file_hash: 0326afbb168982f4144704781a08b3ec
+    configuration: golden_radial_mode2_gpu_ktsense.xml
+  validation:
+    images:
+      golden_radial_mode2_gpu_ktsense.xml/image_0:
+        reference_file: radial_phantom/golden_radial_mode2_20210923_klk.mrd
+        reference_file_hash: 8b296905309f2e6f1458d56417d5c365
+        reference_image: kt/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_golden_radial_mode2_realtime.yml
+++ b/test/e2e/cases/gpu_golden_radial_mode2_realtime.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_golden_radial_mode2_realtime
+  tags:
+  - fast
+  reconstruction:
+    data_file: radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+    measurement: 1
+    data_file_hash: 0326afbb168982f4144704781a08b3ec
+    configuration: golden_radial_mode2_realtime.xml
+  validation:
+    images:
+      golden_radial_mode2_realtime.xml/image_0:
+        reference_file: radial_phantom/golden_radial_mode2_20210923_klk.mrd
+        reference_file_hash: 8b296905309f2e6f1458d56417d5c365
+        reference_image: realtime/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_golden_radial_mode2_sb.yml
+++ b/test/e2e/cases/gpu_golden_radial_mode2_sb.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_golden_radial_mode2_sb
+  tags:
+  - slow
+  reconstruction:
+    data_file: radial_phantom/meas_MID00135_FID20082_CV_Radial_Golden_Angle_128_512_views.dat
+    measurement: 1
+    data_file_hash: 0326afbb168982f4144704781a08b3ec
+    configuration: golden_radial_mode2_gpusense_sb.xml
+  validation:
+    images:
+      golden_radial_mode2_gpusense_sb.xml/image_0:
+        reference_file: radial_phantom/golden_radial_mode2_20210923_klk.mrd
+        reference_file_hash: 8b296905309f2e6f1458d56417d5c365
+        reference_image: sb/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 2048

--- a/test/e2e/cases/gpu_grappa_simple.yml
+++ b/test/e2e/cases/gpu_grappa_simple.yml
@@ -1,8 +1,8 @@
 cases:
 - name: gpu_grappa_simple
   tags:
-  - fast
   - realtime
+  - fast
   reconstruction:
     data_file: rtgrappa/acc_data_with_device_2.dat
     measurement: 1

--- a/test/e2e/cases/gpu_grappa_simple.yml
+++ b/test/e2e/cases/gpu_grappa_simple.yml
@@ -1,0 +1,22 @@
+cases:
+- name: gpu_grappa_simple
+  tags:
+  - fast
+  - realtime
+  reconstruction:
+    data_file: rtgrappa/acc_data_with_device_2.dat
+    measurement: 1
+    data_file_hash: ac0b59c6c8989c94738e41e2c4b5ec13
+    configuration: grappa_float.xml
+  validation:
+    images:
+      grappa_float.xml/image_0:
+        reference_file: rtgrappa/grappa_rate2_cpu_out.mrd
+        reference_file_hash: 5fb75eefe3828a74cffe7da6f521d841
+        reference_image: grappa_float_cpu.xml/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.1
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_spiral.yml
+++ b/test/e2e/cases/gpu_spiral.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_spiral
+  tags:
+  - fast
+  reconstruction:
+    data_file: spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
+    measurement: 1
+    data_file_hash: 763baf3d7d0acff185ec9a3c85d5a3f3
+    configuration: spiral_flow_gpusense_cg.xml
+  validation:
+    images:
+      spiral_flow_gpusense_cg.xml/image_0:
+        reference_file: spiral/simple_spiral_out_v2.mrd
+        reference_file_hash: 7ab538094cb4aefa329da75a3190a948
+        reference_image: spiral_flow_gpusense_cg.xml/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_spiral_realtime_deblurring.yml
+++ b/test/e2e/cases/gpu_spiral_realtime_deblurring.yml
@@ -1,0 +1,27 @@
+cases:
+- name: gpu_spiral_realtime_deblurring
+  tags:
+  - fast
+  dependency:
+    data_file: spiral/meas_MID00080_FID16005_MiniIRT_B0.dat
+    measurement: 1
+    data_file_hash: 31865ce197491bb675e095a1d6096d36
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: spiral/meas_MID00080_FID16005_MiniIRT_B0.dat
+    measurement: 2
+    data_file_hash: 31865ce197491bb675e095a1d6096d36
+    parameter_xsl: IsmrmrdParameterMap_Siemens_B0REF.xsl
+    configuration: deblurring_recon_acctrig.xml
+  validation:
+    images:
+      deblurring_recon_acctrig.xml/image_1:
+        reference_file: spiral/spiral_rt_deblurring_out.mrd
+        reference_file_hash: 75cc7b2aec83ca854a5ad06e6afad76e
+        reference_image: deblurring_recon_acctrig.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/gpu_spiral_sb.yml
+++ b/test/e2e/cases/gpu_spiral_sb.yml
@@ -1,0 +1,21 @@
+cases:
+- name: gpu_spiral_sb
+  tags:
+  - ''
+  reconstruction:
+    data_file: spiral/meas_MID1132_MiniIRT_spiral_16int_tr500_acc1_10reps_FID13142.dat
+    measurement: 1
+    data_file_hash: 763baf3d7d0acff185ec9a3c85d5a3f3
+    configuration: spiral_flow_gpusense_sb.xml
+  validation:
+    images:
+      spiral_flow_gpusense_sb.xml/image_0:
+        reference_file: spiral/simple_spiral_out_sb_v2.mrd
+        reference_file_hash: e86610f38fe302a5c264e0d23270c16d
+        reference_image: spiral_flow_gpusense_sb.xml/image_0
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 2048
+    gpu_support: 1
+    gpu_memory: 1024

--- a/test/e2e/cases/grappa_T2W_python_passthrough.yml
+++ b/test/e2e/cases/grappa_T2W_python_passthrough.yml
@@ -1,0 +1,25 @@
+cases:
+- name: grappa_T2W_python_passthrough
+  tags:
+  - fast
+  dependency:
+    data_file: T2W/meas_MID00057_T2w.dat
+    measurement: 1
+    data_file_hash: 46aa75c471a41c793006328a224a4001
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: T2W/meas_MID00057_T2w.dat
+    measurement: 2
+    data_file_hash: 46aa75c471a41c793006328a224a4001
+    configuration: python_passthrough.xml
+  validation:
+    images:
+      python_passthrough.xml/image_1:
+        reference_file: T2W/generic_grappa_T2W_ref_20220817_klk.mrd
+        reference_file_hash: b13b4d961a1fe24fec79f20e6d126bef
+        reference_image: Generic_Cartesian_Grappa_T2W.xml/image_1
+        scale_comparison_threshold: 0.075
+        value_comparison_threshold: 0.075
+  requirements:
+    system_memory: 4096
+    python_support: 1

--- a/test/e2e/cases/ismrmrd_dump_gadget_test.yml
+++ b/test/e2e/cases/ismrmrd_dump_gadget_test.yml
@@ -1,0 +1,25 @@
+cases:
+- name: ismrmrd_dump_gadget_test
+  tags:
+  - python
+  - local-only
+  - fast
+  - validate
+  reconstruction:
+    copy_file: simple_gre/simple_gre_in_20220831.mrd
+    copy_file_hash: cd1598b0e60854281f5fce6342d42fe3
+    template: ismrmrd_dump_gadget_test.template.xml
+  validation:
+    equals:
+      reference_file: simple_gre/simple_gre_in_20220831.mrd
+      reference_file_hash: cd1598b0e60854281f5fce6342d42fe3
+      dataset_prefix: ismrmrd_dump_output
+    images:
+      reconstruction/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: simple/image_0
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.002
+  requirements:
+    python_support: 1

--- a/test/e2e/cases/parallel_bypass_example.yml
+++ b/test/e2e/cases/parallel_bypass_example.yml
@@ -1,0 +1,19 @@
+cases:
+- name: parallel_bypass_example
+  tags:
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: parallel_bypass_example.xml
+  validation:
+    images:
+      parallel_bypass_example.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: inverted/image_0
+        scale_comparison_threshold: 1.0e-05
+        value_comparison_threshold: 1.0e-05
+  requirements:
+    system_memory: 1024

--- a/test/e2e/cases/simple_gre.yml
+++ b/test/e2e/cases/simple_gre.yml
@@ -1,0 +1,19 @@
+cases:
+- name: simple_gre
+  tags:
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: default.xml
+  validation:
+    images:
+      default.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: default.xml/image_0
+        scale_comparison_threshold: 1.0e-05
+        value_comparison_threshold: 1.0e-05
+  requirements:
+    system_memory: 1024

--- a/test/e2e/cases/simple_gre_3d.yml
+++ b/test/e2e/cases/simple_gre_3d.yml
@@ -1,0 +1,19 @@
+cases:
+- name: simple_gre_3d
+  tags:
+  - fast
+  reconstruction:
+    data_file: gre_3d/meas_MID248_gre_FID30644.dat
+    measurement: 1
+    data_file_hash: 39ac16864627691cf7d84aa2ce13c1ae
+    configuration: default_optimized.xml
+  validation:
+    images:
+      default_optimized.xml/image_0:
+        reference_file: gre_3d/simple_gre_out_3d_20210910_klk.mrd
+        reference_file_hash: 015b111b26991bab81671a1844f08433
+        reference_image: default_optimized.xml/image_0
+        scale_comparison_threshold: 1.0e-05
+        value_comparison_threshold: 1.0e-05
+  requirements:
+    system_memory: 2048

--- a/test/e2e/cases/simple_gre_python.yml
+++ b/test/e2e/cases/simple_gre_python.yml
@@ -1,0 +1,26 @@
+cases:
+- name: simple_gre_python
+  tags:
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: python_short.xml
+  validation:
+    images:
+      python_short.xml/image_1:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: python_short.xml/image_1
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.002
+      python_short.xml/image_2:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: python_short.xml/image_2
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.002
+  requirements:
+    system_memory: 2048
+    python_support: 1

--- a/test/e2e/cases/simple_gre_python_buckets.yml
+++ b/test/e2e/cases/simple_gre_python_buckets.yml
@@ -1,0 +1,20 @@
+cases:
+- name: simple_gre_python_buckets
+  tags:
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: python_buckets.xml
+  validation:
+    images:
+      python_buckets.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: default.xml/image_0
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.002
+  requirements:
+    system_memory: 2048
+    python_support: 1

--- a/test/e2e/cases/simple_gre_python_image_array_recon.yml
+++ b/test/e2e/cases/simple_gre_python_image_array_recon.yml
@@ -1,0 +1,20 @@
+cases:
+- name: simple_gre_python_image_array_recon
+  tags:
+  - fast
+  reconstruction:
+    data_file: simple_gre/meas_MiniGadgetron_GRE.dat
+    measurement: 1
+    data_file_hash: 7c5c255522e42367546b4045560afcf8
+    configuration: python_image_array_recon.xml
+  validation:
+    images:
+      python_image_array_recon.xml/image_0:
+        reference_file: simple_gre/simple_gre_out_20210909_klk.mrd
+        reference_file_hash: 85e35ab4c68fa2e5ee25086bc08e615f
+        reference_image: default.xml/image_0
+        scale_comparison_threshold: 1.0e-05
+        value_comparison_threshold: 1.0e-05
+  requirements:
+    system_memory: 1024
+    python_support: 1

--- a/test/e2e/cases/stream_generic_rtcine_ai_landmark.yml
+++ b/test/e2e/cases/stream_generic_rtcine_ai_landmark.yml
@@ -1,9 +1,9 @@
 cases:
 - name: stream_generic_rtcine_ai_landmark
   tags:
+  - generic
   - fast
   - stream
-  - generic
   reconstruction:
     copy_file: cmr/RTCine/CH4/rtcine_R4_CH2.mrd
     copy_file_hash: fcf7253923df0fee8fff8fb68e410929

--- a/test/e2e/cases/stream_generic_rtcine_ai_landmark.yml
+++ b/test/e2e/cases/stream_generic_rtcine_ai_landmark.yml
@@ -1,0 +1,32 @@
+cases:
+- name: stream_generic_rtcine_ai_landmark
+  tags:
+  - fast
+  - stream
+  - generic
+  reconstruction:
+    copy_file: cmr/RTCine/CH4/rtcine_R4_CH2.mrd
+    copy_file_hash: fcf7253923df0fee8fff8fb68e410929
+    stream:
+    - configuration: CMR_RTCine_Recon.xml
+    - configuration: CMR_Image_Chain_RTCine_LAX_AI.xml
+    - configuration: stream_image_array.xml
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: CMR_RTCine_LAX_AI.xml
+  validation:
+    images:
+      CMR_RTCine_LAX_AI.xml/image_1:
+        reference_file: cmr/RTCine/CH4/ref_20220124_173736.mrd
+        reference_file_hash: b5e9c37bbd3eb4be076d89fd7dd7db6d
+        reference_image: CMR_RTCine_LAX_AI.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.3
+      CMR_RTCine_LAX_AI.xml/image_100:
+        reference_file: cmr/RTCine/CH4/ref_20220124_173736.mrd
+        reference_file_hash: b5e9c37bbd3eb4be076d89fd7dd7db6d
+        reference_image: CMR_RTCine_LAX_AI.xml/image_100
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.3
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/stream_image.yml
+++ b/test/e2e/cases/stream_image.yml
@@ -1,0 +1,38 @@
+cases:
+- name: stream_image
+  tags:
+  - fast
+  - stream
+  - generic
+  dependency:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 1
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    stream:
+    - configuration: default_measurement_dependencies.xml
+      args: --disable_storage true --parameter noisecovarianceout=${test_folder}/mycov.bin
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: Generic_Cartesian_Grappa.xml
+  reconstruction:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 2
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    stream:
+    - configuration: Generic_Cartesian_Grappa_Complex.xml
+      args: --disable_storage true --parameter noisecovariancein=${test_folder}/mycov.bin
+    - configuration: stream_complex_to_float.xml
+    - configuration: stream_float_to_short.xml
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: Generic_Cartesian_Grappa.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa.xml/image_1:
+        reference_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/ref_20220817_klk.mrd
+        reference_file_hash: a0701936b6454524afd5512d0776e78c
+        reference_image: Generic_Cartesian_Grappa.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/stream_image.yml
+++ b/test/e2e/cases/stream_image.yml
@@ -1,9 +1,9 @@
 cases:
 - name: stream_image
   tags:
+  - generic
   - fast
   - stream
-  - generic
   dependency:
     data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
     measurement: 1

--- a/test/e2e/cases/stream_image_array.yml
+++ b/test/e2e/cases/stream_image_array.yml
@@ -1,9 +1,9 @@
 cases:
 - name: stream_image_array
   tags:
+  - generic
   - fast
   - stream
-  - generic
   dependency:
     data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
     measurement: 1

--- a/test/e2e/cases/stream_image_array.yml
+++ b/test/e2e/cases/stream_image_array.yml
@@ -1,0 +1,38 @@
+cases:
+- name: stream_image_array
+  tags:
+  - fast
+  - stream
+  - generic
+  dependency:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 1
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    stream:
+    - configuration: default_measurement_dependencies.xml
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: Generic_Cartesian_Grappa.xml
+  reconstruction:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 2
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    stream:
+    - configuration: Generic_Cartesian_Grappa_ImageArray.xml
+    - configuration: stream_image_array_scaling.xml
+    - configuration: stream_image_array_split.xml
+    - configuration: stream_complex_to_float.xml
+    - configuration: stream_float_to_short.xml
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: Generic_Cartesian_Grappa.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa.xml/image_1:
+        reference_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/ref_20220817_klk.mrd
+        reference_file_hash: a0701936b6454524afd5512d0776e78c
+        reference_image: Generic_Cartesian_Grappa.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/stream_snr_R1_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/stream_snr_R1_PEFOV100_PERes100.yml
@@ -1,0 +1,36 @@
+cases:
+- name: stream_snr_R1_PEFOV100_PERes100
+  tags:
+  - fast
+  - stream
+  - generic
+  dependency:
+    data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+    measurement: 1
+    data_file_hash: 9433b049a4de470c436cfab6f14405d1
+    stream:
+    - configuration: default_measurement_dependencies.xml
+      args: --disable_storage true --parameter noisecovarianceout=${test_folder}/noisecovariance.bin
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: foobar
+  reconstruction:
+    data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
+    measurement: 2
+    data_file_hash: 9433b049a4de470c436cfab6f14405d1
+    stream:
+    - configuration: Generic_Cartesian_Grappa_SNR.xml
+      args: --disable_storage true --parameter noisecovariancein=${test_folder}/noisecovariance.bin
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: Generic_Cartesian_Grappa_SNR.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_SNR.xml/image_300:
+        reference_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/ref_20160401.mrd
+        reference_file_hash: 4aed35caae0fd83ecc43a712f08df12b
+        reference_image: Generic_Cartesian_Grappa_SNR.xml/image_300
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096

--- a/test/e2e/cases/stream_snr_R1_PEFOV100_PERes100.yml
+++ b/test/e2e/cases/stream_snr_R1_PEFOV100_PERes100.yml
@@ -1,9 +1,9 @@
 cases:
 - name: stream_snr_R1_PEFOV100_PERes100
   tags:
+  - generic
   - fast
   - stream
-  - generic
   dependency:
     data_file: generic/meas_MID00393_FID114595_R1_PEFOV100_PERes100/meas_MID00393_FID114595_R1_PEFOV100_PERes100.dat
     measurement: 1

--- a/test/e2e/config/ismrmrd_dump_gadget_test.template.xml
+++ b/test/e2e/config/ismrmrd_dump_gadget_test.template.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <version>2</version>
+
+    <readers>
+        <reader>
+            <dll>gadgetron_core_readers</dll>
+            <classname>AcquisitionReader</classname>
+        </reader>
+        <reader>
+            <dll>gadgetron_core_readers</dll>
+            <classname>WaveformReader</classname>
+        </reader>
+    </readers>
+
+    <writers>
+        <writer>
+            <dll>gadgetron_core_writers</dll>
+            <classname>ImageWriter</classname>
+        </writer>
+    </writers>
+
+    <stream>
+        <external>
+            <execute name="gadgetron.examples" target="pass_through" type="python"/>
+            <configuration/>
+        </external>
+
+        <gadget>
+            <dll>gadgetron_mricore</dll>
+            <classname>IsmrmrdDumpGadget</classname>
+            <property name="folder" value="${test_folder}"/>
+            <property name="file_prefix" value="ismrmrd_dump_output"/>
+        </gadget>
+
+        <external>
+            <execute name="gadgetron.examples" target="recon_acquisitions" type="python"/>
+            <configuration/>
+        </external>
+    </stream>
+</configuration>

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+
+import pytest
+import os
+
+from pathlib import Path
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--host', action='store', default='http://gadgetrondata.blob.core.windows.net/gadgetrontestdata/', 
+        help='Host from which to download the data.'
+    )
+    parser.addoption(
+        '--cache-disable', action='store_true', default=False, 
+        help='Disables local caching of input files.'
+    )
+    parser.addoption(
+        '--cache-path', action='store', default="", 
+        help='Location for storing cached data files.'
+    )
+
+
+@pytest.fixture
+def host_url(request):
+    return request.config.getoption('--host')
+
+@pytest.fixture
+def cache_disable(request):
+    return request.config.getoption('--cache-disable')
+
+@pytest.fixture
+def cache_path(request):
+    base = request.config.getoption('--cache-path')
+
+    if base == "":
+        current_dir = Path(os.path.dirname(__file__))
+        base = current_dir/"data"
+    else:
+        base = Path(base)
+
+    return base

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -5,9 +5,26 @@ import os
 
 from pathlib import Path
 
+
 def pytest_addoption(parser):
     parser.addoption(
-        '--host', action='store', default='http://gadgetrondata.blob.core.windows.net/gadgetrontestdata/', 
+        '--host', action='store', default='localhost', 
+        help='Address of (external) Gadgetron host.'
+    )
+    parser.addoption(
+        '--port', action='store', default='9003', 
+        help='Port used by Gadgetron.'
+    )
+    parser.addoption(
+        '--storage-port', action='store', default='9113', 
+        help='Port used by Gadgetron Storage Server.'
+    )
+    parser.addoption(
+        '--external', action='store_true', default=False,
+        help="External, do not start Gadgetron"
+    )
+    parser.addoption(
+        '--data-host', action='store', default='http://gadgetrondata.blob.core.windows.net/gadgetrontestdata/', 
         help='Host from which to download the data.'
     )
     parser.addoption(
@@ -20,9 +37,25 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def host_url(request):
     return request.config.getoption('--host')
+
+@pytest.fixture(scope="module")
+def port(request):
+    return request.config.getoption('--port')
+
+@pytest.fixture(scope="module")
+def storage_port(request):
+    return request.config.getoption('--storage-port')
+
+@pytest.fixture(scope="module")
+def external(request):
+    return request.config.getoption('--external')
+
+@pytest.fixture
+def data_host_url(request):
+    return request.config.getoption('--data-host')
 
 @pytest.fixture
 def cache_disable(request):
@@ -39,3 +72,4 @@ def cache_path(request):
         base = Path(base)
 
     return base
+

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -35,6 +35,14 @@ def pytest_addoption(parser):
         '--cache-path', action='store', default="", 
         help='Location for storing cached data files.'
     )
+    parser.addoption(
+        '--ignore-requirements', action='store_true', default=False,
+        help="Run tests regardless of Gadgetron capabilities."
+    )
+    parser.addoption(
+        '--tag', action='store', default="", 
+        help='Only run tests that has the provided tag.'
+    )
 
 
 @pytest.fixture(scope="module")
@@ -52,6 +60,11 @@ def storage_port(request):
 @pytest.fixture(scope="module")
 def external(request):
     return request.config.getoption('--external')
+
+@pytest.fixture
+def ignore_requirements(request):
+    return request.config.getoption('--ignore-requirements')
+
 
 @pytest.fixture
 def data_host_url(request):
@@ -72,4 +85,10 @@ def cache_path(request):
         base = Path(base)
 
     return base
+
+
+@pytest.fixture
+def run_tag(request):
+    return request.config.getoption('--tag')
+
 

--- a/test/e2e/sample_test_case_yml
+++ b/test/e2e/sample_test_case_yml
@@ -1,0 +1,251 @@
+# Root of the test case file, can have more then one test case inder it.
+cases:                                
+  # Name of the test case, required.
+- name: cmr_cine_binning_2slices    
+  # Tags related test case. Required, use - '' if the test has no tags
+  #   Tagging streaming test with 'stream' and distributed tests with 'distributed'
+  # is recomended but not required for them to run correctly.
+  tags:                             
+  - generic
+  - fast
+
+# used only for distributed tests, required to make the test distributed
+  distributed:
+    nodes: 2    # The number of distributed nodes to run
+    node_port_base: 9050 # Optional, the base port to used for the distributed nodes
+
+# Requirments for the test to run, if the current gadgetron instance dosn't meet them
+# The test will be skipped
+  requirements:
+    system_memory: 8192   # Ammount of avaliable system memory
+    python_support: 1     # Python support is required
+    julia_support: 1      # Julia support is required
+    matlab_support: 1     # matlab support is required
+    gpu_support: 1        # GPU support is required
+    gpu_memory: 1024      # Ammount of avaliable GPU memory
+  
+# Optional, Describes a dependency file that needs to be processes before the reconstruction. 
+# The fields are exactly the same as the reconstruction group that follows
+dependency:
+  data_file: dependency_file.dat                      
+  data_file_hash: 8be03b636dc08f4f8cd0412874b9f101
+  measurement: 1                                      
+  configuration: default_measurement_dependencies.xml
+
+# Describes the recontstruction process for the gadgetron test
+reconstruction:
+# ======= Only one of the follow blocks of fields ===============
+  # Input data file to send to gadgetron  
+  copy_file: reconstruction.mrd                       # Data file to download and the expected hash of the file
+  copy_file_hash: 54ffc7676ddfeb30349b59be4332dc7f
+
+  # -------------------------------------------------------------
+
+  # Input data file to convert from the siemens format to send to gadgetron
+  data_file: reconstruction_file.dat                  # Data file to download and the expected hash of the file
+  data_file_hash: 8be03b636dc08f4f8cd0412874b9f101
+  measurement: 1                                      # The measurement in the siemens file to convert
+  data_conversion_flag: --flashPatRef                 # Optional, extra flags to pass to the conversion tool
+
+  # Optional, provides alternate values for the XML and XSL file for the gadgetron processing
+  parameter_xml: IsmrmrdParameterMap_Siemens.xml
+  parameter_xsl: IsmrmrdParameterMap_Siemens.xsl
+
+# ===============================================================
+
+# ======= Only one of the follow blocks of fields ===============
+  # The name of a template file used to generrate the configuration file
+  template: ismrmrd_dump_gadget_test.template.xml
+
+  # -------------------------------------------------------------
+
+  # The configuration file to pass to gagetron
+  configuration: default_measurement_dependencies.xml
+# ===============================================================
+
+# ============== Only used for non-streaming tests ==============
+    # Optional, additial arguments to pass to gadgetron 
+  additional_arguments:
+# ===============================================================
+
+# ============== Only used for streaming tests ==================
+  # An array of stream configurations in the order they are to be run
+  # The output of one stream will be the input to to the following stream
+  # Required to enable stream testing
+  stream:
+  - configuration: Generic_Cartesian_Grappa_Complex.xml               # The name of the configuration file to use
+    args: --parameter noisecovariancein=${test_folder}/mycov.bin      # Optional, the arguments for this stream 
+
+  # The input adapter for the stream data to gadgetron
+  input_adapter: ismrmrd_hdf5_to_stream
+  
+  # The output adapter for the stream data from gadgetron
+  output_adapter: ismrmrd_stream_to_hdf5
+
+  # The output group that will be used by the output adapter
+  output_group: Generic_Cartesian_Grappa.xml
+# ===============================================================
+
+# How to validate the test
+validation:    
+  # Comparsion of dumped data from the gadgetronn run
+  equals:     
+    # Reference file to compare against
+    reference_file: simple_gre/simple_gre_in_20220831.mrd
+    reference_file_hash: cd1598b0e60854281f5fce6342d42fe3
+    
+    # The prefix of the output dataset files    
+    dataset_prefix: ismrmrd_dump_output
+
+    # Optional, the dataset group of the generated dataset
+    dataset_group: dataset
+
+    # Optional, the dataset group of the reference dataset
+    reference_group: dataset
+
+  # An array of named images for comparasion
+  images:   
+    # The name of the image
+    CMR_2DT_RTCine_KspaceBinning.xml/image_2: 
+      # The reference file and hash that will be compared againt
+      reference_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd          
+      reference_file_hash: ddd08991b7837dc37d7457cc74fb40cb          
+      
+      # The image in the reference file to compare the output image to
+      reference_image: CMR_2DT_RTCine_KspaceBinning.xml/image_2
+      
+      # Scaling threasholds for the comparsion
+      scale_comparison_threshold: 0.01
+      value_comparison_threshold: 0.01
+
+- name: generic_grappa_epi_ave
+  tags:
+  - generic
+  reconstruction:
+    data_file: epi_ave/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron.dat
+    measurement: 1
+    data_file_hash: 7afdcf271e6aa53952ee8c0a0291acd9
+    parameter_xsl: IsmrmrdParameterMap_Siemens_EPI_FLASHREF.xsl
+    data_conversion_flag: --flashPatRef
+    configuration: Generic_Cartesian_Grappa_EPI_AVE.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa_EPI_AVE.xml/image_1:
+        reference_file: epi_ave/meas_MID01349_FID12150_amri_ep2d_bold_96x72x5_R2_16avg_gadgetron/ref_20161020.mrd
+        reference_file_hash: 6bed66d191c14bd442b6214a6fd0db7d
+        reference_image: Generic_Cartesian_Grappa_EPI_AVE.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096
+
+- name: stream_image_array
+  tags:
+  - generic
+  - fast
+  - stream
+  dependency:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 1
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    stream:
+    - configuration: default_measurement_dependencies.xml
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: Generic_Cartesian_Grappa.xml
+  reconstruction:
+    data_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/meas_MID00450_FID76726_SAX_TE62_DIR_TSE.dat
+    measurement: 2
+    data_file_hash: 72b10d19eb14f558bc30c0e27e1af5f0
+    stream:
+    - configuration: Generic_Cartesian_Grappa_ImageArray.xml
+    - configuration: stream_image_array_scaling.xml
+    - configuration: stream_image_array_split.xml
+    - configuration: stream_complex_to_float.xml
+    - configuration: stream_float_to_short.xml
+    input_adapter: ismrmrd_hdf5_to_stream
+    output_adapter: ismrmrd_stream_to_hdf5
+    output_group: Generic_Cartesian_Grappa.xml
+  validation:
+    images:
+      Generic_Cartesian_Grappa.xml/image_1:
+        reference_file: tse/meas_MID00450_FID76726_SAX_TE62_DIR_TSE/ref_20220817_klk.mrd
+        reference_file_hash: a0701936b6454524afd5512d0776e78c
+        reference_image: Generic_Cartesian_Grappa.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096
+
+- name: cmr_cine_binning_2slices_distributed
+  tags:
+  - slow
+  - distributed
+  reconstruction:
+    data_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
+    measurement: 2
+    data_file_hash: 7f52ef8abeb44b7a23648b195307ccc8
+    configuration: CMR_2DT_RTCine_KspaceBinning_Cloud.xml
+  validation:
+    images:
+      CMR_2DT_RTCine_KspaceBinning_Cloud.xml/image_2:
+        reference_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd
+        reference_file_hash: ddd08991b7837dc37d7457cc74fb40cb
+        reference_image: CMR_2DT_RTCine_KspaceBinning.xml/image_2
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 8192
+  distributed:
+    nodes: 2
+
+- name: generic_rtcine_ai_landmark
+  tags:
+  - slow
+  - generic
+  reconstruction:
+    copy_file: cmr/RTCine/CH4/rtcine_R4_CH2.mrd
+    copy_file_hash: fcf7253923df0fee8fff8fb68e410929
+    configuration: CMR_RTCine_LAX_AI.xml
+  validation:
+    images:
+      CMR_RTCine_LAX_AI.xml/image_1:
+        reference_file: cmr/RTCine/CH4/ref_20220124_173736.mrd
+        reference_file_hash: b5e9c37bbd3eb4be076d89fd7dd7db6d
+        reference_image: CMR_RTCine_LAX_AI.xml/image_1
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+      CMR_RTCine_LAX_AI.xml/image_100:
+        reference_file: cmr/RTCine/CH4/ref_20220124_173736.mrd
+        reference_file_hash: b5e9c37bbd3eb4be076d89fd7dd7db6d
+        reference_image: CMR_RTCine_LAX_AI.xml/image_100
+        scale_comparison_threshold: 0.01
+        value_comparison_threshold: 0.01
+  requirements:
+    system_memory: 4096
+    python_support: 1
+
+- name: epi_2d
+  tags:
+  - ''
+  dependency:
+    data_file: epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
+    measurement: 1
+    data_file_hash: 8790d64a101acdc7b6990dd414b14be6
+    configuration: default_measurement_dependencies.xml
+  reconstruction:
+    data_file: epi/meas_MID517_nih_ep2d_bold_fa60_FID82077.dat
+    measurement: 2
+    data_file_hash: 8790d64a101acdc7b6990dd414b14be6
+    parameter_xsl: IsmrmrdParameterMap_Siemens_EPI.xsl
+    configuration: epi.xml
+  validation:
+    images:
+      epi.xml/image_0:
+        reference_file: epi/epi_2d_out_20161020_pjv.mrd
+        reference_file_hash: cd39f21d02ed6d434f91f8418632f64d
+        reference_image: epi.xml/image_0
+        scale_comparison_threshold: 0.001
+        value_comparison_threshold: 0.001
+  requirements:
+    system_memory: 1024

--- a/test/e2e/test_cases.yml
+++ b/test/e2e/test_cases.yml
@@ -9,11 +9,13 @@ cases:
       # [Optional] parameter_xsl:
       # [Optional] data_conversion_flag:
       configuration: CMR_2DT_RTCine_KspaceBinning.xml
+      # [Optional] additional_arguments: 
     validation:
       images:
         CMR_2DT_RTCine_KspaceBinning.xml/image_2:
-          reference_file_path: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd          
+          reference_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd          
           reference_file_hash: ddd08991b7837dc37d7457cc74fb40cb
+          reference_image: CMR_2DT_RTCine_KspaceBinning.xml/image_2
           scale_comparison_threshold: 0.01
           value_comparison_threshold: 0.01
 

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -612,12 +612,12 @@ def load_cases():
 
     return case_list
 
-def get_recontruction_cases():
+def get_recontruction_cases(stream_cases, distributed_cases):
     cases = []
     case_ids = []
     
     for case in test_cases:
-        if 'stream' not in case['tags'] and 'distributed' not in case['tags']:
+        if case not in stream_cases and case not in distributed_cases:
             cases.append(case)
             case_ids.append(case['name'])
 
@@ -628,7 +628,11 @@ def get_streaming_cases():
     case_ids = []
     
     for case in test_cases:
-        if 'stream' in case['tags']:
+        if 'stream' in case['reconstruction']:    
+            cases.append(case)
+            case_ids.append(case['name'])
+
+        elif 'dependency' in case and 'stream' in case['dependency']:
             cases.append(case)
             case_ids.append(case['name'])
 
@@ -640,7 +644,7 @@ def get_distributed_cases():
     case_ids = []
     
     for case in test_cases:
-        if 'distributed' in case['tags']:
+        if 'distributed' in case:
             cases.append(case)
             case_ids.append(case['name'])
 
@@ -649,9 +653,9 @@ def get_distributed_cases():
 
 test_cases = load_cases()
 
-recontruction_cases, recontruction_ids = get_recontruction_cases()
 stream_cases, stream_ids = get_streaming_cases()
 distributed_cases, distributed_ids = get_distributed_cases()
+recontruction_cases, recontruction_ids = get_recontruction_cases(stream_cases, distributed_cases)
 
 
 @pytest.mark.parametrize('config', recontruction_cases, ids=recontruction_ids)

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python3
+
+import pytest
+import os
+import socket
+import hashlib
+import subprocess
+
+import urllib.error
+import urllib.request
+
+from pathlib import Path
+
+# http://gadgetrondata.blob.core.windows.net/gadgetrontestdata/
+
+@pytest.fixture
+def data_dir():
+    current_dir = Path(os.path.dirname(__file__))
+    return current_dir/"data"
+
+def loaddata():
+    return (["cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat"], ["make1"])
+
+def loaddataX():
+    return [("test1", "make1"), ("test2", "make3"), ("test3", "make5")]
+
+
+def loaddata2():
+    global test_val, test_id, test_g
+    test_val, test_id = loaddata()
+    test_g = loaddataX()
+
+loaddata2()
+
+@pytest.fixture(params=test_val)
+def named(request):
+    return request.param
+
+def calc_mdf5(file):
+    md5 = hashlib.new('md5')
+    
+    with open(file, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            md5.update(chunk)
+    return md5.hexdigest()
+
+def is_valid(file, digest):
+
+    if not os.path.isfile(file):
+        return False
+
+    return digest == calc_mdf5(file) 
+
+def urlretrieve(url, filename, retries=5):
+    if retries <= 0:
+        raise RuntimeError("Download from {} failed".format(url))
+    try:
+        with urllib.request.urlopen(url, timeout=60) as connection:                        
+            with open(filename,'wb') as f:
+                for chunk in iter(lambda : connection.read(1024*1024), b''):
+                    f.write(chunk)
+            return connection.headers["Content-MD5"]
+    except (urllib.error.URLError, ConnectionResetError, socket.timeout) as exc:
+        print("Retrying connection for file {}, reason: {}".format(filename, str(exc)))
+        urlretrieve(url, filename, retries=retries-1)
+
+@pytest.fixture
+def convertFile(tmp_path: Path):
+    def _convertFile(input:str, fileConfig:dict):
+        working_dir = os.path.join(tmp_path, os.path.basename(input) + "output")
+        os.makedirs(working_dir, exist_ok=True)
+        output = os.path.join(working_dir, os.path.basename(input) + ".h5")
+
+        command = ["siemens_to_ismrmrd", "-X",
+                "-f", input, 
+                "-m", fileConfig.get('parameter_xml', 'IsmrmrdParameterMap_Siemens.xml'),
+                "-x", fileConfig.get('parameter_xsl', 'IsmrmrdParameterMap_Siemens.xsl'),
+                "-o", output,
+                "-z", fileConfig['measurement'],
+                fileConfig.get('data_conversion_flag', '')]
+
+        print(command)
+        subprocess.run(command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, 
+                    cwd=working_dir)
+        
+        return output
+    
+    return _convertFile
+
+@pytest.fixture
+def dataFile(cache_path: Path, host_url:str, cache_disable:bool):
+    created_files = []
+    
+    def _dataFile(filename:str, fileHash:str):
+        nonlocal created_files
+        url = "{}{}".format(host_url, filename)
+        destination = os.path.join(cache_path, filename)
+
+        if not os.path.exists(destination):
+            print("Downloading file: {}".format(url)) 
+
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            urlretrieve(url, destination)
+            
+        else:
+            print("File already exists: {}".format(url)) 
+
+        if not is_valid(destination, fileHash):
+            raise(RuntimeError("Downloaded file {} failed validation. Expected MD5 {}. Actual MD5 {}".format(destination, fileHash, calc_mdf5(destination))))
+
+        created_files.append(destination)
+
+        return destination
+    
+    yield _dataFile
+
+    if cache_disable:
+        for file in created_files:
+            os.remove(file)
+            if len(os.listdir(os.path.dirname(file))) == 0:
+                os.removedirs(os.path.dirname(file))
+
+
+
+
+
+
+# def tearDownModule():
+#     raise Exception(f"Run failed")
+
+
+
+def localwork(data_dir: str):
+    print(data_dir)
+
+@pytest.mark.parametrize('val', test_val, ids=test_id)
+def test_123(val: str, dataFile, convertFile):
+    path1 = dataFile(val, "7f52ef8abeb44b7a23648b195307ccc8")
+    path2 = dataFile("cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd", "ddd08991b7837dc37d7457cc74fb40cb")
+    
+    config = {'measurement':'2', 'data_conversion_flag':'--flashPatRef'}
+
+    path3 = convertFile(path1, config)
+    print(path1, path2, path3)
+    assert 1

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -5,36 +5,27 @@ import os
 import socket
 import hashlib
 import subprocess
+import yaml
+import time
+
+import h5py
+import ismrmrd
+import numpy
+
 
 import urllib.error
 import urllib.request
 
 from pathlib import Path
 
+
+# Importing h5py on windows will mess with your environment. When we pass the messed up environment to gadgetron
+# child processes, they won't load properly. We're saving our environment here to spare our children from the
+# crimes of h5py.
+environment = dict(os.environ)
+
+
 # http://gadgetrondata.blob.core.windows.net/gadgetrontestdata/
-
-@pytest.fixture
-def data_dir():
-    current_dir = Path(os.path.dirname(__file__))
-    return current_dir/"data"
-
-def loaddata():
-    return (["cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat"], ["make1"])
-
-def loaddataX():
-    return [("test1", "make1"), ("test2", "make3"), ("test3", "make5")]
-
-
-def loaddata2():
-    global test_val, test_id, test_g
-    test_val, test_id = loaddata()
-    test_g = loaddataX()
-
-loaddata2()
-
-@pytest.fixture(params=test_val)
-def named(request):
-    return request.param
 
 def calc_mdf5(file):
     md5 = hashlib.new('md5')
@@ -45,7 +36,6 @@ def calc_mdf5(file):
     return md5.hexdigest()
 
 def is_valid(file, digest):
-
     if not os.path.isfile(file):
         return False
 
@@ -65,37 +55,12 @@ def urlretrieve(url, filename, retries=5):
         urlretrieve(url, filename, retries=retries-1)
 
 @pytest.fixture
-def convertFile(tmp_path: Path):
-    def _convertFile(input:str, fileConfig:dict):
-        working_dir = os.path.join(tmp_path, os.path.basename(input) + "output")
-        os.makedirs(working_dir, exist_ok=True)
-        output = os.path.join(working_dir, os.path.basename(input) + ".h5")
-
-        command = ["siemens_to_ismrmrd", "-X",
-                "-f", input, 
-                "-m", fileConfig.get('parameter_xml', 'IsmrmrdParameterMap_Siemens.xml'),
-                "-x", fileConfig.get('parameter_xsl', 'IsmrmrdParameterMap_Siemens.xsl'),
-                "-o", output,
-                "-z", fileConfig['measurement'],
-                fileConfig.get('data_conversion_flag', '')]
-
-        print(command)
-        subprocess.run(command,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE, 
-                    cwd=working_dir)
-        
-        return output
-    
-    return _convertFile
-
-@pytest.fixture
-def dataFile(cache_path: Path, host_url:str, cache_disable:bool):
+def fetch_data_file(cache_path: Path, data_host_url:str, cache_disable:bool):
     created_files = []
     
-    def _dataFile(filename:str, fileHash:str):
+    def _fetch_data_file(filename:str, fileHash:str):
         nonlocal created_files
-        url = "{}{}".format(host_url, filename)
+        url = "{}{}".format(data_host_url, filename)
         destination = os.path.join(cache_path, filename)
 
         if not os.path.exists(destination):
@@ -114,7 +79,7 @@ def dataFile(cache_path: Path, host_url:str, cache_disable:bool):
 
         return destination
     
-    yield _dataFile
+    yield _fetch_data_file
 
     if cache_disable:
         for file in created_files:
@@ -122,26 +87,189 @@ def dataFile(cache_path: Path, host_url:str, cache_disable:bool):
             if len(os.listdir(os.path.dirname(file))) == 0:
                 os.removedirs(os.path.dirname(file))
 
+@pytest.fixture
+def siemens_to_ismrmrd(tmp_path: Path, fetch_data_file):
+    def _siemens_to_ismrmrd(fileConfig:dict, section:str):
+        input = fetch_data_file(fileConfig['data_file'], fileConfig['data_file_hash'])
+        output = os.path.join(tmp_path, os.path.basename(input) + "_" + section + ".h5")
 
+        command = ["siemens_to_ismrmrd", "-X",
+                "-f", input, 
+                "-m", fileConfig.get('parameter_xml', 'IsmrmrdParameterMap_Siemens.xml'),
+                "-x", fileConfig.get('parameter_xsl', 'IsmrmrdParameterMap_Siemens.xsl'),
+                "-o", output,
+                "-z", str(fileConfig['measurement']),
+                fileConfig.get('data_conversion_flag', '')]
 
-
-
-
-# def tearDownModule():
-#     raise Exception(f"Run failed")
-
-
-
-def localwork(data_dir: str):
-    print(data_dir)
-
-@pytest.mark.parametrize('val', test_val, ids=test_id)
-def test_123(val: str, dataFile, convertFile):
-    path1 = dataFile(val, "7f52ef8abeb44b7a23648b195307ccc8")
-    path2 = dataFile("cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd", "ddd08991b7837dc37d7457cc74fb40cb")
+        subprocess.run(command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, 
+                    cwd=tmp_path)
+        
+        return output
     
-    config = {'measurement':'2', 'data_conversion_flag':'--flashPatRef'}
+    return _siemens_to_ismrmrd
 
-    path3 = convertFile(path1, config)
-    print(path1, path2, path3)
-    assert 1
+
+@pytest.fixture
+def send_to_gadgetron(tmp_path: Path, host_url, port):
+    def _send_to_gadgetron(fileConfig:dict, input_file:str, section:str):
+        output_file = os.path.join(tmp_path, section + ".output.mrd")
+        additional_arguments = fileConfig.get('additional_arguments', '')
+        configuration = fileConfig['configuration']
+        
+        print("Passing data to Gadgetron: {} -> {}".format(input_file, output_file)) 
+        command = ["gadgetron_ismrmrd_client",
+                    "-a", host_url,
+                    "-p", port,
+                    "-f", input_file,
+                    "-o", output_file,
+                    "-G", configuration,
+                    "-c", configuration]
+
+        if additional_arguments:
+            command = command + additional_arguments.split()
+
+        subprocess.run(command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, 
+                    env=environment)
+
+        return output_file
+
+    return _send_to_gadgetron
+
+def wait_for_storage_server(port, proc, retries=50):
+    for i in range(retries):
+        try:
+            urllib.request.urlopen(f"http://localhost:{port}/healthcheck")
+            return
+        except (urllib.error.URLError, urllib.error.HTTPError) as e:
+            if i == retries - 1 or proc.poll() is not None:
+                raise RuntimeError("Unable to get a successful response from storage server.") from e
+            time.sleep(0.2)
+
+def start_storage_server(*, log, port, storage_folder):
+    storage_server_environment = environment.copy()
+    storage_server_environment["MRD_STORAGE_SERVER_PORT"] = port
+    storage_server_environment["MRD_STORAGE_SERVER_STORAGE_CONNECTION_STRING"] = storage_folder
+    storage_server_environment["MRD_STORAGE_SERVER_DATABASE_CONNECTION_STRING"] = storage_folder + "/metadata.db"
+
+    retries = 5
+    for i in range(retries):
+        print("Starting MRD Storage Server on port", port)
+        proc = subprocess.Popen(["mrd-storage-server", "--require-parent-pid", str(os.getpid())],
+                                stdout=log,
+                                stderr=log,
+                                env=storage_server_environment)
+
+        try:
+            wait_for_storage_server(port, proc)
+            return proc
+        except:
+            # If the process has exited, it might be because the
+            # port was in use. This can be because the previous storage server
+            # instance was just killed. So we try again.
+            if proc.poll() is not None and i < retries:
+                time.sleep(1)
+            else:
+                proc.kill()
+                raise
+
+def start_gadgetron_instance(*, log_stdout, log_stderr, port, storage_address, env=environment):
+    print("Starting Gadgetron instance on port", port)
+    proc = subprocess.Popen(["gadgetron", "-p", port, "-E", storage_address],
+                            stdout=log_stdout,
+                            stderr=log_stderr,
+                            env=env)
+    return proc
+
+
+@pytest.fixture(scope="module", autouse="true")
+def start_gadgetron(host_url, port, external, storage_port, tmp_path_factory):
+    storage_address = "http://localhost:" + storage_port
+    log_path = tmp_path_factory.mktemp("logs")
+    storage_path = tmp_path_factory.mktemp("storage")
+
+    if not external:
+        print("Starting storage server on port", storage_port)
+        with open(os.path.join(log_path, 'storage.log'), 'w') as log:
+            storage = start_storage_server(log=log,
+                        port=str(storage_port),
+                        storage_folder=str(storage_path))
+
+        print("Starting Gadgetron instance on port {} with logs in {}".format(port, log_path))
+
+        with open(os.path.join(log_path, 'gadgetron.log.out'), 'w') as log_stdout:
+            with open(os.path.join(log_path, 'gadgetron.log.err'), 'w') as log_stderr:
+                instance = start_gadgetron_instance(log_stdout=log_stdout, log_stderr=log_stderr, port=port, storage_address=storage_address)
+
+                yield
+
+                instance.kill()
+                storage.kill()
+
+    else:
+        yield
+
+Failure = "Failure", 1
+
+def validate_output(*, output_file, reference_file, output_group, reference_group, value_threshold, scale_threshold):
+    try:
+        # The errors produced by h5py are not entirely excellent. We spend some code here to clear them up a bit.
+        def get_group_data(file, group):
+            with h5py.File(file, mode='r') as f:
+                try:
+                    group = group + '/data'
+                    return numpy.squeeze(f[group])
+                except KeyError:
+                    raise RuntimeError("Did not find group '{}' in file {}".format(group, file))
+
+        output_data = get_group_data(output_file, output_group)
+        reference_data = get_group_data(reference_file, reference_group)
+    except OSError as e:
+        return Failure, str(e)
+    except RuntimeError as e:
+        return Failure, str(e)
+
+    output = output_data[...].flatten().astype('float32')
+    reference = reference_data[...].flatten().astype('float32')
+
+    norm_diff = numpy.linalg.norm(output - reference) / numpy.linalg.norm(reference)
+    scale = numpy.dot(output, output) / numpy.dot(output, reference)
+
+    if value_threshold < norm_diff:
+        return Failure, "Comparing values, norm diff: {} (threshold: {})".format(norm_diff, value_threshold)
+
+    if value_threshold < abs(1 - scale):
+        return Failure, "Comparing image scales, ratio: {} ({}) (threshold: {})".format(scale, abs(1 - scale),
+                                                                                        scale_threshold)
+
+    return None, "Norm: {:.1e} [{}] Scale: {:.1e} [{}]".format(norm_diff, value_threshold, abs(1 - scale),
+                                                                scale_threshold)
+
+
+
+# @pytest.mark.parametrize('val', "test_val", ids="test_id")
+def test_123(fetch_data_file, siemens_to_ismrmrd, send_to_gadgetron):
+
+    with open("test_cases.yml", 'r') as file:
+        cases = yaml.safe_load(file)
+
+    config = cases['cases'][0]
+
+    reconstruction_file = siemens_to_ismrmrd(config['reconstruction'], "reconstruction")
+    output_file = send_to_gadgetron(config['reconstruction'], reconstruction_file, "reconstruction")
+
+    for output_image in config['validation']['images']:        
+        output_image_data = config['validation']['images'][output_image]
+        reference_file = fetch_data_file(output_image_data['reference_file'], output_image_data['reference_file_hash'])
+        result, reason = validate_output(output_file=output_file, 
+                                        reference_file=reference_file, 
+                                        output_group=output_image,
+                                        reference_group=output_image_data['reference_image'], 
+                                        value_threshold=output_image_data['value_comparison_threshold'], 
+                                        scale_threshold=output_image_data['scale_comparison_threshold'])
+        
+        assert result != Failure, reason
+

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -390,7 +390,7 @@ def start_gadgetron_instance(*, log_stdout, log_stderr, port, storage_address, e
     return proc
 
 
-@pytest.fixture(scope="module", autouse="true")
+@pytest.fixture(autouse="true")
 def start_storage(external, storage_port, tmp_path_factory):
     log_path = tmp_path_factory.mktemp("logs")
     storage_path = tmp_path_factory.mktemp("storage")

--- a/test/integration/cases/cmr_cine_binning_2slices_distributed.yml
+++ b/test/integration/cases/cmr_cine_binning_2slices_distributed.yml
@@ -1,0 +1,39 @@
+cases:
+  - name: cmr_cine_binning_2slices
+    tags: slow
+    reconstruction:
+      data_file: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/meas_MID838_PK_rt_test_2slice_FID22519.dat
+      data_file_hash: 7f52ef8abeb44b7a23648b195307ccc8
+      measurement: 2
+      # [Optional] parameter_xml: 
+      # [Optional] parameter_xsl:
+      # [Optional] data_conversion_flag:
+      configuration: CMR_2DT_RTCine_KspaceBinning.xml
+    validation:
+      images:
+        CMR_2DT_RTCine_KspaceBinning.xml/image_2:
+          reference_file_path: cmr/CineBinning/meas_MID838_PK_rt_test_2slice_FID22519/cmr_cine_binning_2slice_ref_20220817.mrd          
+          reference_file_hash: ddd08991b7837dc37d7457cc74fb40cb
+          scale_comparison_threshold: 0.01
+          value_comparison_threshold: 0.01
+
+  - name: generic_cartesian_cine_denoise
+    tags: generic
+    reconstruction:
+      data_file: generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+      measurement: 2
+      configuration: Generic_Cartesian_Grappa_Cine_Denoise.xml
+    noise:
+      data_file: generic/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4.dat
+      measurement: 1
+      configuration: default_measurement_dependencies.xml
+    validation:
+      images:
+        Generic_Cartesian_Grappa_Cine_Denoise.xml/image_1:
+          reference_file_path: denoise/meas_MID00051_FID110020_SAX_realtime_gt_TPAT4/denoise_ref_20220817.mrd
+          scale_comparison_threshold: 0.005
+          value_comparison_threshold: 0.001
+  
+  
+
+  


### PR DESCRIPTION
The core goal of this PR is to move the current custom-made testing system for Gadgetron over to pytest, 

Additional goal include:
 * Replacing the current test file format with a yaml file, improving parsing and allowing multiple tests to be combined into a single test file.
 * Allowing tests to download needed datafiles instead of using an external tool
 * Adding the ability to support disabling the caching of downloaded test data files 
 * Integrating the data file hash information into the test instead of in a secondary file
 * Making it easier to run only selected test cases

By replacing the current test framework with a standard framework, it will improve the overall maintainability of the testing code base and better integration into automated systems.

Test cases are stored in the test/e2e/cases folder. 
Template data is stored in the test/e2e/config folder.

To run the tests you would simply need to switch into the test/e2e folder and run pytest. 

All the standard pytest command line options are support (useful ones include: --co to list all test cases, -k to run matching tests, -v for verbose output and -s to show all the output from the tests). In addition, a number of custom command line options have been added that are specific to the tests.

  --cache-disable: Disable caching of downloaded test files
  --cache-path: The path to save cached test files, defaults to ./data
  --host: Address of (external) Gadgetron host. Default: localhost
  --port: Port used by Gadgetron. Default: 9003
  --storage-port: Port used by Gadgetron Storage Server. Default: 9113
  --external: External, do not start Gadgetron
  --data-host: Host from which to download the data. default: http://gadgetrondata.blob.core.windows.net/gadgetrontestdata/
  --ignore-requirements: Run tests regardless of Gadgetron capabilities.
  --tag: Only run tests that has the provided tag.

These are a close match to the options for the current testing framework. 