### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.17...3.21 FATAL_ERROR)
 if (${CMAKE_VERSION} VERSION_LESS 3.17)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 else ()
-    cmake_policy(VERSION 3.12)
+    cmake_policy(VERSION 3.17)
 endif()
 project(GADGETRON LANGUAGES CXX C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.17...3.21 FATAL_ERROR)
 
-if (${CMAKE_VERSION} VERSION_LESS 3.12)
+if (${CMAKE_VERSION} VERSION_LESS 3.17)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 else ()
-    cmake_policy(VERSION 3.12)
+    cmake_policy(VERSION 3.17)
 endif()
 project(GADGETRON LANGUAGES CXX C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.17...3.21 FATAL_ERROR)
 if (${CMAKE_VERSION} VERSION_LESS 3.17)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 else ()
-    cmake_policy(VERSION 3.17)
+    cmake_policy(VERSION 3.12)
 endif()
 project(GADGETRON LANGUAGES CXX C)
 


### PR DESCRIPTION
We were using policy 3.12 instead of 3.17 ? This causes compilation issues in non-container builds on ubuntu 22.04. Updating the policy to 3.17 solves the issue with finding the correct boost_python.