### PR TITLE
no longer use obsolete DCMTK macros

### DIFF
--- a/gadgets/dicom/DicomFinishGadget.h
+++ b/gadgets/dicom/DicomFinishGadget.h
@@ -18,9 +18,9 @@ The dicom image is sent out with message id -> dicom image -> dicom image name -
 
 #include "dcmtk/config/osconfig.h"
 #include "dcmtk/ofstd/ofstdinc.h"
-#define INCLUDE_CSTDLIB
-#define INCLUDE_CSTDIO
-#define INCLUDE_CSTRING
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 #include "dcmtk/dcmdata/dctk.h"
 #include "dcmtk/dcmdata/dcostrmb.h"
 

--- a/gadgets/dicom/DicomImageWriter.cpp
+++ b/gadgets/dicom/DicomImageWriter.cpp
@@ -10,9 +10,9 @@
 #include "ismrmrd/meta.h"
 
 // DCMTK includes
-#define INCLUDE_CSTDLIB
-#define INCLUDE_CSTDIO
-#define INCLUDE_CSTRING
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 #define NOGDI
 #include "dcmtk/config/osconfig.h"
 #include "dcmtk/ofstd/ofstdinc.h"

--- a/gadgets/dicom/dicom_ismrmrd_utility.h
+++ b/gadgets/dicom/dicom_ismrmrd_utility.h
@@ -14,9 +14,9 @@
 
 #include "dcmtk/config/osconfig.h"
 #include "dcmtk/ofstd/ofstdinc.h"
-#define INCLUDE_CSTDLIB
-#define INCLUDE_CSTDIO
-#define INCLUDE_CSTRING
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 #include "dcmtk/dcmdata/dctk.h"
 #include "dcmtk/dcmdata/dcostrmb.h"
 


### PR DESCRIPTION
DCMTK 3.6.7 made INCLUDE_CSTDIO etc errors. So
just use the C++ files directly.

Fixes #1277