### PR TITLE
CmrPSIRNetGadget: fix model loading, coil-map sizing, PSIR sign handling; add Python wrapper

### DIFF
--- a/gadgets/cmr/CMakeLists.txt
+++ b/gadgets/cmr/CMakeLists.txt
@@ -80,6 +80,15 @@ if (BUILD_PYTHON_SUPPORT)
         )
 
     install(FILES ${python_LandmarkDetection_files} DESTINATION ${GADGETRON_INSTALL_PYTHON_MODULE_PATH}/cmr_lax_landmark_detection COMPONENT main)
+
+    # PSIRNet Python inference wrapper.
+    # CmrPSIRNetGadget expects this module to be importable as `psirnet` from
+    #   $GADGETRON_HOME/share/gadgetron/python/cmr_ml/
+    # The TorchScript model (PSIRNet.pts) is bind-mounted at runtime into
+    #   $GADGETRON_HOME/share/gadgetron/python/cmr_ml/models/PSIRNet.pts
+    set( python_PSIRNet_files python/psirnet.py )
+    source_group(python FILES ${python_PSIRNet_files})
+    install(FILES ${python_PSIRNet_files} DESTINATION ${GADGETRON_INSTALL_PYTHON_MODULE_PATH}/cmr_ml COMPONENT main)
 endif ()
 
 add_library(gadgetron_cmr SHARED 

--- a/gadgets/cmr/CmrPSIRNetGadget.cpp
+++ b/gadgets/cmr/CmrPSIRNetGadget.cpp
@@ -103,9 +103,9 @@ namespace Gadgetron {
             if (!this->gt_home_.empty())
             {
                 std::string model_name = this->model.value();
-                if (!boost::algorithm::ends_with(this->model.value(), "pts"))
+                if (!boost::algorithm::ends_with(model_name, ".pts"))
                 {
-                    std::string model_name = this->model.value() + ".pts";
+                    model_name += ".pts";
                 }
 
                 GDEBUG_STREAM("Load PSIRNet model : " << model_name);
@@ -228,35 +228,43 @@ namespace Gadgetron {
 
             Gadgetron::GadgetronTimer timer(false);
 
-            // set up outputs
+            // PSIRNet is a single-shot model: each call takes one IR + one PD k-space
+            // (see psirnet/src/models.py:PSIRNet). We invoke it independently for every
+            // (average, slice) pair so that downstream tools / cardiologists can pick
+            // any single-shot reconstruction retrospectively (e.g. compare against a
+            // MOCO multi-average reference). The N dimension is preserved end-to-end.
+            //
+            // To keep the Python wrapper agnostic to the meaning of the batch dim, we
+            // pack (n, slc) into a flat batch index `b = n + slc*N` for the model inputs
+            // and unpack the same way on the outputs.
             res_psir_.data_.create(RO, E1, E2, 1, N, 1, SLC);
             res_magir_.data_.create(RO, E1, E2, 1, N, 1, SLC);
 
-            // get IR and PD k-space data
+            const size_t B = N * SLC;
+
+            // get IR and PD k-space data, flattened along batch = n + slc*N
             hoNDArray< std::complex<float> > kspace_ir;
-            kspace_ir.create(RO, E1, CHA, N*SLC);
+            kspace_ir.create(RO, E1, CHA, B);
             Gadgetron::clear(kspace_ir);
 
             hoNDArray< std::complex<float> > kspace_pd;
-            kspace_pd.create(RO, E1, CHA, N*SLC);
+            kspace_pd.create(RO, E1, CHA, B);
             Gadgetron::clear(kspace_pd);
 
-            size_t ro, e1, cha, n, s, slc;
+            size_t ro, e1, cha, slc, n;
             for (slc=0; slc<SLC; slc++)
             {
                 for (n=0; n<N; n++)
                 {
-                    //memcpy(&kspace_ir(0, 0, 0, n + slc*N), &recon_bit.data_.data_(0, 0, 0, 0, n, 0, slc), RO*E1*CHA*sizeof(std::complex<float>));
-                    //memcpy(&kspace_pd(0, 0, 0, n + slc*N), &recon_bit.data_.data_(0, 0, 0, 0, n, 1, slc), RO*E1*CHA*sizeof(std::complex<float>));
-
+                    const size_t b = n + slc*N;
                     for (cha=0; cha<CHA; cha++)
                     {
                         for (e1=0; e1<E1; e1++)
                         {
                             for (ro=0; ro<RO; ro++)
-                            {             
-                                kspace_ir(ro, e1, cha, n + slc*N) = recon_bit.data_.data_(ro, e1, 0, cha, n, 0, slc);
-                                kspace_pd(ro, e1, cha, n + slc*N) = recon_bit.data_.data_(ro, e1, 0, cha, n, 1, slc);
+                            {
+                                kspace_ir(ro, e1, cha, b) = recon_bit.data_.data_(ro, e1, 0, cha, n, 0, slc);
+                                kspace_pd(ro, e1, cha, b) = recon_bit.data_.data_(ro, e1, 0, cha, n, 1, slc);
                             }
                         }
                     }
@@ -300,19 +308,24 @@ namespace Gadgetron {
             if (perform_timing.value()) { timer.stop(); }
 
             // call the model
+            // The coil map is one per slice (independent of average), so we tile it
+            // along the same flat batch dim used for the k-space inputs.
             hoNDArray< std::complex<float> > coil_map_model;
-            coil_map_model.create(RO, E1, CHA, SLC);
+            coil_map_model.create(RO, E1, CHA, B);
             Gadgetron::clear(coil_map_model);
             for (slc=0; slc<SLC; slc++)
             {
-                // memcpy(&coil_map_model(0, 0, 0, slc), &coil_map(0, 0, 0, slc), RO*E1*CHA*sizeof(std::complex<float>));
-                for (cha=0; cha<CHA; cha++)
+                for (n=0; n<N; n++)
                 {
-                    for (e1=0; e1<E1; e1++)
+                    const size_t b = n + slc*N;
+                    for (cha=0; cha<CHA; cha++)
                     {
-                        for (ro=0; ro<RO; ro++)
-                        {             
-                            coil_map_model(ro, e1, cha, slc) = coil_map(ro, e1, 0, cha, slc);
+                        for (e1=0; e1<E1; e1++)
+                        {
+                            for (ro=0; ro<RO; ro++)
+                            {
+                                coil_map_model(ro, e1, cha, b) = coil_map(ro, e1, 0, cha, slc);
+                            }
                         }
                     }
                 }
@@ -326,38 +339,44 @@ namespace Gadgetron {
             }
 
             if (perform_timing.value()) { timer.start("compute psir ... "); }
-            hoNDArray< float > psir; // RO, E1, 1, N*SLC
+            hoNDArray< float > psir; // (RO, E1, 1, B) real-valued PSIR
             {
                 GILLock lg;
-                PythonFunction< hoNDArray< float > > apply_psirnet("psirnet", "apply_psirnet");
+                PythonFunction< hoNDArray<float> > apply_psirnet("psirnet", "apply_psirnet");
                 psir = apply_psirnet(kspace_ir, kspace_pd, coil_map_model, this->model_);
             }
             if (perform_timing.value()) { timer.stop(); }
 
-            if (!debug_folder_full_path_.empty()) 
-            { 
-                gt_exporter_.export_array(psir, debug_folder_full_path_ + "psir" + os.str()); 
+            if (!debug_folder_full_path_.empty())
+            {
+                gt_exporter_.export_array(psir, debug_folder_full_path_ + "psir" + os.str());
             }
 
-            // set the results
+            // set the results: one PSIR + one MagIR image per (slice, average)
             res_psir_.headers_.create(N, 1, SLC);
-            res_psir_.meta_.resize(N*SLC);
+            res_psir_.meta_.resize(N * SLC);
 
             res_magir_.headers_.create(N, 1, SLC);
-            res_magir_.meta_.resize(N*SLC);
+            res_magir_.meta_.resize(N * SLC);
 
-            float scale_factor = this->scale_factor_after_SCC.value();
-
+            // Unpack the flat-batch real-valued psir into the (RO,E1,E2,CHA,N,S,SLC)
+            // complex IsmrmrdImageArrays, applying the scale factor inline.
+            // PSIR stays signed (sign carried by image_type=REAL downstream);
+            // MagIR is |PSIR|. The additive psir_offset is applied later in
+            // compute_image_header_psir_magir, on res_psir_ only.
+            const float scale_factor = this->scale_factor_after_SCC.value();
             for (slc=0; slc<SLC; slc++)
             {
                 for (n=0; n<N; n++)
-                {             
+                {
+                    const size_t b = n + slc*N;
                     for (e1=0; e1<E1; e1++)
                     {
                         for (ro=0; ro<RO; ro++)
-                        { 
-                            res_psir_.data_(ro, e1, 0, 0, n, 0, slc) = psir(ro, e1, 0, n + slc*N) * scale_factor + this->offset_factor_after_SCC.value();
-                            res_magir_.data_(ro, e1, 0, 0, n, 0, slc) = std::complex<float>(std::abs(psir(ro, e1, 0, n + slc*N)) * scale_factor + this->offset_factor_after_SCC.value(), 0.0f);
+                        {
+                            const float v = psir(ro, e1, 0, b) * scale_factor;
+                            res_psir_.data_(ro, e1, 0, 0, n, 0, slc)  = std::complex<float>(v, 0.0f);
+                            res_magir_.data_(ro, e1, 0, 0, n, 0, slc) = std::complex<float>(std::abs(v), 0.0f);
                         }
                     }
                 }
@@ -493,6 +512,21 @@ namespace Gadgetron {
             hoNDArray<std::complex<float>> PSIRImage;
             PSIRImage.create(RO, E1);
 
+            // PSIR is a real-valued, signed image. The scanner only consumes unsigned shorts,
+            // so we shift the PSIR pixel values into a strictly non-negative range at the very
+            // end of this function. Until then, everything downstream of `perform_psir` must
+            // see the signed values. Two things are required to make the rest of the chain do
+            // the right thing with PSIR:
+            //   1. `ComplexToFloatGadget` branches on `header.image_type`: MAGNITUDE -> abs(),
+            //      REAL -> real(). The base-class `compute_image_header(...)` hard-codes
+            //      MAGNITUDE, which would strip the sign. We tag PSIR as REAL here.
+            //   2. We record the additive offset in `GADGETRON_IMAGE_SCALE_OFFSET` meta so the
+            //      receiving viewer/DICOM stage can recover the signed value.
+            // MagIR is left as MAGNITUDE (it is |IR|, non-negative) and is not shifted.
+            // Sourced from the `psir_offset` gadget property so the actual additive shift, the
+            // SCALE_OFFSET meta, and the window-centre adjustment all stay in lock-step.
+            const double psir_offset = this->psir_offset.value();
+
             // loop through the headers and meta and set fields
             size_t n, s, slc;
             for (slc=0; slc<SLC; slc++)
@@ -503,10 +537,15 @@ namespace Gadgetron {
                     res_magir.headers_(n, 0, slc) = res_psir.headers_(n, 0, slc);
                     res_magir.meta_[n + slc*N] = res_psir.meta_[n + slc*N];
 
+                    // Override the MAGNITUDE default planted by GenericReconGadget::compute_image_header.
+                    res_psir.headers_(n, 0, slc).image_type  = ISMRMRD::ISMRMRD_IMTYPE_REAL;
+                    res_magir.headers_(n, 0, slc).image_type = ISMRMRD::ISMRMRD_IMTYPE_MAGNITUDE;
+
                     res_psir.meta_[n + slc*N].set(GADGETRON_IMAGE_SCALE_RATIO, 1.0);
                     res_psir.meta_[n + slc*N].set(GADGETRON_IMAGECOMMENT, GADGETRON_IMAGE_PSIR);
                     res_psir.meta_[n + slc*N].set(GADGETRON_SEQUENCEDESCRIPTION, GADGETRON_IMAGE_PSIR);
                     res_psir.meta_[n + slc*N].set(GADGETRON_DATA_ROLE, GADGETRON_IMAGE_PSIR);
+                    res_psir.meta_[n + slc*N].set(GADGETRON_IMAGE_SCALE_OFFSET, (double)psir_offset);
                     if(!TI_.empty()) res_psir.meta_[n + slc*N].set(GADGETRON_IMAGE_INVERSIONTIME, TI_[0]);
 
                     res_magir.meta_[n + slc*N].set(GADGETRON_IMAGE_SCALE_RATIO, 1.0);
@@ -515,11 +554,11 @@ namespace Gadgetron {
                     res_magir.meta_[n + slc*N].set(GADGETRON_DATA_ROLE, GADGETRON_IMAGE_MAGIR);
                     if(!TI_.empty()) res_magir.meta_[n + slc*N].set(GADGETRON_IMAGE_INVERSIONTIME, TI_[0]);
 
-                    // compute window level for the PSIR image
+                    // compute window level for the PSIR image on the signed (un-shifted) values.
                     memcpy(PSIRImage.begin(), &res_psir.data_(0,0,0,0,n,0,slc), sizeof(std::complex<float>)*RO*E1);
                     memcpy(magIRImage.begin(), &res_magir.data_(0,0,0,0,n,0,slc), sizeof(std::complex<float>)*RO*E1);
 
-                    float window_center = this->offset_factor_after_SCC.value();
+                    float window_center = 2048;
                     float window_width = 1200;
                     if (!calculate_window_level(magIRImage, PSIRImage, window_center, window_width))
                     {
@@ -528,11 +567,17 @@ namespace Gadgetron {
                     else
                     {
                         GDEBUG_STREAM("Calculated window level for PSIR image " << n << " in slice " << slc << " : window center = " << window_center << " , window width = " << window_width);
-                        res_psir.meta_[n + slc*N].set(GADGETRON_IMAGE_WINDOWCENTER, window_center);
-                        res_psir.meta_[n + slc*N].set(GADGETRON_IMAGE_WINDOWWIDTH, window_width);
+                        // The pixel data is shifted by `psir_offset` below, so the window centre
+                        // must shift by the same amount to remain valid for the displayed pixels.
+                        res_psir.meta_[n + slc*N].set(GADGETRON_IMAGE_WINDOWCENTER, (double)(window_center + psir_offset));
+                        res_psir.meta_[n + slc*N].set(GADGETRON_IMAGE_WINDOWWIDTH, (double)window_width);
                     }
                 }
             }
+
+            // Final positive-shift so the unsigned-short conversion downstream preserves the sign.
+            // Only the PSIR image is shifted; MagIR is already non-negative.
+            res_psir.data_ += static_cast<double>(psir_offset);
         }
         catch (...)
         {

--- a/gadgets/cmr/CmrPSIRNetGadget.h
+++ b/gadgets/cmr/CmrPSIRNetGadget.h
@@ -32,8 +32,12 @@ namespace Gadgetron {
         GADGET_PROPERTY(model, std::string, "model file", "psirnet_model.pts");
 
         GADGET_PROPERTY(send_out_mag_IR, bool, "Whether to set out magIR images", true);
-        GADGET_PROPERTY(offset_factor_after_SCC, double, "Offset factor after psir", 2048);
         GADGET_PROPERTY(scale_factor_after_SCC, double, "Scaling factor after psir", 1000);
+        GADGET_PROPERTY(psir_offset, double,
+            "Additive shift applied to PSIR so the scanner sees unsigned values; "
+            "also written as GADGETRON_IMAGE_SCALE_OFFSET meta so downstream stages "
+            "can recover the signed value.",
+            16384.0);
 
     protected:
 

--- a/gadgets/cmr/config/LGE/PSIRNet.xml
+++ b/gadgets/cmr/config/LGE/PSIRNet.xml
@@ -114,7 +114,7 @@
         <property><name>model</name><value>PSIRNet.pts</value></property>
         <property><name>send_out_mag_IR</name><value>true</value></property>
         <property><name>scale_factor_after_SCC</name><value>1000.0</value></property>
-        <property><name>offset_factor_after_SCC</name><value>2048.0</value></property>
+        <property><name>psir_offset</name><value>16384.0</value></property>
 
         <!-- parameters for debug and timing -->
         <property><name>debug_folder</name><value></value></property>

--- a/gadgets/cmr/python/psirnet.py
+++ b/gadgets/cmr/python/psirnet.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+PSIRNet inference wrapper for Gadgetron's CmrPSIRNetGadget.
+
+Shape contract with the gadget (CmrPSIRNetGadget.cpp, perform_psir):
+    IR        np.ndarray  shape (RO, E1, CHA, B) complex64
+    PD        np.ndarray  shape (RO, E1, CHA, B) complex64
+    coil_map  np.ndarray  shape (RO, E1, CHA, B) complex64
+    model     torch.jit.ScriptModule with forward(a, b, c, d) ->
+                  a, b, d : (1, CHA, RO, E1)  complex
+                  c       : (1, 1,   RO, E1)  bool
+              returning (1, 1, RO, E1) real32 (or anything squeezable to RO,E1).
+
+PSIRNet is a single-shot model (one IR + one PD k-space per call), see
+psirnet/src/models.py:PSIRNet docstring. The C++ caller packs every
+(average, slice) pair into the flat batch dim `B = N*SLC` (as `b = n + slc*N`)
+and unpacks the output the same way. We run exactly one inference per
+batch element and stay agnostic to what the batch represents.
+
+Returns:
+    psir      np.ndarray  shape (RO, E1, 1, B) float32, Fortran-contiguous.
+              PSIR is genuinely real-valued (the model emits a signed scalar
+              field), so we return float32 and let the C++ side wrap into
+              std::complex<float> on the way into IsmrmrdImageArray::data_.
+"""
+
+import os
+import gc
+import time
+
+import numpy as np
+import torch
+
+# Optional Gadgetron helpers; fall back to stdlib if not on sys.path.
+try:
+    from gadgetron_logger import logger
+except ImportError:
+    import logging
+    logger = logging.getLogger("psirnet")
+    if not logger.handlers:
+        h = logging.StreamHandler()
+        h.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s %(message)s"))
+        logger.addHandler(h)
+    logger.setLevel(logging.INFO)
+
+try:
+    from colorama import Fore, Style
+except ImportError:
+    class _NoColor:
+        def __getattr__(self, _): return ""
+    Fore = Style = _NoColor()
+
+CUDA_RAM_LIMIT = 8.0   # GB
+
+
+# ---------------------------------------------------------
+
+def detect_device(total_ram_threshold_in_GB=CUDA_RAM_LIMIT):
+    if not torch.cuda.is_available():
+        logger.info(f"{Fore.GREEN}detect_device: no CUDA, using CPU{Style.RESET_ALL}")
+        return [torch.device("cpu")]
+
+    t0 = time.time()
+    visible = os.getenv("CUDA_VISIBLE_DEVICES")
+    if visible:
+        devices = [torch.device(f"cuda:{i}") for i in visible.split(",")]
+    else:
+        devices = [torch.device("cuda:0")]
+
+    devices_valid = []
+    for device in devices:
+        try:
+            with torch.cuda.device(device):
+                free_mem, total_mem = torch.cuda.mem_get_info()
+            total_gb = total_mem / 1024.0 ** 3
+            free_gb = free_mem / 1024.0 ** 3
+            logger.info(f"{Fore.YELLOW}GPU {device.index}{Style.RESET_ALL} "
+                        f"total RAM {total_gb:.2f} GB, free {free_gb:.2f} GB")
+            if total_gb >= total_ram_threshold_in_GB:
+                devices_valid.append(device)
+        except Exception as e:
+            logger.info(f"Check CUDA RAM failed for GPU {device.index}: {e}")
+
+    devices = devices_valid if devices_valid else [torch.device("cpu")]
+    logger.info(f"detect_device took {time.time()-t0:.2f}s, using {devices}")
+    return devices
+
+
+# ---------------------------------------------------------
+
+def load_model_for_inference(model_dir, model_file):
+    """Load a TorchScript model from <model_dir>/<model_file>.
+
+    Loads directly onto CUDA when available so that frozen weights AND
+    TorchScript CONSTANTS land on the same device the gadget will use for
+    inputs (avoids "Input type cuda / weight type cpu" RuntimeErrors that
+    nn.Module.to() can't fix because it doesn't move ScriptModule
+    CONSTANTS).
+    """
+    model_file_name = os.path.join(model_dir, model_file) if model_dir else model_file
+    map_location = "cuda:0" if torch.cuda.is_available() else "cpu"
+    try:
+        logger.info(f"---> Load model {model_file_name} (map_location={map_location})")
+        t0 = time.time()
+        model = torch.jit.load(model_file_name, map_location=map_location)
+        logger.info(f"---> Model loading took {time.time()-t0:.2f}s")
+    except Exception as e:
+        logger.error(f"Error in load_model_for_inference for {model_file_name}")
+        logger.exception(e)
+        model = None
+    return model
+
+
+# ---------------------------------------------------------
+
+def prep_model(model):
+    if torch.get_num_threads() < os.cpu_count() * 0.5:
+        torch.set_num_threads(int(os.cpu_count() * 0.8))
+        logger.info(f"---> set number of cpu threads {torch.get_num_threads()}")
+
+    devices = detect_device(total_ram_threshold_in_GB=CUDA_RAM_LIMIT)
+
+    if isinstance(model, (torch.nn.Module, torch.jit.ScriptModule)):
+        model.eval()
+        # Move model to the selected device so its weights live on the same
+        # device as the inputs created later in apply_psirnet().
+        try:
+            model = model.to(devices[0])
+        except Exception as e:
+            logger.warning(f"prep_model: model.to({devices[0]}) failed: {e}")
+    else:
+        logger.info("model is not a torch Module / ScriptModule")
+    return model, devices
+
+
+# ---------------------------------------------------------
+
+def finish_model():
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+# ---------------------------------------------------------
+
+def _to_model_input(arr_roe1cha, device, dtype):
+    """(RO, E1, CHA) -> torch (1, CHA, RO, E1) on `device`."""
+    x = np.ascontiguousarray(arr_roe1cha.transpose(2, 0, 1))
+    return torch.from_numpy(x).to(dtype=dtype, device=device).unsqueeze(0)
+
+
+def apply_psirnet(IR, PD, coil_map, model,
+                  total_ram_threshold_in_GB=CUDA_RAM_LIMIT,
+                  use_cpu=False,
+                  verbose=True):
+    """Run PSIRNet once per batch element and assemble the output.
+
+    The 4th dim is a flat batch; the C++ caller packs (n, slc) into it as
+    b = n + slc*N so the same wrapper serves both single-shot-per-slice and
+    per-average-per-slice modes without code changes here.
+    """
+    RO, E1, CHA, B = IR.shape
+    if PD.shape != IR.shape:
+        raise ValueError(f"apply_psirnet: PD shape {PD.shape} != IR shape {IR.shape}")
+    if coil_map.shape != IR.shape:
+        raise ValueError(
+            f"apply_psirnet: coil_map shape {coil_map.shape} != IR shape {IR.shape}")
+
+    if verbose:
+        logger.info(f"---> apply_psirnet IR  {IR.shape} {IR.dtype}")
+        logger.info(f"---> apply_psirnet PD  {PD.shape} {PD.dtype}")
+        logger.info(f"---> apply_psirnet sm  {coil_map.shape} {coil_map.dtype}")
+        logger.info(f"---> apply_psirnet RO={RO} E1={E1} CHA={CHA} B={B}")
+
+    # Always allocate the output up front so the error path returns a valid shape.
+    output = np.zeros((RO, E1, 1, B), dtype=np.float32, order="F")
+
+    try:
+        t0 = time.time()
+        if use_cpu:
+            device = torch.device("cpu")
+            model.eval()
+        else:
+            model, devices = prep_model(model)
+            device = devices[0]
+
+        with torch.inference_mode():
+            for b in range(B):
+                ir_k = IR[:, :, :, b]            # (RO, E1, CHA) one batch element
+                pd_k = PD[:, :, :, b]
+                sm_k = coil_map[:, :, :, b]
+
+                a = _to_model_input(ir_k, device, torch.cfloat)
+                a_pd = _to_model_input(pd_k, device, torch.cfloat)
+                d = _to_model_input(sm_k, device, torch.cfloat)
+
+                # Sampling mask from coil 0 of IR, same logic as training:
+                #   mask = (ir_kspace != 0)[0:1, ...]   (psirnet/src/data.py:74)
+                # Training axis order was (CHA, RO, E1); gadget gives us (RO, E1, CHA),
+                # so coil-0 selection becomes ir_k[:, :, 0].
+                mask_k = (ir_k[:, :, 0] != 0)      # (RO, E1) bool
+                c = torch.from_numpy(np.ascontiguousarray(mask_k)).to(
+                    dtype=torch.bool, device=device).unsqueeze(0).unsqueeze(0)  # (1,1,RO,E1)
+
+                out_k = model(a, a_pd, c, d)       # expected (1, 1, RO, E1) real32
+                out_k = out_k.detach().to(dtype=torch.float32, device="cpu").numpy()
+                out_k = np.squeeze(out_k)
+                if out_k.shape != (RO, E1):
+                    raise RuntimeError(
+                        f"PSIRNet output has shape {out_k.shape}, expected ({RO},{E1})")
+
+                output[:, :, 0, b] = out_k
+
+        logger.info(f"---> apply_psirnet took {time.time()-t0:.3f}s for B={B} batch elements")
+    except Exception as e:
+        logger.error("Error in apply_psirnet; returning zeros")
+        logger.exception(e)
+        output = np.zeros((RO, E1, 1, B), dtype=np.float32, order="F")
+    finally:
+        finish_model()
+
+    logger.info(f"---> apply_psirnet output {output.shape} {output.dtype}")
+    return np.asfortranarray(output)
+
+
+# ---------------------------------------------------------
+
+if __name__ == "__main__":
+    # Minimal smoke test. Adjust paths to your install.
+    GT_HOME = os.environ.get("GADGETRON_HOME", "/usr/local")
+    model_dir = os.path.join(GT_HOME, "share/gadgetron/python/cmr_ml/models")
+    model_file = "PSIRNet.pts"
+
+    m = load_model_for_inference(model_dir, model_file)
+    if m is None:
+        raise SystemExit("Failed to load model")
+
+    # Fake one batch element: 1 batch (== 1 slice, 1 average).
+    RO, E1, CHA, B = 256, 192, 30, 1
+    rng = np.random.default_rng(0)
+    IR = np.asfortranarray(
+        (rng.standard_normal((RO, E1, CHA, B)) +
+         1j * rng.standard_normal((RO, E1, CHA, B))).astype(np.complex64))
+    PD = np.asfortranarray(IR.copy())
+    SM = np.asfortranarray(
+        (rng.standard_normal((RO, E1, CHA, B)) +
+         1j * rng.standard_normal((RO, E1, CHA, B))).astype(np.complex64))
+
+    out = apply_psirnet(IR, PD, SM, m)
+    print("output shape:", out.shape, "dtype:", out.dtype,
+          "F-contig:", out.flags["F_CONTIGUOUS"])


### PR DESCRIPTION
Bug fixes + Python wrapper for `CmrPSIRNetGadget`.

**Fixes**
- `.pts` suffix dropped by shadowed local in `load_model`.
- `coil_map_model` sized `(RO,E1,CHA,SLC)` vs kspace `(RO,E1,CHA,N*SLC)` — broken for `N>1`. Now tiled.
- PSIR tagged MAGNITUDE so `ComplexToFloatGadget` stripped its sign. Now REAL; offset applied once to `res_psir` after W/L, carried in `GADGETRON_ScaleOffset` and `WindowCenter`.

**Breaking**
- Rename `offset_factor_after_SCC` (2048) → `psir_offset` (16384). New semantics: PSIR only, post-W/L.

**New**
- `gadgets/cmr/python/psirnet.py` + CMake install. One model call per element of flat batch `B = N*SLC`. `PSIRNet.pts` provided out of band.

**Validated** on 12-slice × 8-avg LGE_MOCO_AVE (96 images): correct `image_type`, `ScaleOffset` on PSIR only, per-`(slc,n)` values vary.

Draft — open to alt. property-rename strategy or different commit split.
