### PR TITLE
Avoid test compilation error with g++-12

### DIFF
--- a/apps/gadgetron/main.cpp
+++ b/apps/gadgetron/main.cpp
@@ -19,7 +19,7 @@ using namespace boost::filesystem;
 using namespace boost::program_options;
 using namespace Gadgetron::Server;
 
-using gadget_parameter = std::pair<std::string, std::string>;
+struct gadget_parameter : std::pair<std::string, std::string> {} ;
 
 std::istream& operator>>(std::istream& in, gadget_parameter& param) {
     std::string token;

--- a/test/nhlbi_compression_tests.cpp
+++ b/test/nhlbi_compression_tests.cpp
@@ -287,7 +287,9 @@ TEST(NHLBICompression, ArgumentValidation)
     ASSERT_THROW(compressor->compress(v, -1, 32), std::runtime_error);
     ASSERT_THROW(compressor->compress(v, -1, 0), std::runtime_error);
     
-    v = { 1e10 };
+    v.resize(1);
+    v[0] = 1e10f;
+    
     ASSERT_THROW(compressor->compress(v, 1e-5), std::runtime_error);
 }
 


### PR DESCRIPTION
Fixes https://github.com/gadgetron/gadgetron/issues/1290

This branch is on top of #1285 to get things to compile. With this branch, ctests pass with g++-12 using conda-forge packages, including cxx-compiler.