### PR TITLE
Add compatibility with version of DCMTK >= 3.6.7

### DIFF
--- a/gadgets/dicom/DicomFinishGadget.h
+++ b/gadgets/dicom/DicomFinishGadget.h
@@ -18,9 +18,6 @@ The dicom image is sent out with message id -> dicom image -> dicom image name -
 
 #include "dcmtk/config/osconfig.h"
 #include "dcmtk/ofstd/ofstdinc.h"
-#define INCLUDE_CSTDLIB
-#define INCLUDE_CSTDIO
-#define INCLUDE_CSTRING
 #include "dcmtk/dcmdata/dctk.h"
 #include "dcmtk/dcmdata/dcostrmb.h"
 
@@ -31,6 +28,9 @@ The dicom image is sent out with message id -> dicom image -> dicom image name -
 #include <string>
 #include <map>
 #include <complex>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 namespace Gadgetron
 {

--- a/gadgets/dicom/DicomImageWriter.cpp
+++ b/gadgets/dicom/DicomImageWriter.cpp
@@ -1,4 +1,7 @@
 #include <complex>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <io/primitives.h>
 #include <time.h>
@@ -10,9 +13,6 @@
 #include "ismrmrd/meta.h"
 
 // DCMTK includes
-#define INCLUDE_CSTDLIB
-#define INCLUDE_CSTDIO
-#define INCLUDE_CSTRING
 #define NOGDI
 #include "dcmtk/config/osconfig.h"
 #include "dcmtk/ofstd/ofstdinc.h"

--- a/gadgets/dicom/dicom_ismrmrd_utility.h
+++ b/gadgets/dicom/dicom_ismrmrd_utility.h
@@ -8,15 +8,15 @@
 #include <string>
 #include <map>
 #include <complex>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "Gadget.h"
 #include "GadgetMRIHeaders.h"
 
 #include "dcmtk/config/osconfig.h"
 #include "dcmtk/ofstd/ofstdinc.h"
-#define INCLUDE_CSTDLIB
-#define INCLUDE_CSTDIO
-#define INCLUDE_CSTRING
 #include "dcmtk/dcmdata/dctk.h"
 #include "dcmtk/dcmdata/dcostrmb.h"
 


### PR DESCRIPTION
Include macros have been made obsolete in DCMTK with commit  [aa43fb59dfa805a695926945db0bfdf492c8368b](https://github.com/DCMTK/dcmtk/commit/aa43fb59dfa805a695926945db0bfdf492c8368b).